### PR TITLE
fix: bundle qwen_tts source files in PyInstaller build

### DIFF
--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -171,9 +171,9 @@ def build_server(cuda=False):
             "tqdm",
             "--hidden-import",
             "requests",
-            "--collect-submodules",
-            "qwen_tts",
-            "--collect-data",
+            # qwen_tts uses inspect.getsource() at runtime to locate
+            # modeling_qwen3_tts.py — needs physical .py source files bundled
+            "--collect-all",
             "qwen_tts",
             # Fix for pkg_resources and jaraco namespace packages
             "--hidden-import",


### PR DESCRIPTION
## Summary

- Replace `--collect-submodules` + `--collect-data` with `--collect-all` for `qwen_tts` in `build_binary.py`, so physical `.py` source files are bundled in the frozen binary
- `qwen_tts` runtime expects `modeling_qwen3_tts.py` as a real file under `_MEIPASS` (likely via `inspect.getsource()`), which only `--collect-all` provides
- Same pattern already used for `inflect` (typeguard's `@typechecked`)

Fixes #212
Supersedes #237 — thanks to @LucianoVandi for identifying the root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binary packaging configuration to improve how dependencies are discovered and bundled, ensuring more complete inclusion of required files during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->