### PR TITLE
fix: harden voice prompt cache loading and SPA path guard

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -135,7 +135,7 @@ def _mount_frontend(application: FastAPI) -> None:
     async def serve_spa(full_path: str):
         file_path = (frontend_dir / full_path).resolve()
         # Guard against path traversal — only serve files inside frontend_dir
-        if full_path and file_path.is_file() and str(file_path).startswith(str(frontend_dir)):
+        if full_path and file_path.is_file() and file_path.is_relative_to(frontend_dir):
             return FileResponse(file_path)
         return FileResponse(frontend_dir / "index.html", media_type="text/html")
 

--- a/backend/utils/cache.py
+++ b/backend/utils/cache.py
@@ -64,7 +64,7 @@ def get_cached_voice_prompt(
     cache_file = _get_cache_dir() / f"{cache_key}.prompt"
     if cache_file.exists():
         try:
-            prompt = torch.load(cache_file)
+            prompt = torch.load(cache_file, weights_only=True)
             _memory_cache[cache_key] = prompt
             return prompt
         except Exception:


### PR DESCRIPTION
## Summary

- Add `weights_only=True` to the `torch.load()` call in the voice prompt cache
- Replace `str.startswith()` with `Path.is_relative_to()` in the SPA catch-all route

## Changes

### 1. Voice prompt cache — `backend/utils/cache.py`

`get_cached_voice_prompt()` calls `torch.load(cache_file)` without `weights_only=True`. Since PyTorch 2.6 this triggers a `FutureWarning`, and the [PyTorch docs recommend](https://pytorch.org/docs/stable/generated/torch.load.html) explicitly opting in to the safe unpickler for all `torch.load()` calls.

The cached `.prompt` files contain dicts of tensors and basic Python types (strings, ints, floats), all of which are supported by the safe unpickler. No functional change is expected.

```python
# Before
prompt = torch.load(cache_file)

# After
prompt = torch.load(cache_file, weights_only=True)
```

### 2. SPA path guard — `backend/app.py`

The `serve_spa` catch-all route (active in Docker/web deployment when `frontend/` exists) guards against path traversal using:

```python
str(file_path).startswith(str(frontend_dir))
```

This string prefix comparison has a subtle flaw: if `frontend_dir` is `/app/frontend`, then a path like `/app/frontend_evil/secret` also passes the check because the string `"/app/frontend_evil"` starts with `"/app/frontend"`.

`Path.is_relative_to()` (Python 3.9+) correctly tests directory containment:

```python
# Before
str(file_path).startswith(str(frontend_dir))

# After
file_path.is_relative_to(frontend_dir)
```

Note: the existing `Path.resolve()` call already blocks `../` traversal. This fix addresses the narrower prefix-collision case.

## Verification

- `py_compile` passes on both modified files
- `torch.load(..., weights_only=True)` is compatible with dicts of tensors and scalars — the format used by the voice prompt cache
- `Path.is_relative_to()` is available in Python 3.9+, matching the project's Python 3.12 target (`backend/STYLE_GUIDE.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation logic for serving static web application files, ensuring more robust and semantically accurate file access control mechanisms throughout the application platform.
  * Enhanced safety protocols when reconstructing cached voice prompts from persistent disk storage, mitigating potential deserialization vulnerabilities and protecting the system against malformed or corrupted cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->