### PR TITLE
fix(paths): strip legacy "data/" prefix when resolving stored paths

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -89,6 +89,14 @@ def resolve_storage_path(path: str | Path | None) -> Path | None:
 
         return stored_path
 
+    # 0.3.0 records sometimes stored relative paths with the data-dir name
+    # baked in (e.g. "data/profiles/..."). Joining those directly with
+    # _data_dir produces a spurious "<data_dir>/data/profiles/..." nest.
+    if stored_path.parts and stored_path.parts[0] == "data":
+        stored_path = (
+            Path(*stored_path.parts[1:]) if len(stored_path.parts) > 1 else Path()
+        )
+
     return (_data_dir / stored_path).resolve()
 
 


### PR DESCRIPTION
## Summary
Fixes 0.3.0 → 0.4.0 upgrade bug where old media paths fail to load with `FileNotFoundError: '<data_dir>/data/profiles/…'` (note the double `data\data`) and 404s on `GET /audio/<id>`.

## Root cause
0.3.0 sometimes stored relative media paths with the data-dir name baked in (e.g. `data/profiles/<uuid>/sample.wav`). `resolve_storage_path` joined those directly with `_data_dir`, producing `<data_dir>/data/profiles/…` — a spurious double nest.

The 0.4.0 startup migration (`_normalize_storage_paths`) didn't catch it because:
1. `resolve_storage_path("data/profiles/…")` produced the buggy `<data_dir>/data/profiles/…`
2. `to_storage_path(that)` found `data` at the first (legitimate) index and returned `data/profiles/…`
3. `normalized == path_val` → row skipped → bad path stays in DB

## Fix
Strip a leading `data/` component from relative stored paths in `resolve_storage_path` before joining with `_data_dir`. This:
- Unblocks runtime reads immediately
- Lets `_normalize_storage_paths` actually rewrite the affected rows on next startup (since `resolve_storage_path` now returns a real path, `to_storage_path` produces the correct stripped form, and the DB row gets rewritten)

No manual migration steps needed — affected users just restart after upgrading to a build with this fix.

## Test plan
- [ ] Fresh install → generate clip → confirm no regression (path stored as `profiles/<uuid>/…` without `data/` prefix, reads succeed)
- [ ] Simulated upgrade: insert DB row with `data/profiles/<uuid>/sample.wav` stored, restart server, confirm `_normalize_storage_paths` rewrites it to `profiles/<uuid>/sample.wav` and audio loads
- [ ] Confirm `GET /audio/<id>` resolves for legacy generations after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core path-resolution used by migrations and audio file serving; a small logic change could affect how existing DB paths map to files if any valid relative paths intentionally start with `data/`.
> 
> **Overview**
> Fixes resolution of DB-stored *relative* media paths that were persisted with a legacy leading `data/` prefix (e.g. `data/profiles/...`), preventing them from being joined into an incorrect `<data_dir>/data/...` nested path.
> 
> This update in `resolve_storage_path` improves compatibility for upgraded installs and enables the existing normalization/migration logic to rewrite affected rows to the corrected relative form on startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da05acdee535366b4e629c322b1c6e9707838196. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected storage path resolution logic to properly handle relative paths beginning with "data", eliminating unintended nested directory structures that were previously created during path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->