### PR TITLE
feat: Intel Arc (XPU) GPU support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -155,6 +155,20 @@ def _get_gpu_status() -> str:
         return "MPS (Apple Silicon)"
     elif backend_type == "mlx":
         return "Metal (Apple Silicon via MLX)"
+
+    # Intel XPU (Arc / Data Center) via IPEX
+    try:
+        import intel_extension_for_pytorch  # noqa: F401
+
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            try:
+                xpu_name = torch.xpu.get_device_name(0)
+            except Exception:
+                xpu_name = "Intel GPU"
+            return f"XPU ({xpu_name})"
+    except ImportError:
+        pass
+
     return "None (CPU only)"
 
 

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -126,6 +126,37 @@ def get_torch_device(
     return "cpu"
 
 
+def empty_device_cache(device: str) -> None:
+    """
+    Free cached memory on the given device (CUDA or XPU).
+
+    Backends should call this after unloading models so VRAM is returned
+    to the OS.
+    """
+    import torch
+
+    if device == "cuda" and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif device == "xpu" and hasattr(torch, "xpu"):
+        torch.xpu.empty_cache()
+
+
+def manual_seed(seed: int, device: str) -> None:
+    """
+    Set the random seed on both CPU and the active accelerator.
+
+    Covers CUDA and Intel XPU so that generation is reproducible
+    regardless of which GPU backend is in use.
+    """
+    import torch
+
+    torch.manual_seed(seed)
+    if device == "cuda" and torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+    elif device == "xpu" and hasattr(torch, "xpu"):
+        torch.xpu.manual_seed(seed)
+
+
 async def combine_voice_prompts(
     audio_paths: List[str],
     reference_texts: List[str],

--- a/backend/backends/chatterbox_backend.py
+++ b/backend/backends/chatterbox_backend.py
@@ -19,6 +19,7 @@ from .base import (
     is_model_cached,
     get_torch_device,
     empty_device_cache,
+    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
     patch_chatterbox_f32,
@@ -198,7 +199,7 @@ class ChatterboxTTSBackend:
             import torch
 
             if seed is not None:
-                torch.manual_seed(seed)
+                manual_seed(seed, self._device)
 
             logger.info(f"[Chatterbox] Generating: lang={language}")
 

--- a/backend/backends/chatterbox_backend.py
+++ b/backend/backends/chatterbox_backend.py
@@ -18,6 +18,7 @@ from . import TTSBackend
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
     patch_chatterbox_f32,
@@ -48,7 +49,7 @@ class ChatterboxTTSBackend:
         self._model_load_lock = asyncio.Lock()
 
     def _get_device(self) -> str:
-        return get_torch_device(force_cpu_on_mac=True)
+        return get_torch_device(force_cpu_on_mac=True, allow_xpu=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None
@@ -117,10 +118,7 @@ class ChatterboxTTSBackend:
             del self.model
             self.model = None
             self._device = None
-            if device == "cuda":
-                import torch
-
-                torch.cuda.empty_cache()
+            empty_device_cache(device)
             logger.info("Chatterbox unloaded")
 
     async def create_voice_prompt(
@@ -220,10 +218,7 @@ class ChatterboxTTSBackend:
             else:
                 audio = np.asarray(wav, dtype=np.float32)
 
-            sample_rate = (
-                getattr(self.model, "sr", None)
-                or getattr(self.model, "sample_rate", 24000)
-            )
+            sample_rate = getattr(self.model, "sr", None) or getattr(self.model, "sample_rate", 24000)
 
             return audio, sample_rate
 

--- a/backend/backends/chatterbox_turbo_backend.py
+++ b/backend/backends/chatterbox_turbo_backend.py
@@ -19,6 +19,7 @@ from .base import (
     is_model_cached,
     get_torch_device,
     empty_device_cache,
+    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
     patch_chatterbox_f32,
@@ -179,7 +180,7 @@ class ChatterboxTurboTTSBackend:
             import torch
 
             if seed is not None:
-                torch.manual_seed(seed)
+                manual_seed(seed, self._device)
 
             logger.info("[Chatterbox Turbo] Generating (English)")
 

--- a/backend/backends/chatterbox_turbo_backend.py
+++ b/backend/backends/chatterbox_turbo_backend.py
@@ -18,6 +18,7 @@ from . import TTSBackend
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
     patch_chatterbox_f32,
@@ -48,7 +49,7 @@ class ChatterboxTurboTTSBackend:
         self._model_load_lock = asyncio.Lock()
 
     def _get_device(self) -> str:
-        return get_torch_device(force_cpu_on_mac=True)
+        return get_torch_device(force_cpu_on_mac=True, allow_xpu=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None
@@ -116,10 +117,7 @@ class ChatterboxTurboTTSBackend:
             del self.model
             self.model = None
             self._device = None
-            if device == "cuda":
-                import torch
-
-                torch.cuda.empty_cache()
+            empty_device_cache(device)
             logger.info("Chatterbox Turbo unloaded")
 
     async def create_voice_prompt(
@@ -200,10 +198,7 @@ class ChatterboxTurboTTSBackend:
             else:
                 audio = np.asarray(wav, dtype=np.float32)
 
-            sample_rate = (
-                getattr(self.model, "sr", None)
-                or getattr(self.model, "sample_rate", 24000)
-            )
+            sample_rate = getattr(self.model, "sr", None) or getattr(self.model, "sample_rate", 24000)
 
             return audio, sample_rate
 

--- a/backend/backends/hume_backend.py
+++ b/backend/backends/hume_backend.py
@@ -24,6 +24,8 @@ from . import TTSBackend
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
+    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -66,7 +68,7 @@ class HumeTadaBackend:
     def _get_device(self) -> str:
         # Force CPU on macOS — MPS has issues with flow matching
         # and large vocab lm_head (>65536 output channels)
-        return get_torch_device(force_cpu_on_mac=True)
+        return get_torch_device(force_cpu_on_mac=True, allow_xpu=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None
@@ -105,6 +107,7 @@ class HumeTadaBackend:
             # package.  The real package pulls in onnx/tensorboard/matplotlib via
             # descript-audiotools, so we use a lightweight shim instead.
             from ..utils.dac_shim import install_dac_shim
+
             install_dac_shim()
 
             import torch
@@ -142,8 +145,11 @@ class HumeTadaBackend:
                 allow_patterns=["tokenizer*", "special_tokens*"],
             )
 
-            # Determine dtype — use bf16 on CUDA for ~50% memory savings
+            # Determine dtype — use bf16 on CUDA/XPU for ~50% memory savings
             if device == "cuda" and torch.cuda.is_bf16_supported():
+                model_dtype = torch.bfloat16
+            elif device == "xpu":
+                # Intel Arc (Alchemist+) supports bf16 natively
                 model_dtype = torch.bfloat16
             else:
                 model_dtype = torch.float32
@@ -153,14 +159,14 @@ class HumeTadaBackend:
             # This avoids monkey-patching AutoTokenizer.from_pretrained
             # which corrupts the classmethod descriptor for other engines.
             from tada.modules.aligner import AlignerConfig
+
             AlignerConfig.tokenizer_name = tokenizer_path
 
             # Load encoder (only needed for voice prompt encoding)
             from tada.modules.encoder import Encoder
+
             logger.info("Loading TADA encoder...")
-            self.encoder = Encoder.from_pretrained(
-                TADA_CODEC_REPO, subfolder="encoder"
-            ).to(device)
+            self.encoder = Encoder.from_pretrained(TADA_CODEC_REPO, subfolder="encoder").to(device)
             self.encoder.eval()
 
             # Load the causal LM (includes decoder for wav generation).
@@ -169,12 +175,11 @@ class HumeTadaBackend:
             # which hits the gated repo. Pre-load the config from HF,
             # inject the local tokenizer path, then pass it in.
             from tada.modules.tada import TadaForCausalLM, TadaConfig
+
             logger.info(f"Loading TADA {model_size} model...")
             config = TadaConfig.from_pretrained(repo)
             config.tokenizer_name = tokenizer_path
-            self.model = TadaForCausalLM.from_pretrained(
-                repo, config=config, torch_dtype=model_dtype
-            ).to(device)
+            self.model = TadaForCausalLM.from_pretrained(repo, config=config, torch_dtype=model_dtype).to(device)
             self.model.eval()
 
         logger.info(f"HumeAI TADA {model_size} loaded successfully on {device}")
@@ -188,11 +193,11 @@ class HumeTadaBackend:
             del self.encoder
             self.encoder = None
 
+        device = self._device
         self._device = None
 
-        import torch
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        if device:
+            empty_device_cache(device)
 
         logger.info("HumeAI TADA unloaded")
 
@@ -213,9 +218,7 @@ class HumeTadaBackend:
         """
         await self.load_model(self.model_size)
 
-        cache_key = (
-            "tada_" + get_cache_key(audio_path, reference_text)
-        ) if use_cache else None
+        cache_key = ("tada_" + get_cache_key(audio_path, reference_text)) if use_cache else None
 
         if cache_key:
             cached = get_cached_voice_prompt(cache_key)
@@ -239,9 +242,7 @@ class HumeTadaBackend:
 
             # Encode with forced alignment
             text_arg = [reference_text] if reference_text else None
-            prompt = self.encoder(
-                audio, text=text_arg, sample_rate=sr
-            )
+            prompt = self.encoder(audio, text=text_arg, sample_rate=sr)
 
             # Serialize EncoderOutput to a dict of CPU tensors for caching
             prompt_dict = {}
@@ -299,9 +300,7 @@ class HumeTadaBackend:
             from tada.modules.encoder import EncoderOutput
 
             if seed is not None:
-                torch.manual_seed(seed)
-                if torch.cuda.is_available():
-                    torch.cuda.manual_seed(seed)
+                manual_seed(seed, self._device)
 
             device = self._device
 

--- a/backend/backends/luxtts_backend.py
+++ b/backend/backends/luxtts_backend.py
@@ -16,6 +16,7 @@ from .base import (
     is_model_cached,
     get_torch_device,
     empty_device_cache,
+    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -163,12 +164,8 @@ class LuxTTSBackend:
         await self.load_model()
 
         def _generate_sync():
-            import torch
-
             if seed is not None:
-                torch.manual_seed(seed)
-                if torch.cuda.is_available():
-                    torch.cuda.manual_seed(seed)
+                manual_seed(seed, self.device)
 
             wav = self.model.generate_speech(
                 text=text,

--- a/backend/backends/luxtts_backend.py
+++ b/backend/backends/luxtts_backend.py
@@ -12,7 +12,13 @@ from typing import Optional, Tuple
 import numpy as np
 
 from . import TTSBackend
-from .base import is_model_cached, get_torch_device, combine_voice_prompts as _combine_voice_prompts, model_load_progress
+from .base import (
+    is_model_cached,
+    get_torch_device,
+    empty_device_cache,
+    combine_voice_prompts as _combine_voice_prompts,
+    model_load_progress,
+)
 from ..utils.cache import get_cache_key, get_cached_voice_prompt, cache_voice_prompt
 
 logger = logging.getLogger(__name__)
@@ -30,7 +36,7 @@ class LuxTTSBackend:
         self._device = None
 
     def _get_device(self) -> str:
-        return get_torch_device(allow_mps=True)
+        return get_torch_device(allow_mps=True, allow_xpu=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None
@@ -69,9 +75,12 @@ class LuxTTSBackend:
 
             if device == "cpu":
                 import os
+
                 threads = os.cpu_count() or 4
                 self.model = LuxTTS(
-                    model_path=LUXTTS_HF_REPO, device="cpu", threads=min(threads, 8),
+                    model_path=LUXTTS_HF_REPO,
+                    device="cpu",
+                    threads=min(threads, 8),
                 )
             else:
                 self.model = LuxTTS(model_path=LUXTTS_HF_REPO, device=device)
@@ -81,12 +90,12 @@ class LuxTTSBackend:
     def unload_model(self) -> None:
         """Unload model to free memory."""
         if self.model is not None:
+            device = self.device
             del self.model
             self.model = None
+            self._device = None
 
-            import torch
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            empty_device_cache(device)
 
             logger.info("LuxTTS unloaded")
 

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -14,6 +14,8 @@ from . import TTSBackend, STTBackend, LANGUAGE_CODE_TO_NAME, WHISPER_HF_REPOS
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
+    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -120,8 +122,7 @@ class PyTorchTTSBackend:
             self.model = None
             self._current_model_size = None
 
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            empty_device_cache(self.device)
 
             logger.info("TTS model unloaded")
 
@@ -213,9 +214,7 @@ class PyTorchTTSBackend:
             """Run synchronous generation in thread pool."""
             # Set seed if provided
             if seed is not None:
-                torch.manual_seed(seed)
-                if torch.cuda.is_available():
-                    torch.cuda.manual_seed(seed)
+                manual_seed(seed, self.device)
 
             # Generate audio - this is the blocking operation
             wavs, sample_rate = self.model.generate_voice_clone(
@@ -297,8 +296,7 @@ class PyTorchSTTBackend:
             self.model = None
             self.processor = None
 
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            empty_device_cache(self.device)
 
             logger.info("Whisper model unloaded")
 

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -110,6 +110,11 @@ async def health():
     vram_used = None
     if has_cuda:
         vram_used = torch.cuda.memory_allocated() / 1024 / 1024
+    elif has_xpu:
+        try:
+            vram_used = torch.xpu.memory_allocated() / 1024 / 1024
+        except Exception:
+            pass  # memory_allocated() may not be available on all IPEX versions
 
     model_loaded = False
     model_size = None
@@ -162,7 +167,10 @@ async def health():
         gpu_type=gpu_type,
         vram_used_mb=vram_used,
         backend_type=backend_type,
-        backend_variant=os.environ.get("VOICEBOX_BACKEND_VARIANT", "cuda" if torch.cuda.is_available() else "cpu"),
+        backend_variant=os.environ.get(
+            "VOICEBOX_BACKEND_VARIANT",
+            "cuda" if torch.cuda.is_available() else ("xpu" if has_xpu else "cpu"),
+        ),
     )
 
 

--- a/justfile
+++ b/justfile
@@ -69,8 +69,10 @@ setup-python:
     }
     Write-Host "Installing Python dependencies..."
     & "{{ python }}" -m pip install --upgrade pip -q
-    $hasNvidia = $null -ne (Get-WmiObject Win32_VideoController | Where-Object { $_.Name -match 'NVIDIA' })
-    $hasIntelArc = $null -ne (Get-WmiObject Win32_VideoController | Where-Object { $_.Name -match 'Intel.*Arc' })
+    $gpus = Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name
+    Write-Host "Detected GPUs: $($gpus -join ', ')"
+    $hasNvidia = ($gpus | Where-Object { $_ -match 'NVIDIA' }).Count -gt 0
+    $hasIntelArc = ($gpus | Where-Object { $_ -match 'Arc' }).Count -gt 0
     if ($hasNvidia) { \
         Write-Host "NVIDIA GPU detected — installing PyTorch with CUDA support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128; \
@@ -78,6 +80,11 @@ setup-python:
         Write-Host "Intel Arc GPU detected — installing PyTorch with XPU support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu; \
         & "{{ pip }}" install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu; \
+    } else { \
+        Write-Host "No NVIDIA or Intel Arc GPU detected — using CPU-only PyTorch."; \
+        Write-Host "If you have an Intel Arc GPU, install XPU support manually:"; \
+        Write-Host "  pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu"; \
+        Write-Host "  pip install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu"; \
     }
     & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
     & "{{ pip }}" install --no-deps chatterbox-tts

--- a/justfile
+++ b/justfile
@@ -70,9 +70,14 @@ setup-python:
     Write-Host "Installing Python dependencies..."
     & "{{ python }}" -m pip install --upgrade pip -q
     $hasNvidia = $null -ne (Get-WmiObject Win32_VideoController | Where-Object { $_.Name -match 'NVIDIA' })
+    $hasIntelArc = $null -ne (Get-WmiObject Win32_VideoController | Where-Object { $_.Name -match 'Intel.*Arc' })
     if ($hasNvidia) { \
         Write-Host "NVIDIA GPU detected — installing PyTorch with CUDA support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128; \
+    } elseif ($hasIntelArc) { \
+        Write-Host "Intel Arc GPU detected — installing PyTorch with XPU support..."; \
+        & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu; \
+        & "{{ pip }}" install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu; \
     }
     & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
     & "{{ pip }}" install --no-deps chatterbox-tts


### PR DESCRIPTION
## Summary

Adds Intel Arc GPU (XPU) support so that users with Intel Arc A-series GPUs (e.g. A770, A750) can use hardware acceleration instead of falling back to CPU.

Prompted by user feedback: an Intel Arc A770 16GB owner installed `intel-extension-for-pytorch` system-wide, but voicebox's venv didn't include it, and most backends didn't check for XPU anyway.

## Changes

- **`justfile`** — Windows `setup-python` now auto-detects Intel Arc GPUs (via `Win32_VideoController`) and installs `torch` from the XPU wheel index + `intel-extension-for-pytorch`, mirroring the existing NVIDIA/CUDA auto-detection
- **`backend/backends/base.py`** — Added two shared helpers:
  - `empty_device_cache(device)` — clears VRAM on CUDA or XPU after model unload
  - `manual_seed(seed, device)` — sets reproducible seeds on CPU + CUDA or XPU
- **All TTS backends** now pass `allow_xpu=True` to `get_torch_device()`:
  - `chatterbox_backend.py`
  - `chatterbox_turbo_backend.py`
  - `hume_backend.py` (also enables bf16 on XPU — Intel Arc supports it natively)
  - `luxtts_backend.py`
  - `pytorch_backend.py` (already had `allow_xpu=True`, now uses shared helpers)
- Replaced all inline `torch.cuda.empty_cache()` / `torch.cuda.manual_seed()` calls with the shared helpers so XPU gets the same treatment

## Device priority

The existing priority in `get_torch_device()` is unchanged: **CUDA > XPU > DirectML > MPS > CPU**. Users with both NVIDIA and Intel GPUs will still use CUDA.

## Testing notes

- Requires an Intel Arc GPU + oneAPI toolchain to test XPU path end-to-end
- CPU and CUDA paths are unchanged (the helpers are no-ops for non-matching devices)
- The `setup-python` detection uses `Intel.*Arc` regex, so Intel integrated GPUs (UHD, Iris) won't trigger the XPU install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Intel Arc (XPU) detection and optional installation path; UI/backend now report XPU devices where available.
  * Health/status reporting now accounts for XPU memory usage when present.

* **Chores**
  * Unified device-aware cache clearing and seed initialization across backends for consistent behavior on CPU/CUDA/XPU.
  * Refined device selection logic and unload handling for more robust resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->