### PR TITLE
fix(api-client): declare moved + errors on migrateModels response type

### DIFF
--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -390,7 +390,9 @@ class ApiClient {
     return this.request<{ path: string }>('/models/cache-dir');
   }
 
-  async migrateModels(destination: string): Promise<{ source: string; destination: string }> {
+  async migrateModels(
+    destination: string,
+  ): Promise<{ source: string; destination: string; moved: number; errors: string[] }> {
     return this.request('/models/migrate', {
       method: 'POST',
       body: JSON.stringify({ destination }),


### PR DESCRIPTION
## Summary

Follow-up to #433. `ModelManagement.tsx` reads `migrationResult.moved` to decide whether to skip the storage-change flow, but `apiClient.migrateModels()` was typed as `Promise<{ source: string; destination: string }>` — so the check doesn't typecheck under the new frontend CI gate from #418.

The backend actually returns `{ moved: int, errors: list[str], source, destination }` (see `backend/routes/models.py:140, 168`). This widens the TS return type to match.

## Test plan

- [ ] \`bunx tsc -p app/tsconfig.json --noEmit\` passes
- [ ] \`bun run ci\` passes (after #418 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only widens the TypeScript return type for `apiClient.migrateModels()` to match the backend response and unblock frontend typechecks, without changing runtime behavior.
> 
> **Overview**
> Updates `apiClient.migrateModels()`’s TypeScript return type to include backend-provided `moved` and `errors` fields (in addition to `source`/`destination`), aligning the client contract with actual migration results consumed by the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5763a8abf5e028fdec18fa7f41955f357d7486a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration operations now return additional details, including the count of successfully moved items and a list of any errors encountered during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->