### PR TITLE
fix: prevent intermittent clip splitting failures

### DIFF
--- a/app/src/components/StoriesTab/StoryTrackEditor.tsx
+++ b/app/src/components/StoriesTab/StoryTrackEditor.tsx
@@ -500,7 +500,7 @@ export function StoryTrackEditor({ storyId, items }: StoryTrackEditorProps) {
   }, [trimmingItem, trimSide, tempTrimValues, storyId, trimItem, toast]);
 
   const handleSplit = useCallback(() => {
-    if (!selectedClipId) return;
+    if (!selectedClipId || splitItem.isPending) return;
 
     const item = items.find((i) => i.id === selectedClipId);
     if (!item) return;

--- a/backend/services/stories.py
+++ b/backend/services/stories.py
@@ -484,13 +484,15 @@ async def split_story_item(
     Returns:
         List of two updated item details (original and new) or None if not found/invalid
     """
-    # Get the item
+    # Get the item with a row lock to prevent concurrent splits on the
+    # same clip (e.g. from rapid double-clicks racing each other).
     item = (
         db.query(DBStoryItem)
         .filter_by(
             id=item_id,
             story_id=story_id,
         )
+        .with_for_update()
         .first()
     )
     if not item:


### PR DESCRIPTION
## Summary

Addresses the intermittent "Failed to split clip" error reported in #366 with two changes targeting the race condition.

## Root cause

`split_story_item` in `backend/services/stories.py` queries the item, mutates it, creates a new item, and commits - all without any row locking. Rapid double-clicks (or query invalidation re-renders triggering concurrent mutations) can cause the second request to read stale state from the first, leading to a 404 or inconsistent trim values.

## Changes

**Backend** (`backend/services/stories.py`): Added `with_for_update()` to the item query in `split_story_item` (line 490). This acquires a row-level lock so concurrent split requests on the same clip are serialized rather than racing.

**Frontend** (`app/src/components/StoriesTab/StoryTrackEditor.tsx`): Added `splitItem.isPending` guard to `handleSplit` (line 503). Prevents the callback from firing while a split mutation is already in flight, which is the most common trigger for the race.

## Testing

The race is intermittent by nature, so there's no deterministic repro. The row lock prevents the database-level race, and the `isPending` guard prevents the UI-level double-fire.

Fixes #366

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split operation reliability by preventing new requests from being initiated when another operation is already in progress, reducing duplicate action risks.
  * Implemented database-level locking to safely manage concurrent split attempts and prevent race conditions during simultaneous operations on the same items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->