### PR TITLE
docs: define tier-1 and tier-2 platform support targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ Full API documentation available at `http://localhost:17493/docs`.
 
 ---
 
+## Support Policy (Tier 1 vs Tier 2)
+
+To reduce regression risk and set clear expectations, Voicebox uses support tiers.
+
+### Tier 1 (must-pass release targets)
+- macOS (Apple Silicon)
+- Windows + NVIDIA CUDA
+
+Tier 1 targets are expected to pass release validation before shipping.
+
+### Tier 2 (best-effort / community-supported)
+- Intel macOS
+- Linux CPU
+- AMD ROCm
+- Intel Arc / XPU
+- Docker deployments
+
+Tier 2 targets are important, but may receive delayed fixes when regressions are specific to niche hardware/runtime combinations.
+
+### Practical Guidance
+- If you are filing a bug on a Tier 2 target, include full environment details and logs.
+- CI/release gating should prioritize Tier 1 first.
+- Platform-specific docs should call out experimental paths explicitly.
 ## Roadmap
 
 | Feature                 | Description                                    |


### PR DESCRIPTION
## Summary
This PR adds an explicit platform support policy to reduce ambiguity about release expectations.

## What changed
- Added a new Support Policy (Tier 1 vs Tier 2) section to README.md.
- Defined:
  - Tier 1 (must-pass release targets)
  - Tier 2 (best-effort/community-supported targets)
- Added practical guidance for bug reports and CI/release prioritization.

## Why
Issue #420 asks for a formalized support matrix so users know what is guaranteed at release time versus best-effort.

## Notes
- This PR is docs-only and non-breaking.
- CI matrix changes can be handled in a follow-up implementation PR.

Closes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Support Policy section defining Tier 1 (officially supported) and Tier 2 (community-supported) environments with specific platform requirements.
  * Included practical guidance for reporting issues, CI/release prioritization, and recommended documentation practices across all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->