### PR TITLE
fix(deps): relax PyTorch requirement for macOS Intel (x86_64) compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ sqlalchemy>=2.0.0
 alembic>=1.13.0
 
 # ML models
-torch>=2.7.0
+torch>=2.2.0
 transformers>=4.36.0,<=4.57.6
 accelerate>=0.26.0
 huggingface_hub>=0.20.0


### PR DESCRIPTION
### Discovery
During our testing on Intel-based MacBook devices (`x86_64` architecture), we discovered that the initial backend setup completely fails. 

The root cause is that PyTorch officially dropped pre-compiled wheel support for macOS `x86_64` starting after version `2.2.2`. The highest available wheel on PyPI for older Macs is `2.2.2`. Because the `backend/requirements.txt` strictly enforces `torch>=2.7.0`, `pip` throws a `No matching distribution found` error, entirely blocking the setup script and preventing developers with Intel chips from running Voicebox locally.

### Solution
- Relaxed the hard dependency in `backend/requirements.txt` from `torch>=2.7.0` to `torch>=2.2.0`. 
- This restores compatibility allowing `pip` to resolve the `2.2.2` fallback version for Intel Macs, while still pulling the latest versions (like `2.6.0` or `2.7.0`) for Apple Silicon and Windows/Linux CUDA environments natively.

### Verification
- Tested and confirmed a 100% successful local build and inference execution on an Intel Mac using CPU paths.
- Verified existing PRs to ensure this specific OS architecture gap hasn't been covered yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency compatibility to support a wider range of library versions, enabling broader installation flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->