### PR TITLE
fix: keep cpal Stream alive until playback completes

### DIFF
--- a/tauri/src-tauri/src/audio_output.rs
+++ b/tauri/src-tauri/src/audio_output.rs
@@ -401,9 +401,25 @@ impl AudioOutputState {
             eprintln!("play_to_device: Failed to play stream: {}", e);
             format!("Failed to play stream: {}", e)
         })?;
-        
+
         eprintln!("play_to_device: Stream started successfully");
 
+        // Keep the stream alive until playback finishes.
+        // Previously the stream was dropped immediately on function return,
+        // causing silent playback (cpal stops output when its Stream is dropped).
+        let total_samples = {
+            buffer.lock().unwrap().len()
+        };
+        loop {
+            let pos = position.load(std::sync::atomic::Ordering::Relaxed);
+            if pos >= total_samples || stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        // stream is dropped here, after audio has finished playing
+        drop(stream);
         eprintln!("play_to_device: Function completed successfully");
         Ok(())
     }


### PR DESCRIPTION
Closes #404

## Problem

In `play_to_device()`, a `cpal::Stream` is created and `stream.play()` is called, but the stream variable is immediately dropped when the function returns (`Ok(())` at end of scope). Per the cpal documentation, dropping a `Stream` stops audio output immediately. This means every call to `play_to_device()` results in silent playback — the stream is created, play is invoked, and then instantly torn down before any audio is sent to the hardware.

## Fix

After calling `stream.play()`, add a spin-wait loop that holds the `Stream` in scope until either:
- All samples in the buffer have been consumed (`position >= total_samples`), or  
- The `stop_flag` is set (for external interruption)

The loop sleeps 10ms between checks to avoid busy-waiting. The `Stream` is then explicitly dropped after the loop exits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback to properly complete instead of stopping immediately after starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->