### PR TITLE
fix: add asyncio.Lock to prevent concurrent CUDA downloads

### DIFF
--- a/backend/services/cuda.py
+++ b/backend/services/cuda.py
@@ -248,6 +248,9 @@ async def download_cuda_binary(version: Optional[str] = None):
     Args:
         version: Version tag (e.g. "v0.3.0"). Defaults to current app version.
     """
+    if _download_lock.locked():
+        logger.info("CUDA download already in progress, skipping duplicate request")
+        return
     async with _download_lock:
         await _download_cuda_binary_locked(version)
 

--- a/backend/services/cuda.py
+++ b/backend/services/cuda.py
@@ -11,6 +11,7 @@ Both archives are extracted into {data_dir}/backends/cuda/ which forms the
 complete PyInstaller --onedir directory structure that torch expects.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -33,6 +34,12 @@ PROGRESS_KEY = "cuda-backend"
 # The current expected CUDA libs version.  Bump this when we change the
 # CUDA toolkit version or torch's CUDA dependency changes (e.g. cu126 -> cu128).
 CUDA_LIBS_VERSION = "cu128-v1"
+
+# Prevents concurrent download_cuda_binary() calls from racing on the same
+# temp file.  The auto-update background task and the manual HTTP endpoint
+# can both invoke download_cuda_binary(); without this lock the progress-
+# manager status check is a TOCTOU race.
+_download_lock = asyncio.Lock()
 
 
 def get_backends_dir() -> Path:
@@ -241,6 +248,12 @@ async def download_cuda_binary(version: Optional[str] = None):
     Args:
         version: Version tag (e.g. "v0.3.0"). Defaults to current app version.
     """
+    async with _download_lock:
+        await _download_cuda_binary_locked(version)
+
+
+async def _download_cuda_binary_locked(version: Optional[str] = None):
+    """Inner implementation of download_cuda_binary, called under _download_lock."""
     import httpx
 
     if version is None:


### PR DESCRIPTION
## Summary

- Add a module-level `asyncio.Lock` in `backend/services/cuda.py` to prevent concurrent calls to `download_cuda_binary()` from racing on the same temp file

## Problem

The startup auto-update task (`check_and_update_cuda_binary()`, fired via `create_background_task` in `app.py`) and the manual download endpoint (`POST /backend/download-cuda`) can both invoke `download_cuda_binary()` concurrently.

The manual endpoint has two guards:
1. Check if the binary already exists on disk (`get_cuda_binary_path()`)
2. Check if the progress manager reports `status == "downloading"`

Both guards are TOCTOU (time-of-check/time-of-use) races. The auto-update path performs several synchronous checks (`_needs_server_download`, `_needs_cuda_libs_download`, version introspection via subprocess) before it ever calls `progress.update_progress()` with `status="downloading"`. Until that first status update fires, Guard 2 sees `None` and grants a second concurrent download.

**Race window:**
```
startup:  check_and_update → _needs_server_download()=True → ...
                                                  |
                                         [asyncio yields here]
                                                  |
HTTP:     POST /backend/download-cuda arrives during this gap
          guard: get_progress("cuda-backend") → None (not set yet)
          → starts its own download_cuda_binary()
                                                  |
startup:  resumes → also calls download_cuda_binary()
```

Both coroutines then write to the same deterministic temp file path (`.download-CUDA-server.tmp`), corrupting the download. The SHA-256 verification catches the corruption and aborts, but the error is silently logged with no user-visible feedback.

The most realistic trigger is a user clicking "Download CUDA" in the GPU settings immediately after a fresh install — exactly the intended UX flow.

## Changes

| File | Change |
|------|--------|
| `backend/services/cuda.py` | Added `asyncio.Lock` and wrapped `download_cuda_binary()` body in `async with _download_lock` |

The lock is module-level and acquired before any status checks or downloads begin, eliminating the TOCTOU window entirely.

## Verification

- `py_compile` passes on the modified file
- The lock is cooperative (`asyncio.Lock`, not `threading.Lock`) matching the existing async architecture
- Existing callers are unaffected — the public API `download_cuda_binary()` signature is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA binary download handling: concurrent requests are now serialized so automatic updates and manual requests no longer run duplicate downloads or overlapping extraction/progress checks, preventing conflicts and preserving consistent progress/state for shared temp/destination files. This reduces failed or partial downloads, duplicate progress indicators, and unexpected file corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->