### PR TITLE
Fix: "Failed to Save" preset error by resolving backend import path resolution

### DIFF
--- a/backend/services/effects.py
+++ b/backend/services/effects.py
@@ -11,6 +11,8 @@ from typing import List, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
+from backend.utils.effects import validate_effects_chain
+
 from ..database import EffectPreset as DBEffectPreset
 from ..models import EffectPresetResponse, EffectPresetCreate, EffectPresetUpdate, EffectConfig
 
@@ -52,7 +54,6 @@ def get_preset_by_name(name: str, db: Session) -> Optional[EffectPresetResponse]
 
 def create_preset(data: EffectPresetCreate, db: Session) -> EffectPresetResponse:
     """Create a new user effect preset."""
-    from .utils.effects import validate_effects_chain
 
     chain_dicts = [e.model_dump() for e in data.effects_chain]
     error = validate_effects_chain(chain_dicts)
@@ -94,7 +95,6 @@ def update_preset(preset_id: str, data: EffectPresetUpdate, db: Session) -> Opti
     if data.description is not None:
         preset.description = data.description
     if data.effects_chain is not None:
-        from .utils.effects import validate_effects_chain
 
         chain_dicts = [e.model_dump() for e in data.effects_chain]
         error = validate_effects_chain(chain_dicts)


### PR DESCRIPTION

<img width="1477" height="1439" alt="image" src="https://github.com/user-attachments/assets/c47f2377-02a5-4c5c-aa8b-8511b601a4e9" />

**Problem:**
Users encounter a "Failed to Save" warning in the UI when attempting to save voice effect presets. This is caused by a ModuleNotFoundError in the backend, specifically because the application cannot resolve the .utils path during runtime in production (EXE) or certain Windows environments.

**Technical Root Cause:**
The previous implementation used a lazy import inside the create_preset and update_preset functions. When the function was called, Python failed to locate the relative module path, leading to a silent backend crash that triggered the UI warning.

**Changes Made:**

Refactored Imports: Moved imports from inside functions to the top-level of backend/services/effects.py. This allows static analysis and compilers (like PyInstaller) to correctly package the dependencies.

Absolute Path Resolution: Updated imports to use absolute paths (from backend.utils.effects import ...) to ensure consistent module resolution regardless of where the backend process is initiated.

Code Cleanup: Removed old commented-out lazy imports to maintain a clean codebase.

**Impact:**
Successfully resolves the "Failed to Save" preset warning and ensures the voice effect system is functional in production builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no impact to end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->