### PR TITLE
fix(history): populate status/error/engine fields from DB row

### DIFF
--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -89,11 +89,11 @@ async def get_generation(
         duration=gen.duration,
         seed=gen.seed,
         instruct=gen.instruct,
-        engine=gen.engine,
+        engine=gen.engine or "qwen",
         model_size=gen.model_size,
-        status=gen.status,
+        status=gen.status or "completed",
         error=gen.error,
-        is_favorited=gen.is_favorited,
+        is_favorited=bool(gen.is_favorited),
         created_at=gen.created_at,
     )
 

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -89,6 +89,11 @@ async def get_generation(
         duration=gen.duration,
         seed=gen.seed,
         instruct=gen.instruct,
+        engine=gen.engine,
+        model_size=gen.model_size,
+        status=gen.status,
+        error=gen.error,
+        is_favorited=gen.is_favorited,
         created_at=gen.created_at,
     )
 


### PR DESCRIPTION
## Problem

`GET /history/{generation_id}` constructs `HistoryResponse` without passing `status`, `error`, `engine`, `model_size`, or `is_favorited` from the DB row. Since `HistoryResponse.status` defaults to `"completed"` in the Pydantic model ([`models.py:141`](https://github.com/jamiepine/voicebox/blob/main/backend/models.py#L141)), **this endpoint returns `status="completed"` for every generation regardless of the actual DB state** — including jobs still in `loading_model` or `generating`, and even `failed` jobs.

This breaks any client polling `/history/{id}` for job completion: the API lies about the status, so the only trustworthy success signal becomes `audio_path` being non-empty.

## Reproduction

```bash
# 1. Start a generation
JOB_ID=$(curl -s -X POST http://localhost:17493/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"Hello world","profile_id":"<id>","language":"en"}' \
  | jq -r .id)

# 2. Poll immediately — status lies
curl -s http://localhost:17493/history/$JOB_ID | jq '{status, audio_path}'
# => {"status": "completed", "audio_path": ""}   ← WRONG, still generating

# 3. Check the SQLite DB directly — truth
sqlite3 ~/.local/share/voicebox/voicebox.db \
  "SELECT status, audio_path FROM generations WHERE id='$JOB_ID';"
# => generating|
```

The API response contradicts the DB on every in-flight generation.

## Fix

Pass all fields through from the DB row. The `Generation` model in [`database/models.py`](https://github.com/jamiepine/voicebox/blob/main/backend/database/models.py#L52) already has all these columns, so the change is a pure field-forwarding addition — no schema or migration impact.

```diff
     gen, profile_name = result
     return models.HistoryResponse(
         id=gen.id,
         profile_id=gen.profile_id,
         profile_name=profile_name,
         text=gen.text,
         language=gen.language,
         audio_path=gen.audio_path,
         duration=gen.duration,
         seed=gen.seed,
         instruct=gen.instruct,
+        engine=gen.engine,
+        model_size=gen.model_size,
+        status=gen.status,
+        error=gen.error,
+        is_favorited=gen.is_favorited,
         created_at=gen.created_at,
     )
```

## Verification

Tested on a CPU-only install (Qwen3-TTS 1.7B). After the patch, the status progression observed via the endpoint matches the DB:

```
t+0s   status='loading_model'  audio_path=''
t+20s  status='generating'     audio_path=''
t+40s  status='completed'      audio_path='generations/<id>.wav'
```

Jobs interrupted by a server restart mid-generation now correctly report `status="failed"` with `error="Server was shut down during generation"` instead of `status="completed"`.

## Context

Found while building a batch TTS pipeline that relied on `/history/{id}` as the polling endpoint. The workaround on the client side is to treat `audio_path` as the sole completion signal, but that hides the distinction between "still running" and "actually failed" and can't expose engine/model_size to clients either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The generation history view now returns expanded metadata for individual generations: engine info, model size, processing status, any error details, and favorite status. This gives users a clearer, more complete snapshot of past generation requests for easier review, troubleshooting, and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->