### PR TITLE
Add Spacebot banner to landing page

### DIFF
--- a/landing/src/app/layout.tsx
+++ b/landing/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { Banner } from '@/components/Banner';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 
@@ -31,6 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning className="dark">
       <body className={inter.variable}>
         <div className="relative min-h-screen bg-background font-sans flex flex-col">
+          <Banner />
           <Header />
           <main className="container mx-auto px-4 sm:px-6 md:px-4 flex-1 py-4 sm:py-6 md:py-0">
             {children}

--- a/landing/src/components/Banner.tsx
+++ b/landing/src/components/Banner.tsx
@@ -1,0 +1,25 @@
+import { ArrowRight } from 'lucide-react';
+
+export function Banner() {
+  return (
+    <div className="bg-primary/[0.06] border-b border-border backdrop-blur-sm">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-center h-10 text-sm">
+          <a
+            href="https://spacebot.sh"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors group"
+          >
+            <span>
+              Also by the creator of Voicebox:{' '}
+              <strong className="text-foreground/90">Spacebot</strong>, an AI agent OS for teams.
+              Connect Discord, Slack, or Telegram in one click.
+            </span>
+            <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a persistent banner to the top of the landing page linking to [spacebot.sh](https://spacebot.sh), another project by the creator of Voicebox.

- New `Banner` component using existing design tokens
- Sits above the header, always visible
- Dismissal-free, clean one-liner with hover arrow CTA
- Copy: *Also by the creator of Voicebox: **Spacebot**, an AI agent OS for teams. Connect Discord, Slack, or Telegram in one click.*