### PR TITLE
fix: include changelog in docker web build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,7 +38,6 @@ biome.json
 .bumpversion.cfg
 .npmrc
 Makefile
-CHANGELOG.md
 CONTRIBUTING.md
 SECURITY.md
 LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM oven/bun:1 AS frontend
 WORKDIR /build
 
 # Copy workspace config and frontend source
-COPY package.json bun.lock ./
+COPY package.json bun.lock CHANGELOG.md ./
 COPY app/ ./app/
 COPY web/ ./web/
 


### PR DESCRIPTION
## Summary
- fix the Docker web build by including `CHANGELOG.md` in the frontend build context
- stop excluding `CHANGELOG.md` from the Docker build context in `.dockerignore`

## Problem
`docker compose up --build -d` was failing on current `main` during the frontend build.

The Vite changelog plugin reads `CHANGELOG.md` at build time, but the Dockerfile only copied `package.json`, `bun.lock`, `app/`, and `web/` into the frontend stage. The build then failed with:

```text
[changelog] Could not load virtual:changelog ... ENOENT: no such file or directory, open '/build/CHANGELOG.md'
```

## Fix
- copy `CHANGELOG.md` into the frontend Docker build stage
- remove `CHANGELOG.md` from `.dockerignore` so it is actually available to Docker

## Validation
- reproduced the failure locally on a fresh branch from latest `main`
- ran `docker compose up --build -d`
- confirmed the container reaches healthy state on `127.0.0.1:17493`
- confirmed `GET /health` returns healthy JSON
- opened `http://127.0.0.1:17493/` in the browser and verified the Voicebox UI loads

Closes #308.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include the CHANGELOG file in the Docker image, making it available within the containerized application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->