### PR TITLE
fix: reliably keep server alive after GUI close on Windows

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -105,6 +105,11 @@ def _start_parent_watchdog(parent_pid, data_dir=None):
     This is the clean shutdown mechanism: instead of the Tauri app trying to
     forcefully kill the server (which spawns console windows on Windows),
     the server monitors its parent and shuts itself down gracefully.
+
+    The Tauri app writes a .keep-running sentinel file to data_dir before
+    exiting when "remain running after close" is enabled. This is a reliable
+    fallback for the HTTP /watchdog/disable request, which can race with
+    process exit on Windows.
     """
     import os
     import signal
@@ -177,6 +182,18 @@ def _start_parent_watchdog(parent_pid, data_dir=None):
                 time.sleep(1)
                 if _watchdog_disabled:
                     watchdog_logger.info("Watchdog was disabled during grace period, keeping server alive")
+                    return
+                # Check for sentinel file written by Tauri before exit.
+                # This catches the case where the HTTP disable request
+                # didn't arrive before the parent process died (common
+                # on Windows where process teardown is fast).
+                sentinel = os.path.join(data_dir, ".keep-running") if data_dir else None
+                if sentinel and os.path.exists(sentinel):
+                    watchdog_logger.info("Found .keep-running sentinel file, keeping server alive")
+                    try:
+                        os.remove(sentinel)
+                    except OSError:
+                        pass
                     return
                 watchdog_logger.info("Watchdog still enabled after grace period, shutting down server...")
                 if sys.platform == "win32":

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -860,6 +860,22 @@ pub fn run() {
                         // Tell the server to disable its watchdog so it survives
                         // after this process exits.
                         println!("Keep server running: disabling watchdog...");
+
+                        // Write a sentinel file as a reliable fallback. On Windows
+                        // the HTTP request below can race with process exit, leaving
+                        // the watchdog unaware it should stay alive. The sentinel
+                        // file is checked during the watchdog grace period.
+                        let data_dir = app
+                            .path()
+                            .app_data_dir()
+                            .unwrap_or_default();
+                        let sentinel = data_dir.join(".keep-running");
+                        if let Err(e) = std::fs::write(&sentinel, b"1") {
+                            eprintln!("Failed to write keep-running sentinel: {}", e);
+                        } else {
+                            println!("Wrote keep-running sentinel to {:?}", sentinel);
+                        }
+
                         let client = reqwest::blocking::Client::builder()
                             .timeout(std::time::Duration::from_secs(2))
                             .build()


### PR DESCRIPTION
## Summary

On Windows, closing the GUI with "remain running after close" enabled kills the server anyway. The HTTP `/watchdog/disable` request races with process exit - the Tauri process dies before the request arrives at the server.

## Root cause

In `main.rs` RunEvent::Exit, the blocking HTTP request has a 2-second timeout, but on Windows the process can terminate before the request completes. The watchdog in `server.py` detects parent death, sleeps 1 second, checks `_watchdog_disabled` (still false because the request never arrived), and calls `os._exit(0)`.

## Fix

Added a `.keep-running` sentinel file as a reliable fallback:

1. `tauri/src-tauri/src/main.rs`: Writes `.keep-running` to `app_data_dir` before sending the HTTP request. File writes are synchronous and complete before process exit.
2. `backend/server.py`: Watchdog checks for the sentinel file during the grace period after detecting parent death. If found, keeps the server alive and removes the file.

The HTTP request still fires as before (and works on macOS/Linux where the race doesn't occur). The sentinel file is a Windows-specific safety net.

## Testing

Needs Windows 11 to reproduce. The fix is additive - existing macOS/Linux behavior is unchanged since the HTTP request typically succeeds there.

Fixes #372

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior to prevent unexpected termination in race conditions, particularly on Windows systems where timing-sensitive requests may be delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->