### PR TITLE
fix: torch.from_numpy crash with numpy 2.x — TTS generation fails with 'Unable to create tensor'

### DIFF
--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -52,6 +52,16 @@ def build_server(cuda=False):
     if platform.system() == "Windows":
         args.append("--noconsole")
 
+    # numpy 2.x / torch ABI mismatch fix: install memmove fallback for
+    # torch.from_numpy() before the app starts. Runtime hooks run after
+    # FrozenImporter is registered so frozen torch/numpy are importable.
+    args.extend(
+        [
+            "--runtime-hook",
+            str(backend_dir / "pyi_rth_numpy_compat.py"),
+        ]
+    )
+
     # Add local qwen_tts path if specified (for editable installs)
     qwen_tts_path = os.getenv("QWEN_TTS_PATH")
     if qwen_tts_path and Path(qwen_tts_path).exists():

--- a/backend/pyi_rth_numpy_compat.py
+++ b/backend/pyi_rth_numpy_compat.py
@@ -1,0 +1,80 @@
+"""
+PyInstaller runtime hook: numpy 2.x / torch ABI mismatch fix.
+
+Problem
+-------
+torch is compiled against numpy 1.x headers. numpy 2.x changed the version
+number returned by PyArray_GetNDArrayCVersion() (0x01000009 → 0x02000000),
+so torch's is_numpy_available() returns False and every torch.from_numpy()
+call raises:
+
+    RuntimeError: Numpy is not available
+
+This surfaces as:
+
+    ValueError: Unable to create tensor, you should probably activate
+    padding with 'padding=True'
+
+during TTS generation (EncodecFeatureExtractor → BatchFeature.convert_to_tensors).
+
+Fix
+---
+Runtime hooks execute after PyInstaller's FrozenImporter is registered, so
+frozen torch/numpy are importable here. We start a background thread that
+waits for torch to finish loading then wraps torch.from_numpy with a ctypes
+memmove fallback that bypasses the C-level numpy ABI check entirely.
+
+This approach works with any numpy version and is safer than binary-patching
+libtorch_python.dylib (which risks PyArray_Descr struct layout mismatches).
+"""
+
+import sys
+import threading
+
+
+def _patch_torch_from_numpy():
+    import time
+
+    for _ in range(7200):  # poll up to 360 s at 50 ms intervals
+        time.sleep(0.05)
+        torch = sys.modules.get("torch")
+        if torch is None or not hasattr(torch, "from_numpy"):
+            continue
+        if getattr(torch, "_vb_from_numpy_patched", False):
+            return
+        try:
+            import ctypes
+            import numpy as np
+
+            _orig = torch.from_numpy
+
+            def _safe_from_numpy(arr, _orig=_orig, _c=ctypes, _np=np, _t=torch):
+                try:
+                    return _orig(arr)
+                except RuntimeError:
+                    a = _np.ascontiguousarray(arr)
+                    dtype_map = {
+                        "float32": _t.float32,
+                        "float64": _t.float64,
+                        "int32": _t.int32,
+                        "int64": _t.int64,
+                        "int16": _t.int16,
+                        "int8": _t.int8,
+                        "uint8": _t.uint8,
+                        "bool": _t.bool,
+                    }
+                    out = _t.empty(
+                        list(a.shape),
+                        dtype=dtype_map.get(str(a.dtype), _t.float32),
+                    )
+                    _c.memmove(out.data_ptr(), a.ctypes.data, a.nbytes)
+                    return out
+
+            torch.from_numpy = _safe_from_numpy
+            torch._vb_from_numpy_patched = True
+        except Exception:
+            pass
+        return
+
+
+threading.Thread(target=_patch_torch_from_numpy, daemon=True).start()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -50,7 +50,7 @@ en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_
 # Audio processing
 librosa>=0.10.0
 soundfile>=0.12.0
-numpy>=1.24.0
+numpy>=1.24.0,<2.0
 numba>=0.60.0,<0.61.0
 pedalboard>=0.9.0
 


### PR DESCRIPTION
## Problem

TTS generation fails on macOS (x86_64 / Rosetta) with:

```
RuntimeError: Numpy is not available
ValueError: Unable to create tensor, you should probably activate padding with 'padding=True'
```

**Root cause:** torch is compiled against numpy 1.x. numpy 2.x changed the ABI version number returned by `PyArray_GetNDArrayCVersion()` from `0x01000009` to `0x02000000`. torch's C-level `is_numpy_available()` compares against the compile-time constant `0x01000009`, fails, caches `False`, and every subsequent `torch.from_numpy()` call raises `RuntimeError`. This hits during `EncodecFeatureExtractor.__call__` → `BatchFeature.convert_to_tensors`.

The bundled binary ships numpy 2.0.2 against a torch that expects numpy 1.x ABI, triggering this on every TTS request.

The `requirements.txt` already had a comment flagging the numpy<1.26 concern, but the upper bound was never added to the actual pin.

## Fix

**1. `backend/requirements.txt` — pin numpy<2.0**

Prevents new builds from bundling an incompatible numpy version.

**2. `backend/pyi_rth_numpy_compat.py` — PyInstaller runtime hook**

Adds a belt-and-suspenders fallback: a background thread that waits for torch to finish loading then wraps `torch.from_numpy` with a `ctypes.memmove`-based implementation that bypasses the C-level ABI check entirely. Runtime hooks execute after FrozenImporter is registered, so frozen torch/numpy are importable.

This is wired into `build_binary.py` via `--runtime-hook`. It protects against this class of ABI mismatch regardless of which numpy version ends up in the bundle.

## Testing

Verified on macOS 13 (MacBook Pro, running x86_64 via Rosetta 2) against Voicebox v0.3.0. TTS generation succeeds after applying these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup compatibility between PyTorch and NumPy in frozen apps: application now installs a runtime workaround so tensor-from-NumPy operations avoid intermittent RuntimeErrors during import, improving initialization reliability and preventing startup crashes.

* **Chores**
  * Tightened NumPy dependency bounds to avoid incompatible major-version upgrades (prevents NumPy 2.x), reducing risk of runtime incompatibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->