### PR TITLE
docs: clarify paralinguistic tag support in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ Five TTS engines with different strengths, switchable per-generation:
 
 ### Emotions & Paralinguistic Tags
 
-Type `/` in the text input to insert expressive tags that the model synthesizes inline with speech (Chatterbox Turbo):
+Only **Chatterbox Turbo** interprets paralinguistic tags like `[laugh]` and
+`[sigh]`. Qwen3-TTS, LuxTTS, Chatterbox Multilingual, and HumeAI TADA read them
+literally as text.
+
+With **Chatterbox Turbo** selected, type `/` in the text input to open the tag
+inserter and add expressive tags inline with speech:
 
 `[laugh]` `[chuckle]` `[gasp]` `[cough]` `[sigh]` `[groan]` `[sniff]` `[shush]` `[clear throat]`
 

--- a/docs/content/docs/overview/quick-start.mdx
+++ b/docs/content/docs/overview/quick-start.mdx
@@ -69,6 +69,16 @@ Now let's use your new voice profile to generate speech.
     ```
     Hello! This is my first voice generation with Voicebox.
     ```
+
+    <Callout type="info">
+      Paralinguistic tags like `[laugh]`, `[sigh]`, and `[gasp]` only work with
+      **Chatterbox Turbo**. Qwen3-TTS, LuxTTS, Chatterbox Multilingual, and
+      HumeAI TADA will read those tags literally instead of turning them into
+      expressive sounds.
+    </Callout>
+
+    To insert supported tags, select **Chatterbox Turbo** and type `/` in the
+    text input to open the tag inserter.
   </Step>
 
   <Step title="Generate">


### PR DESCRIPTION
## Summary
- clarify in the Quick Start guide that paralinguistic tags only work with Chatterbox Turbo
- explain that other engines read those tags literally
- mirror the same wording in the README tag section

Closes #442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that paralinguistic tags (e.g., `[laugh]`, `[sigh]`) are supported only with Chatterbox Turbo; other TTS engines treat them as literal text.
  * Added instructions for using the tag inserter in Chatterbox Turbo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->