### PR TITLE
fix(mlx): bundle native libs and broaden error handling for Apple Silicon

### DIFF
--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -83,9 +83,13 @@ def build_server():
             '--hidden-import', 'mlx_audio.stt',
             '--collect-submodules', 'mlx',
             '--collect-submodules', 'mlx_audio',
-            # Collect MLX data files including Metal shader libraries (.metallib)
-            '--collect-data', 'mlx',
-            '--collect-data', 'mlx_audio',
+            # Use --collect-all so PyInstaller bundles both data files AND
+            # native shared libraries (.dylib, .metallib) for MLX.
+            # Previously only --collect-data was used, which caused MLX to
+            # raise OSError at runtime inside the bundled binary because
+            # the Metal shader libraries were missing.
+            '--collect-all', 'mlx',
+            '--collect-all', 'mlx_audio',
         ])
     else:
         print("Building for non-Apple Silicon platform - PyTorch only")

--- a/backend/platform_detect.py
+++ b/backend/platform_detect.py
@@ -19,15 +19,17 @@ def is_apple_silicon() -> bool:
 def get_backend_type() -> Literal["mlx", "pytorch"]:
     """
     Detect the best backend for the current platform.
-    
+
     Returns:
-        "mlx" on Apple Silicon (if MLX is available), "pytorch" otherwise
+        "mlx" on Apple Silicon (if MLX is available and functional), "pytorch" otherwise
     """
     if is_apple_silicon():
         try:
-            import mlx
+            import mlx.core  # noqa: F401 — triggers native lib loading
             return "mlx"
-        except ImportError:
-            # MLX not installed, fallback to PyTorch
+        except (ImportError, OSError, RuntimeError):
+            # MLX not installed, or native libraries failed to load inside a
+            # PyInstaller bundle (OSError on missing .dylib / .metallib).
+            # Fall through to PyTorch.
             return "pytorch"
     return "pytorch"

--- a/backend/voicebox-server.spec
+++ b/backend/voicebox-server.spec
@@ -6,8 +6,13 @@ from PyInstaller.utils.hooks import copy_metadata
 datas = []
 hiddenimports = ['backend', 'backend.main', 'backend.config', 'backend.database', 'backend.models', 'backend.profiles', 'backend.history', 'backend.tts', 'backend.transcribe', 'backend.platform_detect', 'backend.backends', 'backend.backends.pytorch_backend', 'backend.utils.audio', 'backend.utils.cache', 'backend.utils.progress', 'backend.utils.hf_progress', 'backend.utils.validation', 'torch', 'transformers', 'fastapi', 'uvicorn', 'sqlalchemy', 'librosa', 'soundfile', 'qwen_tts', 'qwen_tts.inference', 'qwen_tts.inference.qwen3_tts_model', 'qwen_tts.inference.qwen3_tts_tokenizer', 'qwen_tts.core', 'qwen_tts.cli', 'pkg_resources.extern', 'backend.backends.mlx_backend', 'mlx', 'mlx.core', 'mlx.nn', 'mlx_audio', 'mlx_audio.tts', 'mlx_audio.stt']
 datas += collect_data_files('qwen_tts')
-datas += collect_data_files('mlx')
-datas += collect_data_files('mlx_audio')
+# Use collect_all (not collect_data_files) so native .dylib and .metallib
+# files are bundled as binaries, not data. Without this, MLX raises OSError
+# when loading Metal shaders inside the PyInstaller bundle.
+from PyInstaller.utils.hooks import collect_all as _collect_all
+_mlx_datas, _mlx_bins, _mlx_hidden = _collect_all('mlx')
+_mlxa_datas, _mlxa_bins, _mlxa_hidden = _collect_all('mlx_audio')
+datas += _mlx_datas + _mlxa_datas
 datas += copy_metadata('qwen-tts')
 hiddenimports += collect_submodules('qwen_tts')
 hiddenimports += collect_submodules('jaraco')
@@ -18,7 +23,7 @@ hiddenimports += collect_submodules('mlx_audio')
 a = Analysis(
     ['server.py'],
     pathex=[],
-    binaries=[],
+    binaries=_mlx_bins + _mlxa_bins,
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[],


### PR DESCRIPTION
## Problem

The distributed macOS aarch64 binary (`voicebox_aarch64.app.tar.gz`) silently falls back to PyTorch CPU instead of using MLX, despite the README advertising 4-5x faster inference on Apple Silicon.

Two root causes:

### 1. `platform_detect.py` only catches `ImportError`

Inside a PyInstaller bundle, MLX loads its Metal shader libraries (`.metallib`) at import time. When those files are missing from the bundle, Python raises `OSError` — not `ImportError`. The original code:

```python
try:
    import mlx
    return "mlx"
except ImportError:   # ← OSError slips through here
    return "pytorch"
```

This causes a silent fallback to PyTorch on every Apple Silicon machine running the binary.

### 2. `collect_data_files` misses native libraries

`build_binary.py` and `voicebox-server.spec` used `--collect-data` / `collect_data_files` for `mlx` and `mlx_audio`. This only copies pure-Python files — native `.dylib` and `.metallib` files are excluded. PyInstaller needs `--collect-all` / `collect_all` + `Analysis(binaries=...)` to bundle shared libraries correctly.

## Fix

1. **`platform_detect.py`** — catch `(ImportError, OSError, RuntimeError)` and import `mlx.core` (forces native lib loading eagerly so any failure is caught here)
2. **`build_binary.py`** — replace `--collect-data mlx/mlx_audio` with `--collect-all`
3. **`voicebox-server.spec`** — use `collect_all()` and pass collected binaries to `Analysis(binaries=...)`

## Testing

Reproduced on macOS 15 (Apple Silicon M4 Mac mini):
- **Before fix**: binary logs `Backend: pytorch`, generation takes 30+ min for a 5s clip
- **After fix (source build with MLX)**: logs `Backend: MLX | GPU: MPS (Apple Silicon)`, same clip in ~39s (first run) / ~8s (warm)