### PR TITLE
fix(web): add @tailwindcss/vite plugin to web config

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../app/src'),


### PR DESCRIPTION
## Summary
Adds the missing `@tailwindcss/vite` plugin to `web/vite.config.ts`.

## Problem
The web version was rendering without any CSS styles, appearing as a blank white page. This was tested and confirmed on both Chrome and Safari on macOS.

## Root Cause
The `tauri/vite.config.ts` correctly includes the Tailwind plugin, but `web/vite.config.ts` was missing it. Since Tailwind CSS v4 requires the Vite plugin to process styles, the web version had no CSS at all.

## Changes
- Added `import tailwindcss from '@tailwindcss/vite'`
- Added `tailwindcss()` to the plugins array

## Testing
- Verified CSS loads correctly after the fix
- Tested on Chrome and Safari

Fixes #121