### PR TITLE
fix: delete version rows and files in delete_generations_by_profile

### DIFF
--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -282,6 +282,10 @@ async def delete_generations_by_profile(
     
     count = 0
     for generation in generations:
+        # Delete associated version files and rows first
+        from . import versions as versions_mod
+        versions_mod.delete_versions_for_generation(generation.id, db)
+
         # Delete audio file
         audio_path = config.resolve_storage_path(generation.audio_path)
         if audio_path is not None and audio_path.exists():


### PR DESCRIPTION
## Summary

`delete_generations_by_profile` was missing version cleanup, causing orphaned version database rows and audio files when a voice profile is deleted.

## Changes

Added a call to `versions_mod.delete_versions_for_generation(generation.id, db)` inside the loop in `delete_generations_by_profile`, matching the cleanup pattern already used by `delete_failed_generations`.

Closes #446

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the deletion of generations to properly remove all associated version files and related records when deleting multiple generations from a user profile. This enhancement ensures complete data cleanup and removal, prevents orphaned files from being left behind, and provides consistent deletion behavior across all generation removal operations and workflows in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->