### PR TITLE
fix: warn user when no models to migrate during storage change

### DIFF
--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -977,7 +977,19 @@ export function ModelManagement() {
                 });
                 try {
                   // Start the migration (background task)
-                  await apiClient.migrateModels(newDir);
+                  const migrationResult = await apiClient.migrateModels(newDir);
+
+                  // If no models to migrate, warn user and skip the change
+                  if (migrationResult.moved === 0) {
+                    setMigrating(false);
+                    setMigrationProgress(null);
+                    toast({
+                      title: 'No models to migrate',
+                      description: 'Download at least one model before changing the storage location.',
+                    });
+                    setPendingMigrateDir(null);
+                    return;
+                  }
 
                   // Connect to SSE for progress
                   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary

When user attempts to change model storage location with no models downloaded, the migration API returns `moved: 0` early. Previously the UI would still call `setCustomModelsDir()` and restart the server, causing unexpected behavior (hang/connection lost) as described in issue #426.

This fix checks `migrationResult.moved === 0` and shows a helpful toast message instructing the user to download at least one model before changing the storage location, instead of proceeding with a no-op storage change.

## Test plan

1. Open Voicebox with no models downloaded
2. Attempt to change model storage location via the UI
3. Confirm a toast appears: 'No models to migrate' with description 'Download at least one model before changing the storage location.'
4. Confirm storage location remains unchanged and server is not restarted

## Related issue

Fixes #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the model migration process to exit early when no models are available for relocation, skipping unnecessary processing steps. Users now receive a clear notification when a migration completes without moving any models, improving the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->