### PR TITLE
docs: clarify paralinguistic tag engine support

### DIFF
--- a/docs/content/docs/overview/quick-start.mdx
+++ b/docs/content/docs/overview/quick-start.mdx
@@ -86,6 +86,14 @@ Now let's use your new voice profile to generate speech.
   </Step>
 </Steps>
 
+<Callout type="info">
+  **Paralinguistic tags are engine-specific.**
+
+  Tags like `[laugh]`, `[sigh]`, and `[gasp]` only work with **Chatterbox Turbo**. To insert them, select Chatterbox Turbo in the generator and type `/` in the text input to open the tag menu.
+
+  **Qwen3-TTS**, **LuxTTS**, **Chatterbox Multilingual**, and **HumeAI TADA** do not interpret these tags, so they may read them literally.
+</Callout>
+
 ## Step 3: Build a Story (Optional)
 
 The Stories Editor lets you create multi-voice narratives with a timeline-based interface.


### PR DESCRIPTION
## Summary
- add a Quick Start callout explaining that paralinguistic tags are engine-specific
- clarify that `/` opens the tag menu only for Chatterbox Turbo
- note that Qwen3-TTS, LuxTTS, Chatterbox Multilingual, and HumeAI TADA do not interpret these tags

Closes #442.

## Testing
- `git diff --check`
- `cd docs && bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Quick Start guide with details on paralinguistic tag support across text-to-speech engines, clarifying which platforms interpret tags like [laugh], [sigh], and [gasp], and how to access them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->