### PR TITLE
fix/allows deletion of failed generations 292

### DIFF
--- a/app/src/components/History/HistoryTable.tsx
+++ b/app/src/components/History/HistoryTable.tsx
@@ -569,15 +569,27 @@ export function HistoryTable() {
                       )}
 
                       {isFailed ? (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6 text-muted-foreground/50 hover:bg-muted-foreground/20 hover:text-muted-foreground"
-                          aria-label="Retry generation"
-                          onClick={() => handleRetry(gen.id)}
-                        >
-                          <RotateCcw className="h-2 w-2" />
-                        </Button>
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-muted-foreground/50 hover:bg-muted-foreground/20 hover:text-muted-foreground"
+                            aria-label="Retry generation"
+                            onClick={() => handleRetry(gen.id)}
+                          >
+                            <RotateCcw className="h-2 w-2" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-muted-foreground/50 hover:bg-muted-foreground/20 hover:text-muted-foreground"
+                            aria-label="Delete generation"
+                            disabled={deleteGeneration.isPending}
+                            onClick={() => handleDeleteClick(gen.id, gen.profile_name)}
+                          >
+                            <Trash2 className="h-2 w-2" />
+                          </Button>
+                        </>
                       ) : (
                         <>
                           <DropdownMenu>

--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -5041,7 +5041,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voicebox"
-version = "0.2.3"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "core-foundation-sys",


### PR DESCRIPTION
 **What?**
Allow deletion of failed generations. When a generation task fails for some reason, the user gets an option (trash can button below the regenerate option) to delete it without regenerating. Addresses https://github.com/jamiepine/voicebox/issues/292.

**Why?**
I created a long generation that took a lot of time (and battery energy) that never finished and wanted to delete but had no way to do so. Noticed someone ([else](https://github.com/jamiepine/voicebox/issues/292)) had the same scenario so I decided to take the issue on myself.

**Tested?**
yes using `just dev` was able to test and confirm the deletion of a failed generation job.
<img width="1177" height="157" alt="Screenshot 2026-03-18 at 16 07 38" src="https://github.com/user-attachments/assets/1bb906f7-e350-4ea6-9365-df061e67ae7a" />
<img width="574" height="272" alt="Screenshot 2026-03-18 at 16 08 17" src="https://github.com/user-attachments/assets/8928d9ae-33b1-40b1-975c-59add00b8ff3" />
