### PR TITLE
feat: add Blackwell GPU (sm_120) CUDA support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,12 @@ jobs:
       - name: Build CUDA server binary (onedir)
         shell: bash
         working-directory: backend
+        env:
+          # Include Blackwell (sm_120) via PTX forward compatibility.
+          # Pre-built PyTorch cu128 wheels ship native kernels for sm_80/86/89/90
+          # but not sm_120. Setting this env var causes torch.utils.cpp_extension
+          # (and any JIT-compiled kernels) to target Blackwell GPUs as well.
+          TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;12.0+PTX"
         run: python build_binary.py --cuda
 
       - name: Package into server core + CUDA libs archives


### PR DESCRIPTION
Adds TORCH_CUDA_ARCH_LIST to the CUDA build step in release.yml to include 12.0+PTX for Blackwell GPU forward compatibility. 5 reports (#386 #395 #396 #399 #400) from RTX 50-series users hitting 'no kernel image' because pre-built PyTorch cu128 doesn't include sm_120. Fixes #386. This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support additional NVIDIA GPU architectures, expanding GPU compatibility and compatibility with newer GPU models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->