### PR TITLE
feat: add network access toggle to server settings

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -93,10 +93,11 @@ function App() {
     }
 
     serverStartingRef.current = true;
-    console.log('Production mode: Starting bundled server...');
+    const isRemote = useServerStore.getState().mode === 'remote';
+    console.log(`Production mode: Starting bundled server... (remote: ${isRemote})`);
 
     platform.lifecycle
-      .startServer(false)
+      .startServer(isRemote)
       .then((serverUrl) => {
         console.log('Server is ready at:', serverUrl);
         // Update the server URL in the store with the dynamically assigned port

--- a/app/src/components/ServerSettings/ConnectionForm.tsx
+++ b/app/src/components/ServerSettings/ConnectionForm.tsx
@@ -31,6 +31,8 @@ export function ConnectionForm() {
   const setServerUrl = useServerStore((state) => state.setServerUrl);
   const keepServerRunningOnClose = useServerStore((state) => state.keepServerRunningOnClose);
   const setKeepServerRunningOnClose = useServerStore((state) => state.setKeepServerRunningOnClose);
+  const mode = useServerStore((state) => state.mode);
+  const setMode = useServerStore((state) => state.setMode);
   const { toast } = useToast();
 
   const form = useForm<ConnectionFormValues>({
@@ -115,6 +117,38 @@ export function ConnectionForm() {
             </div>
           </div>
         </div>
+
+        {platform.metadata.isTauri && (
+          <div className="mt-6 pt-6 border-t">
+            <div className="flex items-start space-x-3">
+              <Checkbox
+                id="allowNetworkAccess"
+                checked={mode === 'remote'}
+                onCheckedChange={(checked: boolean) => {
+                  setMode(checked ? 'remote' : 'local');
+                  toast({
+                    title: 'Setting updated',
+                    description: checked
+                      ? 'Network access enabled. Restart the app to apply.'
+                      : 'Network access disabled. Restart the app to apply.',
+                  });
+                }}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor="allowNetworkAccess"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                >
+                  Allow network access
+                </label>
+                <p className="text-sm text-muted-foreground">
+                  Makes the server accessible from other devices on your network. Restart the app
+                  after changing this setting.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Adds an "Allow network access" checkbox to Server Connection settings
- When enabled, the server binds to `0.0.0.0` instead of `127.0.0.1`, making it accessible from other devices on the network
- Setting is persisted and applied on next app launch

## Details
The plumbing for this already existed:
- **Rust** (`main.rs`): passes `--host 0.0.0.0` when `remote=true`
- **Store** (`serverStore.ts`): has `mode: 'local' | 'remote'` with persistence
- **Python** (`server.py`): accepts `--host` CLI arg
- **Frontend** (`lifecycle.ts`): `startServer(remote)` accepts boolean

But `App.tsx` hardcoded `startServer(false)`, and no UI exposed the toggle. This PR wires it up:

1. **`App.tsx`** — reads persisted `mode` from store on startup and passes `mode === 'remote'` to `startServer()`
2. **`ConnectionForm.tsx`** — adds a checkbox that toggles `mode` between `'local'` and `'remote'`, with a toast indicating restart is required

Only shown in Tauri (desktop) mode, not in web.

Closes #104

## Test plan
- [x] Toggle "Allow network access" in Server settings — checkbox renders, toast shows
- [x] Backend with `--host 0.0.0.0` binds to all interfaces (`TCP *:17493`)
- [x] Backend with `--host 127.0.0.1` only accessible on localhost
- [x] LAN IP access works when bound to `0.0.0.0`
- [ ] Full Tauri build + restart cycle (requires Xcode)