### PR TITLE
fix: avoid ScreenCaptureKit launch crash on macOS 11

### DIFF
--- a/app/src/lib/hooks/useSystemAudioCapture.ts
+++ b/app/src/lib/hooks/useSystemAudioCapture.ts
@@ -26,8 +26,24 @@ export function useSystemAudioCapture({
 
   // Check if system audio capture is supported
   useEffect(() => {
-    const supported = platform.audio.isSystemAudioSupported();
-    setIsSupported(supported);
+    let isActive = true;
+
+    void platform.audio
+      .isSystemAudioSupported()
+      .then((supported) => {
+        if (isActive) {
+          setIsSupported(supported);
+        }
+      })
+      .catch(() => {
+        if (isActive) {
+          setIsSupported(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
   }, [platform]);
 
   const startRecording = useCallback(async () => {

--- a/app/src/platform/types.ts
+++ b/app/src/platform/types.ts
@@ -42,7 +42,7 @@ export interface AudioDevice {
 }
 
 export interface PlatformAudio {
-  isSystemAudioSupported(): boolean;
+  isSystemAudioSupported(): Promise<boolean>;
   startSystemAudioCapture(maxDurationSecs: number): Promise<void>;
   stopSystemAudioCapture(): Promise<Blob>;
   listOutputDevices(): Promise<AudioDevice[]>;

--- a/tauri/src-tauri/build.rs
+++ b/tauri/src-tauri/build.rs
@@ -5,6 +5,10 @@ fn main() {
     // Link Swift runtime libraries for screencapturekit crate
     #[cfg(target_os = "macos")]
     {
+        // ScreenCaptureKit does not exist on macOS 11, so weak-link it to
+        // allow the app to launch and gate usage at runtime instead.
+        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
+
         // Add Swift runtime library paths to RPATH
         println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
         println!("cargo:rustc-link-arg=-L/usr/lib/swift");

--- a/tauri/src-tauri/src/audio_capture/macos.rs
+++ b/tauri/src-tauri/src/audio_capture/macos.rs
@@ -13,6 +13,7 @@ use screencapturekit::{
     },
 };
 use std::io::Cursor;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
@@ -20,6 +21,10 @@ pub async fn start_capture(
     state: &AudioCaptureState,
     max_duration_secs: u32,
 ) -> Result<(), String> {
+    if !is_supported() {
+        return Err("System audio capture requires macOS 12.3 or newer.".to_string());
+    }
+
     // Reset previous samples
     state.reset();
 
@@ -144,17 +149,22 @@ pub async fn stop_capture(state: &AudioCaptureState) -> Result<String, String> {
 }
 
 pub fn is_supported() -> bool {
-    // ScreenCaptureKit requires macOS 12.3+
-    // Check if we're on a supported version
-    #[cfg(target_os = "macos")]
-    {
-        // Basic check - ScreenCaptureKit should be available on macOS 12.3+
-        true
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        false
-    }
+    macos_version_at_least(12, 3)
+}
+
+fn macos_version_at_least(required_major: u64, required_minor: u64) -> bool {
+    let output = match Command::new("sw_vers").arg("-productVersion").output() {
+        Ok(output) if output.status.success() => output,
+        _ => return false,
+    };
+
+    let version = String::from_utf8_lossy(&output.stdout);
+    let mut parts = version.trim().split('.');
+
+    let major = parts.next().and_then(|part| part.parse::<u64>().ok()).unwrap_or(0);
+    let minor = parts.next().and_then(|part| part.parse::<u64>().ok()).unwrap_or(0);
+
+    major > required_major || (major == required_major && minor >= required_minor)
 }
 
 fn extract_audio_samples(sample_buffer: CMSampleBuffer) -> Result<Vec<f32>, String> {

--- a/tauri/src/platform/audio.ts
+++ b/tauri/src/platform/audio.ts
@@ -2,9 +2,8 @@ import { invoke } from '@tauri-apps/api/core';
 import type { PlatformAudio, AudioDevice } from '@/platform/types';
 
 export const tauriAudio: PlatformAudio = {
-  isSystemAudioSupported(): boolean {
-    // This will be checked dynamically via invoke
-    return true; // Tauri supports it, but actual support depends on platform
+  async isSystemAudioSupported(): Promise<boolean> {
+    return await invoke<boolean>('is_system_audio_supported');
   },
 
   async startSystemAudioCapture(maxDurationSecs: number): Promise<void> {

--- a/web/src/platform/audio.ts
+++ b/web/src/platform/audio.ts
@@ -1,7 +1,7 @@
 import type { PlatformAudio, AudioDevice } from '@/platform/types';
 
 export const webAudio: PlatformAudio = {
-  isSystemAudioSupported(): boolean {
+  async isSystemAudioSupported(): Promise<boolean> {
     return false; // System audio capture not supported in web
   },
 


### PR DESCRIPTION
## Summary
- weak-link ScreenCaptureKit so the macOS app can launch on systems where the framework is unavailable
- gate macOS system audio capture behind a real 12.3+ version check and return a clean unsupported error on older releases
- query backend support from the frontend so unsupported systems do not advertise system audio capture

Closes #391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system audio capture compatibility detection with enhanced runtime platform validation
  * System audio capture now requires macOS 12.3 or newer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->