### PR TITLE
feat: add MiniMax TTS provider support

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -169,6 +169,7 @@ TTS_ENGINES = {
     "chatterbox_turbo": "Chatterbox Turbo",
     "tada": "TADA",
     "kokoro": "Kokoro",
+    "minimax": "MiniMax TTS",
 }
 
 
@@ -421,6 +422,13 @@ async def ensure_model_cached_or_raise(engine: str, model_size: str = "default")
                 status_code=400,
                 detail=f"Model {model_size} is not downloaded yet. Use /generate to trigger a download.",
             )
+    elif engine == "minimax":
+        # MiniMax is a cloud API — check API key instead of local cache
+        if not backend._is_model_cached():
+            raise HTTPException(
+                status_code=400,
+                detail="MINIMAX_API_KEY is not configured. Set it in your environment or ~/.env.local.",
+            )
     else:
         if not backend._is_model_cached():
             display = cfg.display_name if cfg else engine
@@ -575,6 +583,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 
             backend = QwenCustomVoiceBackend()
+        elif engine == "minimax":
+            from .minimax_backend import MiniMaxTTSBackend
+
+            backend = MiniMaxTTSBackend()
         else:
             raise ValueError(f"Unknown TTS engine: {engine}. Supported: {list(TTS_ENGINES.keys())}")
 

--- a/backend/backends/minimax_backend.py
+++ b/backend/backends/minimax_backend.py
@@ -1,0 +1,312 @@
+"""
+MiniMax TTS backend implementation.
+
+Uses the MiniMax Text-to-Audio (T2A) cloud API to generate speech.
+Unlike other backends, this does not download a local model — it sends
+requests to https://api.minimax.io/v1/t2a_v2 and streams back PCM audio
+encoded as hex in SSE events.  PCM (signed 16-bit LE) is decoded directly
+to numpy float32 without any codec dependency.
+
+Requirements:
+  - MINIMAX_API_KEY environment variable (or ~/.env.local)
+  - httpx (already in requirements.txt)
+
+Models:
+  - speech-2.8-hd  (default, highest quality)
+  - speech-2.8-turbo  (faster)
+
+Voice IDs are preset MiniMax system voices — voice cloning is not supported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+MINIMAX_TTS_BASE_URL = "https://api.minimax.io"
+MINIMAX_TTS_ENDPOINT = "/v1/t2a_v2"
+MINIMAX_TTS_SAMPLE_RATE = 32000
+MINIMAX_TTS_DEFAULT_MODEL = "speech-2.8-hd"
+MINIMAX_TTS_DEFAULT_VOICE = "English_Graceful_Lady"
+
+# Available MiniMax system voice IDs
+MINIMAX_VOICES: list[tuple[str, str, str]] = [
+    # (voice_id, display_name, language)
+    ("English_Graceful_Lady", "Graceful Lady", "en"),
+    ("English_Insightful_Speaker", "Insightful Speaker", "en"),
+    ("English_radiant_girl", "Radiant Girl", "en"),
+    ("English_Persuasive_Man", "Persuasive Man", "en"),
+    ("English_Lucky_Robot", "Lucky Robot", "en"),
+    ("English_expressive_narrator", "Expressive Narrator", "en"),
+    ("Chinese_Gentle_and_Clear", "Gentle and Clear", "zh"),
+    ("Chinese_Energetic_Boy", "Energetic Boy", "zh"),
+    ("Chinese_Elegant_Lady", "Elegant Lady", "zh"),
+    ("Chinese_Intellectual_Female", "Intellectual Female", "zh"),
+    ("Chinese_Magnetic_Male", "Magnetic Male", "zh"),
+]
+
+# Available TTS model IDs
+MINIMAX_TTS_MODELS = [
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+]
+
+
+def _load_api_key() -> Optional[str]:
+    """Load MINIMAX_API_KEY from environment or ~/.env.local."""
+    key = os.environ.get("MINIMAX_API_KEY")
+    if key:
+        return key
+
+    env_local = os.path.expanduser("~/.env.local")
+    if os.path.exists(env_local):
+        try:
+            with open(env_local) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("MINIMAX_API_KEY="):
+                        val = line[len("MINIMAX_API_KEY="):].strip().strip("\"'")
+                        if val:
+                            return val
+        except OSError:
+            pass
+
+    return None
+
+
+def _pcm_bytes_to_numpy(pcm_bytes: bytes, sample_rate: int) -> tuple[np.ndarray, int]:
+    """
+    Convert raw PCM bytes (signed 16-bit little-endian) to float32 numpy array.
+
+    MiniMax streams PCM audio as hex-encoded signed 16-bit LE samples.
+    We convert directly to float32 in [-1.0, 1.0] without any codec dependency.
+    """
+    if not pcm_bytes:
+        return np.zeros(sample_rate, dtype=np.float32), sample_rate
+
+    # int16 LE → float32
+    audio_int16 = np.frombuffer(pcm_bytes, dtype="<i2")
+    audio_float32 = audio_int16.astype(np.float32) / 32768.0
+    return audio_float32, sample_rate
+
+
+class MiniMaxTTSBackend:
+    """
+    MiniMax cloud TTS backend.
+
+    This backend is always "loaded" — there is no local model to download.
+    ``load_model`` is a no-op; ``is_loaded`` returns True whenever the
+    API key is available.
+    """
+
+    def __init__(self) -> None:
+        self._api_key: Optional[str] = None
+        self.model_size = "default"
+
+    # ── Protocol helpers ─────────────────────────────────────────────────────
+
+    def is_loaded(self) -> bool:
+        """Return True if the API key is configured."""
+        if self._api_key is None:
+            self._api_key = _load_api_key()
+        return bool(self._api_key)
+
+    def _get_model_path(self, model_size: str) -> str:
+        """MiniMax has no local model path — return the API endpoint."""
+        return MINIMAX_TTS_BASE_URL + MINIMAX_TTS_ENDPOINT
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        """For a cloud API 'cached' means the API key is present."""
+        return self.is_loaded()
+
+    def unload_model(self) -> None:
+        """No-op: nothing to unload for a cloud API backend."""
+
+    # ── Model loading ────────────────────────────────────────────────────────
+
+    async def load_model(self, model_size: str = "default") -> None:
+        """
+        Validate API key availability.
+
+        For a cloud API there is nothing to download, but we still check
+        that MINIMAX_API_KEY is set so the user gets an early, clear error
+        rather than a cryptic HTTP 401 later.
+        """
+        if self._api_key is None:
+            self._api_key = _load_api_key()
+        if not self._api_key:
+            raise RuntimeError(
+                "MINIMAX_API_KEY is not set. "
+                "Add it to your environment or to ~/.env.local."
+            )
+        logger.info("MiniMax TTS backend ready (cloud API, no local model)")
+
+    # ── Voice prompt API ─────────────────────────────────────────────────────
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> Tuple[dict, bool]:
+        """
+        MiniMax uses preset system voices, not user-provided reference audio.
+
+        When this method is called (e.g., for a cloned profile fallback) we
+        return the default voice.  In normal usage the voice prompt is built
+        by the profile service from preset_voice_id and never calls this.
+        """
+        return {
+            "voice_type": "preset",
+            "preset_engine": "minimax",
+            "preset_voice_id": MINIMAX_TTS_DEFAULT_VOICE,
+        }, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: List[str],
+        reference_texts: List[str],
+    ) -> Tuple[np.ndarray, str]:
+        """
+        Combine voice prompts — delegates to the shared audio utility.
+
+        MiniMax does not support voice cloning, so this is only called if
+        a cloned profile somehow reaches this backend.
+        """
+        from .base import combine_voice_prompts as _combine
+
+        return await _combine(audio_paths, reference_texts, sample_rate=MINIMAX_TTS_SAMPLE_RATE)
+
+    # ── Core generation ──────────────────────────────────────────────────────
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> Tuple[np.ndarray, int]:
+        """
+        Generate speech via the MiniMax TTS API.
+
+        The API returns audio as hex-encoded MP3 in SSE events.  We collect
+        all ``status=1`` chunks, concatenate them, and decode to numpy.
+
+        Args:
+            text: Text to synthesize (max 10,000 characters per request).
+            voice_prompt: Dict with ``preset_voice_id`` key.
+            language: ISO language code (informational; MiniMax handles it).
+            seed: Ignored — MiniMax API does not expose a seed parameter.
+            instruct: Ignored — not supported by the TTS API.
+
+        Returns:
+            Tuple of (audio_array float32, sample_rate).
+        """
+        await self.load_model()
+
+        voice_id = (
+            voice_prompt.get("preset_voice_id")
+            or MINIMAX_TTS_DEFAULT_VOICE
+        )
+        tts_model = voice_prompt.get("tts_model") or MINIMAX_TTS_DEFAULT_MODEL
+
+        mp3_bytes = await asyncio.to_thread(
+            self._generate_sync, text, voice_id, tts_model
+        )
+        audio, sr = await asyncio.to_thread(_pcm_bytes_to_numpy, mp3_bytes, MINIMAX_TTS_SAMPLE_RATE)
+        return audio, sr
+
+    def _generate_sync(self, text: str, voice_id: str, model: str) -> bytes:
+        """Blocking HTTP call to the MiniMax TTS API."""
+        import httpx
+
+        api_key = self._api_key or _load_api_key()
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not configured.")
+
+        payload = {
+            "model": model,
+            "text": text,
+            "stream": True,
+            "voice_setting": {
+                "voice_id": voice_id,
+                "speed": 1,
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": MINIMAX_TTS_SAMPLE_RATE,
+                "format": "pcm",
+                "channel": 1,
+            },
+            "stream_options": {
+                "exclude_aggregated_audio": True,
+            },
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        url = MINIMAX_TTS_BASE_URL + MINIMAX_TTS_ENDPOINT
+        audio_hex_parts: list[str] = []
+
+        with httpx.Client(timeout=60.0) as client:
+            with client.stream("POST", url, json=payload, headers=headers) as resp:
+                resp.raise_for_status()
+
+                buffer = ""
+                for chunk in resp.iter_text():
+                    buffer += chunk
+                    lines = buffer.split("\n")
+                    buffer = lines.pop()  # keep incomplete last line
+
+                    for line in lines:
+                        line = line.strip()
+                        if not line.startswith("data:"):
+                            continue
+                        json_str = line[len("data:"):].strip()
+                        if not json_str or json_str == "[DONE]":
+                            continue
+
+                        import json
+
+                        try:
+                            event = json.loads(json_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        # status=1: audio chunk; status=2: aggregated (we skip it)
+                        event_data = event.get("data", {})
+                        status = event_data.get("status")
+                        audio_hex = event_data.get("audio", "")
+
+                        if status == 1 and audio_hex:
+                            audio_hex_parts.append(audio_hex)
+
+                        # Surface API-level errors
+                        base_resp = event.get("base_resp", {})
+                        status_code = base_resp.get("status_code", 0)
+                        if status_code != 0:
+                            msg = base_resp.get("status_msg", "Unknown error")
+                            raise RuntimeError(
+                                f"MiniMax TTS API error {status_code}: {msg}"
+                            )
+
+        if not audio_hex_parts:
+            raise RuntimeError(
+                "MiniMax TTS API returned no audio data. "
+                "Check your MINIMAX_API_KEY and request parameters."
+            )
+
+        pcm_bytes = bytes.fromhex("".join(audio_hex_parts))
+        logger.debug("MiniMax TTS: received %d bytes of PCM audio", len(pcm_bytes))
+        return pcm_bytes

--- a/backend/models.py
+++ b/backend/models.py
@@ -78,7 +78,7 @@ class GenerationRequest(BaseModel):
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|minimax)$")
     max_chunk_chars: int = Field(
         default=800, ge=100, le=5000, description="Max characters per chunk for long text splitting"
     )

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -72,6 +72,11 @@ def _get_preset_voice_ids(engine: str) -> set[str]:
 
         return {voice_id for voice_id, _name, _gender, _lang, _desc in QWEN_CUSTOM_VOICES}
 
+    if engine == "minimax":
+        from ..backends.minimax_backend import MINIMAX_VOICES
+
+        return {voice_id for voice_id, _name, _lang in MINIMAX_VOICES}
+
     return set()
 
 

--- a/backend/tests/test_minimax_backend.py
+++ b/backend/tests/test_minimax_backend.py
@@ -1,0 +1,404 @@
+"""
+Unit tests for the MiniMax TTS backend.
+
+These tests exercise backend logic without making real HTTP calls.
+Integration tests (skipped when MINIMAX_API_KEY is absent) call the
+live MiniMax API.
+
+Usage:
+    cd backend
+    python -m pytest tests/test_minimax_backend.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sse_response(chunks: list[str]) -> list[bytes]:
+    """Build raw SSE bytes from a list of hex audio strings."""
+    import json
+
+    lines: list[bytes] = []
+    for i, hex_chunk in enumerate(chunks):
+        event = {"data": {"status": 1, "audio": hex_chunk}, "base_resp": {"status_code": 0, "status_msg": "success"}}
+        lines.append(f"data: {json.dumps(event)}\n\n".encode())
+    # final [DONE]
+    lines.append(b"data: [DONE]\n\n")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Module-level imports (no heavy ML deps needed)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_can_be_imported():
+    """The backend module must import without heavy ML dependencies."""
+    from backend.backends.minimax_backend import MiniMaxTTSBackend  # noqa: F401
+
+    assert MiniMaxTTSBackend is not None
+
+
+def test_constants_are_sane():
+    """Check that public constants have expected values."""
+    from backend.backends.minimax_backend import (
+        MINIMAX_TTS_BASE_URL,
+        MINIMAX_TTS_DEFAULT_MODEL,
+        MINIMAX_TTS_DEFAULT_VOICE,
+        MINIMAX_TTS_SAMPLE_RATE,
+        MINIMAX_VOICES,
+        MINIMAX_TTS_MODELS,
+    )
+
+    assert MINIMAX_TTS_BASE_URL.startswith("https://api.minimax.io")
+    assert MINIMAX_TTS_DEFAULT_MODEL in MINIMAX_TTS_MODELS
+    assert MINIMAX_TTS_DEFAULT_VOICE in {v[0] for v in MINIMAX_VOICES}
+    assert MINIMAX_TTS_SAMPLE_RATE > 0
+    assert len(MINIMAX_VOICES) >= 6
+    assert "speech-2.8-hd" in MINIMAX_TTS_MODELS
+    assert "speech-2.8-turbo" in MINIMAX_TTS_MODELS
+
+
+def test_pcm_decode():
+    """PCM bytes decode correctly to float32 numpy arrays."""
+    from backend.backends.minimax_backend import _pcm_bytes_to_numpy, MINIMAX_TTS_SAMPLE_RATE
+
+    # Two samples: 0x7FFF (max positive) and 0x8001 (near max negative)
+    import struct
+
+    pcm_bytes = struct.pack("<h", 32767) + struct.pack("<h", -32767)
+    audio, sr = _pcm_bytes_to_numpy(pcm_bytes, MINIMAX_TTS_SAMPLE_RATE)
+
+    assert audio.dtype == np.float32
+    assert len(audio) == 2
+    assert sr == MINIMAX_TTS_SAMPLE_RATE
+    assert abs(audio[0] - (32767 / 32768.0)) < 1e-4
+    assert abs(audio[1] - (-32767 / 32768.0)) < 1e-4
+
+
+def test_pcm_decode_empty_returns_silence():
+    from backend.backends.minimax_backend import _pcm_bytes_to_numpy, MINIMAX_TTS_SAMPLE_RATE
+
+    audio, sr = _pcm_bytes_to_numpy(b"", MINIMAX_TTS_SAMPLE_RATE)
+    assert len(audio) == MINIMAX_TTS_SAMPLE_RATE  # 1 second of silence
+    assert (audio == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# _load_api_key
+# ---------------------------------------------------------------------------
+
+
+def test_load_api_key_from_env():
+    from backend.backends.minimax_backend import _load_api_key
+
+    with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-from-env"}):
+        assert _load_api_key() == "test-key-from-env"
+
+
+def test_load_api_key_missing_returns_none(tmp_path):
+    from backend.backends.minimax_backend import _load_api_key
+
+    with patch.dict(os.environ, {}, clear=True):
+        # Patch os.path.expanduser to point to a non-existent file
+        with patch("backend.backends.minimax_backend.os.path.expanduser", return_value=str(tmp_path / "nonexistent.env")):
+            result = _load_api_key()
+    assert result is None
+
+
+def test_load_api_key_from_env_local(tmp_path):
+    from backend.backends.minimax_backend import _load_api_key
+
+    env_local = tmp_path / ".env.local"
+    env_local.write_text("MINIMAX_API_KEY=key-from-file\n")
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("backend.backends.minimax_backend.os.path.expanduser", return_value=str(env_local)):
+            with patch("backend.backends.minimax_backend.os.path.exists", return_value=True):
+                result = _load_api_key()
+    assert result == "key-from-file"
+
+
+# ---------------------------------------------------------------------------
+# MiniMaxTTSBackend — structural / non-network tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxTTSBackendBasics:
+    def setup_method(self):
+        from backend.backends.minimax_backend import MiniMaxTTSBackend
+
+        self.backend = MiniMaxTTSBackend()
+
+    def test_is_loaded_false_without_key(self):
+        with patch("backend.backends.minimax_backend._load_api_key", return_value=None):
+            self.backend._api_key = None
+            assert not self.backend.is_loaded()
+
+    def test_is_loaded_true_with_key(self):
+        with patch("backend.backends.minimax_backend._load_api_key", return_value="sk-test"):
+            self.backend._api_key = None
+            assert self.backend.is_loaded()
+
+    def test_unload_model_is_noop(self):
+        """unload_model must not raise."""
+        self.backend.unload_model()
+
+    def test_get_model_path_returns_endpoint(self):
+        path = self.backend._get_model_path("default")
+        assert "minimax.io" in path
+        assert "t2a_v2" in path
+
+    def test_is_model_cached_reflects_key_presence(self):
+        with patch.object(self.backend, "is_loaded", return_value=True):
+            assert self.backend._is_model_cached()
+        with patch.object(self.backend, "is_loaded", return_value=False):
+            assert not self.backend._is_model_cached()
+
+    @pytest.mark.asyncio
+    async def test_load_model_raises_without_key(self):
+        self.backend._api_key = None
+        with patch("backend.backends.minimax_backend._load_api_key", return_value=None):
+            with pytest.raises(RuntimeError, match="MINIMAX_API_KEY"):
+                await self.backend.load_model()
+
+    @pytest.mark.asyncio
+    async def test_load_model_succeeds_with_key(self):
+        self.backend._api_key = None
+        with patch("backend.backends.minimax_backend._load_api_key", return_value="sk-test"):
+            await self.backend.load_model()  # should not raise
+        assert self.backend._api_key == "sk-test"
+
+
+class TestMiniMaxVoicePrompt:
+    def setup_method(self):
+        from backend.backends.minimax_backend import MiniMaxTTSBackend
+
+        self.backend = MiniMaxTTSBackend()
+
+    @pytest.mark.asyncio
+    async def test_create_voice_prompt_returns_preset(self):
+        prompt, was_cached = await self.backend.create_voice_prompt("/dummy/path.wav", "hello")
+        assert prompt["voice_type"] == "preset"
+        assert prompt["preset_engine"] == "minimax"
+        assert "preset_voice_id" in prompt
+        assert not was_cached
+
+
+class TestMiniMaxGenerateSyncParsing:
+    """Test SSE parsing logic in _generate_sync via unit mocking."""
+
+    def _build_backend_with_key(self):
+        from backend.backends.minimax_backend import MiniMaxTTSBackend
+
+        b = MiniMaxTTSBackend()
+        b._api_key = "sk-test"
+        return b
+
+    def test_hex_audio_collected_from_sse(self):
+        import json
+
+        backend = self._build_backend_with_key()
+
+        # Build fake SSE events with known hex data (PCM bytes for 2 samples of silence)
+        # 4 bytes = 2 signed int16 samples at 0
+        hex1 = "00000000"
+        hex2 = "00000000"
+        events = [
+            {"data": {"status": 1, "audio": hex1}, "base_resp": {"status_code": 0}},
+            {"data": {"status": 1, "audio": hex2}, "base_resp": {"status_code": 0}},
+            # status=2 aggregated audio should be ignored when exclude_aggregated_audio is set
+            {"data": {"status": 2, "audio": "deadbeef"}, "base_resp": {"status_code": 0}},
+        ]
+        sse_text = "".join(f"data: {json.dumps(e)}\n\n" for e in events)
+
+        # Mock the httpx streaming response
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.iter_text.return_value = iter([sse_text])
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = lambda s: mock_resp
+        mock_stream.__exit__ = MagicMock(return_value=False)
+
+        # We expect the returned bytes to be hex1 + hex2 only (not the aggregated audio)
+        expected_bytes = bytes.fromhex(hex1 + hex2)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__ = lambda s: mock_client
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.stream.return_value = mock_stream
+
+            result = backend._generate_sync("hello", "English_Graceful_Lady", "speech-2.8-hd")
+
+        assert result == expected_bytes
+
+    def test_api_error_status_code_raises(self):
+        import json
+
+        backend = self._build_backend_with_key()
+
+        error_event = {"data": {}, "base_resp": {"status_code": 1004, "status_msg": "Auth failed"}}
+        sse_text = f"data: {json.dumps(error_event)}\n\n"
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.iter_text.return_value = iter([sse_text])
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = lambda s: mock_resp
+        mock_stream.__exit__ = MagicMock(return_value=False)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__ = lambda s: mock_client
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.stream.return_value = mock_stream
+
+            with pytest.raises(RuntimeError, match="1004"):
+                backend._generate_sync("hello", "English_Graceful_Lady", "speech-2.8-hd")
+
+    def test_empty_response_raises(self):
+        import json
+
+        backend = self._build_backend_with_key()
+
+        # SSE with no audio data (e.g., only [DONE])
+        sse_text = "data: [DONE]\n\n"
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.iter_text.return_value = iter([sse_text])
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = lambda s: mock_resp
+        mock_stream.__exit__ = MagicMock(return_value=False)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__ = lambda s: mock_client
+            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.stream.return_value = mock_stream
+
+            with pytest.raises(RuntimeError, match="no audio data"):
+                backend._generate_sync("hello", "English_Graceful_Lady", "speech-2.8-hd")
+
+
+# ---------------------------------------------------------------------------
+# Registration — engine registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_minimax_in_tts_engines():
+    from backend.backends import TTS_ENGINES
+
+    assert "minimax" in TTS_ENGINES
+
+
+def test_get_tts_backend_for_engine_minimax():
+    """get_tts_backend_for_engine('minimax') must return a MiniMaxTTSBackend."""
+    from backend.backends import get_tts_backend_for_engine, reset_backends
+    from backend.backends.minimax_backend import MiniMaxTTSBackend
+
+    reset_backends()
+    backend = get_tts_backend_for_engine("minimax")
+    assert isinstance(backend, MiniMaxTTSBackend)
+    reset_backends()
+
+
+# ---------------------------------------------------------------------------
+# Profile service — preset voice validation
+# ---------------------------------------------------------------------------
+
+
+def test_minimax_preset_voice_ids_registered():
+    from backend.services.profiles import _get_preset_voice_ids
+    from backend.backends.minimax_backend import MINIMAX_VOICES
+
+    ids = _get_preset_voice_ids("minimax")
+    assert len(ids) > 0
+    for voice_id, _name, _lang in MINIMAX_VOICES:
+        assert voice_id in ids
+
+
+def test_minimax_not_in_cloning_engines():
+    from backend.services.profiles import CLONING_ENGINES
+
+    assert "minimax" not in CLONING_ENGINES
+
+
+# ---------------------------------------------------------------------------
+# GenerationRequest model — engine field validation
+# ---------------------------------------------------------------------------
+
+
+def test_generation_request_accepts_minimax():
+    from backend.models import GenerationRequest
+
+    req = GenerationRequest(profile_id="abc", text="hello", engine="minimax")
+    assert req.engine == "minimax"
+
+
+def test_generation_request_rejects_unknown_engine():
+    from backend.models import GenerationRequest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GenerationRequest(profile_id="abc", text="hello", engine="openai-tts")
+
+
+# ---------------------------------------------------------------------------
+# Integration test (real API call — skipped without key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_integration_generate_speech():
+    """
+    Live integration test: call MiniMax TTS API and verify we get audio back.
+
+    Skipped automatically when MINIMAX_API_KEY is not configured.
+    """
+    from backend.backends.minimax_backend import MiniMaxTTSBackend, _load_api_key, _pcm_bytes_to_numpy, MINIMAX_TTS_SAMPLE_RATE
+
+    api_key = _load_api_key()
+    if not api_key:
+        pytest.skip("MINIMAX_API_KEY not configured")
+
+    backend = MiniMaxTTSBackend()
+    await backend.load_model()
+
+    voice_prompt = {
+        "voice_type": "preset",
+        "preset_engine": "minimax",
+        "preset_voice_id": "English_Graceful_Lady",
+    }
+
+    audio, sr = await backend.generate(
+        text="Hello, this is a MiniMax TTS integration test.",
+        voice_prompt=voice_prompt,
+    )
+
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    assert len(audio) > 0
+    assert sr == MINIMAX_TTS_SAMPLE_RATE


### PR DESCRIPTION
## Summary

This PR adds MiniMax TTS (Text-to-Audio) as a new voice generation backend for Voicebox.

### What's added

- **`backend/backends/minimax_backend.py`** — Cloud TTS backend that calls the [MiniMax T2A v2 API](https://platform.minimax.io/docs/api-reference/speech-t2a-http). Streams PCM audio via SSE, decodes hex-encoded chunks directly to NumPy float32 — no local model download required.
- **`backend/backends/__init__.py`** — Registers `minimax` in `TTS_ENGINES` and `get_tts_backend_for_engine`.
- **`backend/models.py`** — Adds `minimax` to the `GenerationRequest.engine` validation pattern.
- **`backend/services/profiles.py`** — Exposes MiniMax preset voice IDs for profile validation.
- **`backend/tests/test_minimax_backend.py`** — 25 unit tests covering API key loading, SSE parsing, error handling, PCM decoding, engine registration, and profile service integration. Includes a live integration test (auto-skipped when `MINIMAX_API_KEY` is absent).

### How it works

MiniMax is a **cloud API backend** (no local model download). Users create a *preset* voice profile using one of the MiniMax system voices, then generate speech via the Voicebox UI or API — the backend streams PCM audio from `api.minimax.io` and returns it as a NumPy array at 32 kHz.

**Environment variable**: `MINIMAX_API_KEY` (set in your environment or `~/.env.local`).

**Available models**: `speech-2.8-hd` (default, highest quality), `speech-2.8-turbo` (faster).

**Available voices** (6 built-in, English + Chinese):
- `English_Graceful_Lady`, `English_Insightful_Speaker`, `English_radiant_girl`
- `English_Persuasive_Man`, `English_Lucky_Robot`, `English_expressive_narrator`
- `Chinese_Gentle_and_Clear`, `Chinese_Energetic_Boy`, `Chinese_Elegant_Lady`, and more

### Key design decisions

- Requests **PCM format** (16-bit LE) instead of MP3 so audio decodes with a single NumPy call — no codec dependency.
- `load_model()` validates the API key on first call and is otherwise a no-op (no download progress tracking needed).
- MiniMax does **not** support voice cloning — it is a preset-only engine and is intentionally excluded from `CLONING_ENGINES`.

### API documentation

- TTS: https://platform.minimax.io/docs/api-reference/speech-t2a-http

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax TTS engine support, enabling text-to-audio speech synthesis using MiniMax's cloud service with preset voice options. Requires API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->