### PR TITLE
fix: pass language parameter to TTS models

### DIFF
--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/components/ui/use-toast';
-import { LANGUAGE_OPTIONS } from '@/lib/constants/languages';
+import { LANGUAGE_OPTIONS, type LanguageCode } from '@/lib/constants/languages';
 import { useGenerationForm } from '@/lib/hooks/useGenerationForm';
 import { useProfile, useProfiles } from '@/lib/hooks/useProfiles';
 import { useAddStoryItem, useStory } from '@/lib/hooks/useStories';
@@ -111,6 +111,13 @@ export function FloatingGenerateBox({
       setSelectedProfileId(profiles[0].id);
     }
   }, [selectedProfileId, profiles, setSelectedProfileId]);
+
+  // Sync generation form language with selected profile's language
+  useEffect(() => {
+    if (selectedProfile?.language) {
+      form.setValue('language', selectedProfile.language as LanguageCode);
+    }
+  }, [selectedProfile, form]);
 
   // Auto-resize textarea based on content (only when expanded)
   useEffect(() => {

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -15,6 +15,12 @@ from ..utils.progress import get_progress_manager
 from ..utils.hf_progress import HFProgressTracker, create_hf_progress_callback
 from ..utils.tasks import get_task_manager
 
+LANGUAGE_CODE_TO_NAME = {
+    "zh": "chinese", "en": "english", "ja": "japanese", "ko": "korean",
+    "de": "german", "fr": "french", "ru": "russian", "pt": "portuguese",
+    "es": "spanish", "it": "italian",
+}
+
 
 class PyTorchTTSBackend:
     """PyTorch-based TTS backend using Qwen3-TTS."""
@@ -335,6 +341,7 @@ class PyTorchTTSBackend:
             wavs, sample_rate = self.model.generate_voice_clone(
                 text=text,
                 voice_clone_prompt=voice_prompt,
+                language=LANGUAGE_CODE_TO_NAME.get(language, "auto"),
                 instruct=instruct,
             )
             return wavs[0], sample_rate


### PR DESCRIPTION
## Summary

- **Both backends silently dropped the `language` parameter** — it was accepted by `generate()` but never forwarded to the underlying Qwen3-TTS model, causing it to default to "Auto" detection which frequently confuses Portuguese for Spanish
- **Added `LANGUAGE_CODE_TO_NAME` mapping** (ISO 639-1 → full language name) to both PyTorch and MLX backends, matching the format Qwen3-TTS expects (e.g. `"pt"` → `"portuguese"`)
- **PyTorch backend**: passes `language=` to `generate_voice_clone()`
- **MLX backend**: passes `lang_code=` to all 4 `model.generate()` call sites
- **Frontend**: auto-syncs the generation form's language dropdown with the selected voice profile's language via a new `useEffect`

## Test plan

- [ ] Select a Portuguese voice profile → language dropdown should auto-sync to Portuguese
- [ ] Generate speech in Portuguese → output should sound Portuguese, not Spanish
- [ ] Switch to English profile → language dropdown syncs to English, generation works normally
- [ ] Test with other supported languages (Chinese, Japanese, etc.)
- [ ] Check backend logs for any language-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)