### PR TITLE
feat: Qwen CustomVoice engine + profile compatibility UX

### DIFF
--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -125,22 +125,22 @@ export function FloatingGenerateBox({
   }, [watchedEngine, setSelectedEngine]);
 
   // Sync generation form language, engine, and effects with selected profile
+  type EngineValue = 'qwen' | 'luxtts' | 'chatterbox' | 'chatterbox_turbo' | 'tada' | 'kokoro' | 'qwen_custom_voice';
   useEffect(() => {
     if (selectedProfile?.language) {
       form.setValue('language', selectedProfile.language as LanguageCode);
     }
-    // Auto-switch engine if profile has a default
-    if (selectedProfile?.default_engine) {
-      form.setValue(
-        'engine',
-        selectedProfile.default_engine as
-          | 'qwen'
-          | 'luxtts'
-          | 'chatterbox'
-          | 'chatterbox_turbo'
-          | 'tada'
-          | 'kokoro',
-      );
+    // Auto-switch engine to match the profile
+    const engine = selectedProfile?.default_engine ?? selectedProfile?.preset_engine;
+    if (engine) {
+      form.setValue('engine', engine as EngineValue);
+    } else if (selectedProfile && selectedProfile.voice_type !== 'preset') {
+      // Cloned/designed profile with no default — ensure a compatible (non-preset) engine
+      const currentEngine = form.getValues('engine');
+      const presetEngines = new Set(['kokoro', 'qwen_custom_voice']);
+      if (presetEngines.has(currentEngine)) {
+        form.setValue('engine', 'qwen');
+      }
     }
     // Pre-fill effects from profile defaults
     if (

--- a/app/src/components/VoiceProfiles/ProfileCard.tsx
+++ b/app/src/components/VoiceProfiles/ProfileCard.tsx
@@ -25,9 +25,10 @@ const ENGINE_DISPLAY_NAMES: Record<string, string> = {
 
 interface ProfileCardProps {
   profile: VoiceProfileResponse;
+  disabled?: boolean;
 }
 
-export function ProfileCard({ profile }: ProfileCardProps) {
+export function ProfileCard({ profile, disabled }: ProfileCardProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const deleteProfile = useDeleteProfile();
@@ -80,8 +81,9 @@ export function ProfileCard({ profile }: ProfileCardProps) {
     <>
       <Card
         className={cn(
-          'cursor-pointer hover:shadow-md transition-all flex flex-col h-[162px]',
-          isSelected && 'ring-2 ring-accent shadow-md',
+          'cursor-pointer transition-all flex flex-col h-[162px]',
+          disabled ? 'opacity-40 hover:opacity-60' : 'hover:shadow-md',
+          isSelected && !disabled && 'ring-2 ring-accent shadow-md',
         )}
         onClick={handleSelect}
         tabIndex={0}

--- a/app/src/components/VoiceProfiles/ProfileCard.tsx
+++ b/app/src/components/VoiceProfiles/ProfileCard.tsx
@@ -41,6 +41,12 @@ export function ProfileCard({ profile, disabled }: ProfileCardProps) {
   const isSelected = selectedProfileId === profile.id;
 
   const handleSelect = () => {
+    // If disabled but already selected, bounce the selection to re-trigger engine auto-switch
+    if (disabled && isSelected) {
+      setSelectedProfileId(null);
+      setTimeout(() => setSelectedProfileId(profile.id), 0);
+      return;
+    }
     setSelectedProfileId(isSelected ? null : profile.id);
   };
 

--- a/app/src/components/VoiceProfiles/ProfileList.tsx
+++ b/app/src/components/VoiceProfiles/ProfileList.tsx
@@ -20,17 +20,20 @@ export function ProfileList() {
   // Scroll to the selected profile after engine/sort changes
   useEffect(() => {
     if (!selectedProfileId) return;
-    // Wait a frame for the DOM to update after re-sort
-    requestAnimationFrame(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const rafId = requestAnimationFrame(() => {
       const el = cardRefs.current.get(selectedProfileId);
       if (!el) return;
 
       // Temporarily apply scroll-margin so it doesn't land flush at the top
       el.style.scrollMarginTop = '180px';
       el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
-      // Clean up after scroll completes
-      setTimeout(() => { el.style.scrollMarginTop = ''; }, 500);
+      timeoutId = setTimeout(() => { el.style.scrollMarginTop = ''; }, 500);
     });
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
   }, [selectedProfileId, selectedEngine]);
 
   if (isLoading) {

--- a/app/src/components/VoiceProfiles/ProfileList.tsx
+++ b/app/src/components/VoiceProfiles/ProfileList.tsx
@@ -1,4 +1,5 @@
-import { Mic, Music, Sparkles } from 'lucide-react';
+import { Info, Mic, Sparkles } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useProfiles } from '@/lib/hooks/useProfiles';
@@ -9,16 +10,28 @@ import { ProfileForm } from './ProfileForm';
 /** Engines that use preset (built-in) voices instead of cloned profiles. */
 const PRESET_ENGINES = new Set(['kokoro', 'qwen_custom_voice']);
 
-/** Human-readable engine names for empty state messages. */
-const ENGINE_NAMES: Record<string, string> = {
-  kokoro: 'Kokoro',
-  qwen_custom_voice: 'Qwen CustomVoice',
-};
-
 export function ProfileList() {
   const { data: profiles, isLoading, error } = useProfiles();
   const setDialogOpen = useUIStore((state) => state.setProfileDialogOpen);
   const selectedEngine = useUIStore((state) => state.selectedEngine);
+  const selectedProfileId = useUIStore((state) => state.selectedProfileId);
+  const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Scroll to the selected profile after engine/sort changes
+  useEffect(() => {
+    if (!selectedProfileId) return;
+    // Wait a frame for the DOM to update after re-sort
+    requestAnimationFrame(() => {
+      const el = cardRefs.current.get(selectedProfileId);
+      if (!el) return;
+
+      // Temporarily apply scroll-margin so it doesn't land flush at the top
+      el.style.scrollMarginTop = '180px';
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      // Clean up after scroll completes
+      setTimeout(() => { el.style.scrollMarginTop = ''; }, 500);
+    });
+  }, [selectedProfileId, selectedEngine]);
 
   if (isLoading) {
     return null;
@@ -35,10 +48,18 @@ export function ProfileList() {
   const allProfiles = profiles || [];
   const isPresetEngine = PRESET_ENGINES.has(selectedEngine);
 
-  // Filter profiles based on selected engine
-  const filteredProfiles = isPresetEngine
-    ? allProfiles.filter((p) => p.voice_type === 'preset' && p.preset_engine === selectedEngine)
-    : allProfiles.filter((p) => p.voice_type !== 'preset');
+  /** Whether a profile is supported by the currently selected engine. */
+  const isSupported = (p: (typeof allProfiles)[number]) =>
+    isPresetEngine
+      ? p.voice_type === 'preset' && p.preset_engine === selectedEngine
+      : p.voice_type !== 'preset';
+
+  // Sort so supported profiles come first
+  const sortedProfiles = [...allProfiles].sort(
+    (a, b) => (isSupported(a) ? 0 : 1) - (isSupported(b) ? 0 : 1),
+  );
+
+  const hasUnsupported = sortedProfiles.some((p) => !isSupported(p));
 
   return (
     <div className="flex flex-col">
@@ -56,29 +77,26 @@ export function ProfileList() {
               </Button>
             </CardContent>
           </Card>
-        ) : filteredProfiles.length === 0 && isPresetEngine ? (
-          <Card>
-            <CardContent className="flex flex-col items-center justify-center py-12">
-              <Music className="h-12 w-12 text-muted-foreground mb-4" />
-              <p className="text-muted-foreground mb-2">
-                No {ENGINE_NAMES[selectedEngine] ?? selectedEngine} voices created yet.
-              </p>
-              <p className="text-sm text-muted-foreground mb-4">
-                Create a profile to choose a specific voice before generating.
-              </p>
-              <Button onClick={() => setDialogOpen(true)}>
-                <Sparkles className="mr-2 h-4 w-4" />
-                Create {ENGINE_NAMES[selectedEngine] ?? selectedEngine} Voice
-              </Button>
-            </CardContent>
-          </Card>
         ) : (
           <div className="flex gap-4 overflow-x-auto p-1 pb-1 lg:grid lg:grid-cols-3 lg:auto-rows-auto lg:overflow-x-visible lg:pb-[150px]">
-            {filteredProfiles.map((profile) => (
-              <div key={profile.id} className="shrink-0 w-[200px] lg:w-auto lg:shrink">
-                <ProfileCard profile={profile} />
+            {sortedProfiles.map((profile) => (
+              <div
+                key={profile.id}
+                className="shrink-0 w-[200px] lg:w-auto lg:shrink"
+                ref={(el) => {
+                  if (el) cardRefs.current.set(profile.id, el);
+                  else cardRefs.current.delete(profile.id);
+                }}
+              >
+                <ProfileCard profile={profile} disabled={!isSupported(profile)} />
               </div>
             ))}
+            {hasUnsupported && (
+              <div className="col-span-full flex items-center gap-2 text-xs text-muted-foreground py-2">
+                <Info className="h-3.5 w-3.5 shrink-0" />
+                <span>Only supported voice profiles can be selected for the current model.</span>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -10,6 +10,7 @@ import { useGeneration } from '@/lib/hooks/useGeneration';
 import { useModelDownloadToast } from '@/lib/hooks/useModelDownloadToast';
 import { useGenerationStore } from '@/stores/generationStore';
 import { useServerStore } from '@/stores/serverStore';
+import { useUIStore } from '@/stores/uiStore';
 
 const generationSchema = z.object({
   text: z.string().min(1, '').max(50000),
@@ -45,6 +46,7 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
   const maxChunkChars = useServerStore((state) => state.maxChunkChars);
   const crossfadeMs = useServerStore((state) => state.crossfadeMs);
   const normalizeAudio = useServerStore((state) => state.normalizeAudio);
+  const selectedEngine = useUIStore((state) => state.selectedEngine);
   const [downloadingModelName, setDownloadingModelName] = useState<string | null>(null);
   const [downloadingDisplayName, setDownloadingDisplayName] = useState<string | null>(null);
 
@@ -62,7 +64,7 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
       seed: undefined,
       modelSize: '1.7B',
       instruct: '',
-      engine: 'qwen',
+      engine: (selectedEngine as GenerationFormValues['engine']) || 'qwen',
       ...options.defaultValues,
     },
   });

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -4,6 +4,7 @@ import io
 import json as _json
 import logging
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile


### PR DESCRIPTION
## Summary
- Add Qwen CustomVoice as a new preset engine with 9 built-in voices and instruct control
- Gray out unsupported voice profiles instead of hiding them, with supported profiles sorted first
- Clicking a grayed-out profile auto-switches the engine to a compatible one and scrolls to it
- Fix engine/profile desync when navigating between tabs by initializing form state from the store
- Store media paths relative to data dir for portability

## Test plan
- [ ] Select a preset engine (Kokoro/CustomVoice) — cloned profiles should appear grayed out
- [ ] Click a grayed-out profile — engine should switch and profile becomes active
- [ ] Navigate away to another tab and back — engine and profile selection should stay in sync
- [ ] Verify info tip appears at bottom of profile list when unsupported profiles exist
- [ ] Create and generate with Qwen CustomVoice preset voices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes in generation form defaulting and auto-switching engine based on selected profiles, which can affect what model/engine is used for requests. Backend impact appears minimal (route import/update timestamp behavior) but should be verified with preset voice listing and profile update flows.
> 
> **Overview**
> Adds support for the new preset engine `qwen_custom_voice` and updates generation/profile selection so the form engine auto-aligns with the selected profile (including falling back away from preset engines when selecting non-preset voices).
> 
> Updates the voice profile list UX to **sort supported profiles first**, **gray out unsupported profiles instead of filtering them out**, show an inline info hint when unsupported profiles exist, and auto-scroll the list to the currently selected profile after engine changes.
> 
> Initializes generation form `engine` from the global `selectedEngine` store to prevent engine/profile desync when navigating between views, and includes a small backend tweak in `profiles.py` (imports `datetime`, used for updated timestamps in effects updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ebf57d8f46d641711153b54a7bb3168f44c45ab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice profiles now organized by engine compatibility, with supported profiles listed first.
  * Unsupported profiles are visually disabled; an informational row explains selection limits.
  * Selected voice profile auto-scrolls into view; engine selection now defaults to your previously chosen engine.

* **Bug Fixes**
  * Improved profile-to-generation synchronization to avoid incompatible engine selections when cloning or switching profiles.
  * Server now updates profile timestamps when effects are changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->