### PR TITLE
fix: await for confirmation before deleting voices and channels

### DIFF
--- a/app/src/components/AudioTab/AudioTab.tsx
+++ b/app/src/components/AudioTab/AudioTab.tsx
@@ -124,6 +124,13 @@ export function AudioTab() {
     );
   }
 
+  const handleChannelDelete = async (e, channelId) => {
+    e.stopPropagation();
+    if (await confirm('Delete this channel?')) {
+      deleteChannel.mutate(channelId);
+    }
+  }
+
   const allChannels = channels || [];
   const allDevices = devices || [];
   const selectedChannel = selectedChannelId
@@ -241,12 +248,7 @@ export function AudioTab() {
                             variant="ghost"
                             size="sm"
                             className="h-8 w-8 p-0"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (confirm('Delete this channel?')) {
-                                deleteChannel.mutate(channel.id);
-                              }
-                            }}
+                            onClick={(e) => handleChannelDelete(e, channel.id)}
                           >
                             <Trash2 className="h-4 w-4" />
                           </Button>

--- a/app/src/components/VoicesTab/VoicesTab.tsx
+++ b/app/src/components/VoicesTab/VoicesTab.tsx
@@ -79,8 +79,8 @@ export function VoicesTab() {
     setDialogOpen(true);
   };
 
-  const handleDelete = (profileId: string) => {
-    if (confirm('Are you sure you want to delete this profile?')) {
+  const handleProfileDelete = async (profileId: string) => {
+    if (await confirm('Are you sure you want to delete this profile?')) {
       deleteProfile.mutate(profileId);
     }
   };
@@ -147,7 +147,7 @@ export function VoicesTab() {
                 channels={channels || []}
                 onChannelChange={(channelIds) => handleChannelChange(profile.id, channelIds)}
                 onEdit={() => handleEdit(profile.id)}
-                onDelete={() => handleDelete(profile.id)}
+                onDelete={() => handleProfileDelete(profile.id)}
               />
             ))}
           </TableBody>


### PR DESCRIPTION

### PR Checklist

- [X] Code follows style guidelines
- [ ] Documentation updated
- [X] Changes tested
- [X] No breaking changes (or documented)
- [ ] CHANGELOG.md updated


### Decription

I realized that when deleting a voice the action triggered before confirmation. [According to the documentation](https://v2.tauri.app/plugin/dialog/#create-okcancel-dialog), the confirmation() method returns a promise that wasn't properly awaited.

Just for the sake of clarity I also renamed the generic handleDelete method to a more specific one.