### PR TITLE
feat(history): add "Clear failed" button

### DIFF
--- a/app/src/components/History/HistoryTable.tsx
+++ b/app/src/components/History/HistoryTable.tsx
@@ -45,6 +45,7 @@ import { apiClient } from '@/lib/api/client';
 import type { EffectConfig, GenerationVersionResponse, HistoryResponse } from '@/lib/api/types';
 import { BOTTOM_SAFE_AREA_PADDING } from '@/lib/constants/ui';
 import {
+  useClearFailedGenerations,
   useDeleteGeneration,
   useExportGeneration,
   useExportGenerationAudio,
@@ -124,6 +125,8 @@ export function HistoryTable() {
   });
 
   const deleteGeneration = useDeleteGeneration();
+  const clearFailed = useClearFailedGenerations();
+  const [clearFailedDialogOpen, setClearFailedDialogOpen] = useState(false);
   const exportGeneration = useExportGeneration();
   const exportGenerationAudio = useExportGenerationAudio();
   const importGeneration = useImportGeneration();
@@ -157,11 +160,11 @@ export function HistoryTable() {
   const pendingCount = useGenerationStore((state) => state.pendingGenerationIds.size);
   const prevPendingCountRef = useRef(pendingCount);
   useEffect(() => {
-    if (deleteGeneration.isSuccess || importGeneration.isSuccess) {
+    if (deleteGeneration.isSuccess || importGeneration.isSuccess || clearFailed.isSuccess) {
       setPage(0);
       setAllHistory([]);
     }
-  }, [deleteGeneration.isSuccess, importGeneration.isSuccess]);
+  }, [deleteGeneration.isSuccess, importGeneration.isSuccess, clearFailed.isSuccess]);
 
   useEffect(() => {
     // A generation finished (pending count decreased) — scroll back to show it
@@ -415,6 +418,27 @@ export function HistoryTable() {
 
   const history = allHistory;
   const hasMore = allHistory.length < total;
+  const failedCount = history.filter((g) => g.status === 'failed').length;
+
+  const handleClearFailedConfirm = () => {
+    clearFailed.mutate(undefined, {
+      onSuccess: (data) => {
+        setClearFailedDialogOpen(false);
+        toast({
+          title: 'Cleared failed generations',
+          description: `${data.deleted} failed ${data.deleted === 1 ? 'generation' : 'generations'} removed.`,
+        });
+      },
+      onError: (error) => {
+        setClearFailedDialogOpen(false);
+        toast({
+          title: 'Failed to clear',
+          description: error instanceof Error ? error.message : 'Unknown error',
+          variant: 'destructive',
+        });
+      },
+    });
+  };
 
   return (
     <div className="flex flex-col h-full min-h-0 relative">
@@ -424,6 +448,23 @@ export function HistoryTable() {
         </div>
       ) : (
         <>
+          {failedCount > 0 && (
+            <div className="flex items-center justify-between px-1 pb-2">
+              <span className="text-xs text-muted-foreground">
+                {failedCount} failed {failedCount === 1 ? 'generation' : 'generations'}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs text-muted-foreground hover:text-destructive"
+                onClick={() => setClearFailedDialogOpen(true)}
+                disabled={clearFailed.isPending}
+              >
+                <Trash2 className="h-3 w-3 mr-1.5" />
+                {clearFailed.isPending ? 'Clearing...' : 'Clear failed'}
+              </Button>
+            </div>
+          )}
           {isScrolled && (
             <div className="absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-background to-transparent z-10 pointer-events-none" />
           )}
@@ -754,6 +795,31 @@ export function HistoryTable() {
               disabled={deleteGeneration.isPending}
             >
               {deleteGeneration.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={clearFailedDialogOpen} onOpenChange={setClearFailedDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Clear failed generations</DialogTitle>
+            <DialogDescription>
+              This will permanently delete {failedCount} failed{' '}
+              {failedCount === 1 ? 'generation' : 'generations'} from your history. This cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setClearFailedDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleClearFailedConfirm}
+              disabled={clearFailed.isPending}
+            >
+              {clearFailed.isPending ? 'Clearing...' : 'Clear all'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -270,6 +270,12 @@ class ApiClient {
     });
   }
 
+  async clearFailedGenerations(): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(`/history/failed`, {
+      method: 'DELETE',
+    });
+  }
+
   async exportGeneration(generationId: string): Promise<Blob> {
     const url = `${this.getBaseUrl()}/history/${generationId}/export`;
     const response = await fetch(url);

--- a/app/src/lib/hooks/useHistory.ts
+++ b/app/src/lib/hooks/useHistory.ts
@@ -29,6 +29,17 @@ export function useDeleteGeneration() {
   });
 }
 
+export function useClearFailedGenerations() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiClient.clearFailedGenerations(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
+  });
+}
+
 export function useExportGeneration() {
   const platform = usePlatform();
 

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -62,6 +62,13 @@ async def import_generation(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.delete("/history/failed")
+async def clear_failed_generations(db: Session = Depends(get_db)):
+    """Delete every generation with status='failed'. Used by the UI's 'Clear failed' button (#410)."""
+    count = await history.delete_failed_generations(db)
+    return {"deleted": count}
+
+
 @router.get("/history/{generation_id}", response_model=models.HistoryResponse)
 async def get_generation(
     generation_id: str,

--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -264,6 +264,43 @@ async def delete_generation(
     return True
 
 
+async def delete_failed_generations(db: Session) -> int:
+    """
+    Delete every generation whose status is 'failed'.
+
+    Used by the "Clear failed" action in the UI so users can tidy up
+    history after the model wasn't loaded, the app was closed mid-run,
+    or a generation otherwise errored out (see issue #410).
+
+    Returns:
+        Number of generations deleted.
+    """
+    from . import versions as versions_mod
+
+    failed = db.query(DBGeneration).filter(DBGeneration.status == "failed").all()
+    count = 0
+    for generation in failed:
+        # Clean up version files/rows first.
+        versions_mod.delete_versions_for_generation(generation.id, db)
+
+        # Remove the main audio file if it somehow made it to disk.
+        if generation.audio_path:
+            audio_path = config.resolve_storage_path(generation.audio_path)
+            if audio_path is not None and audio_path.exists():
+                try:
+                    audio_path.unlink()
+                except OSError:
+                    # Best-effort cleanup — don't abort the whole sweep
+                    # if a single file can't be removed.
+                    pass
+
+        db.delete(generation)
+        count += 1
+
+    db.commit()
+    return count
+
+
 async def delete_generations_by_profile(
     profile_id: str,
     db: Session,


### PR DESCRIPTION
## Summary
Closes #410.

When the model isn't loaded or the app is closed mid-generation, failed rows pile up in the history and can't be cleared in bulk — the existing delete action only runs for successful generations individually. This adds:

- **Backend**: `DELETE /history/failed` → `delete_failed_generations()` sweeps all `status='failed'` rows plus their version files and any stray audio file on disk. Returns `{ deleted: N }`.
- **Frontend**:
  - `apiClient.clearFailedGenerations()` + `useClearFailedGenerations()` hook.
  - New header strip in `HistoryTable` — only rendered when `failedCount > 0` — showing `"N failed generations"` and a **Clear failed** button.
  - Confirmation dialog (same pattern as the existing single-delete one) before the sweep runs.
  - History view resets to page 0 on success, toast reports how many rows were removed.

## Test plan
- [x] Python syntax / import check on modified backend files
- [x] TSX files type-compile against existing `HistoryResponse.status` union
- [ ] Run backend + app, produce a failed generation (cancel while loading model), click "Clear failed", confirm row disappears and toast fires
- [ ] Verify `deleted: 0` when no failed rows exist (button is hidden anyway, but endpoint is safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now clear failed generation records directly from their history with a dedicated control
  * Confirmation dialog shows the count of failed generations before removal to prevent accidental deletion
  * New header displays the number of failed generations with a quick-access clear button in the history interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->