### PR TITLE
Add Dockerfiles, docker-compose, and docs for Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+node_modules
+dist
+build
+venv
+__pycache__
+*.pyc
+.env
+*.egg-info
+*.log

--- a/DOCKER_RUN.md
+++ b/DOCKER_RUN.md
@@ -1,0 +1,19 @@
+# Run with Docker
+
+Quick steps to build and run the project using Docker Compose:
+
+Build and start both services:
+
+```bash
+docker-compose up --build
+```
+
+This will:
+- Build the Python backend (exposes port 8000)
+- Build the frontend and serve it via nginx (exposes port 3000 -> nginx:80)
+
+Backend data is persisted to a Docker volume mounted at `/data` in the container.
+
+Notes:
+- The backend installs large ML dependencies (torch, transformers) and may result in a large image.
+- You can pass a custom data directory by mounting a host folder to the `data` volume in `docker-compose.yml`.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Install deps and build
+COPY app/package.json app/package-lock.json* ./
+COPY app/ ./
+RUN npm install --legacy-peer-deps
+RUN npm run build
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system deps (audio libs, ffmpeg for processing)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libsndfile1 ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps
+COPY backend/requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy server entrypoint and package
+COPY backend/server.py /app/server.py
+COPY backend /app/backend
+
+VOLUME ["/data"]
+
+EXPOSE 8000
+
+CMD ["python", "server.py", "--host", "0.0.0.0", "--port", "8000", "--data-dir", "/data"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - data:/data
+    environment:
+      - PYTHONUNBUFFERED=1
+
+  frontend:
+    build:
+      context: .
+      dockerfile: app/Dockerfile
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+
+volumes:
+  data:


### PR DESCRIPTION
Added steps to build and run the project using Docker Compose:This will:
- Build the Python backend (exposes port 8000)
- Build the frontend and serve it via nginx (exposes port 3000 -> nginx:80)

The backend installs the large ML dependencies (torch, transformers) and may result in a large image.
 Users can pass a custom data directory by mounting a host folder to the `data` volume in `docker-compose.yml`.