### PR TITLE
fix: guard getUserMedia call against undefined mediaDevices in non-secure contexts

### DIFF
--- a/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
+++ b/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
@@ -58,6 +58,7 @@ export function AudioSampleRecording({
   // Request microphone access when component mounts
   useEffect(() => {
     if (!showWaveform) return;
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
 
     let stream: MediaStream | null = null;
 


### PR DESCRIPTION
## Summary

- Adds a guard check for `navigator.mediaDevices` and `navigator.mediaDevices.getUserMedia` before attempting to access the microphone in `AudioSampleRecording.tsx`
- Prevents a crash (`Cannot read properties of undefined (reading 'getUserMedia')`) that occurs in non-secure (HTTP) contexts where `navigator.mediaDevices` is `undefined`
- The error surfaced when closing the voice profile edit screen in remote/non-HTTPS setups (e.g. Windows desktop app pointing at a remote server)

## Root cause

`navigator.mediaDevices` is only available in secure contexts (HTTPS or localhost). On plain HTTP, it is `undefined`. The cleanup effect unconditionally called `.getUserMedia(...)` on mount, causing an unhandled exception when the component unmounted — even if the user never interacted with the record tab.

## Fix

```diff
  useEffect(() => {
    if (!showWaveform) return;
+   if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
```

## Credit

Bug found and fix identified by **AuroraSkye** on the Voicebox Discord. Thank you!