### PR TITLE
fix(build): pin transformers in MLX requirements to prevent 5.x upgrade

### DIFF
--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -3,3 +3,11 @@
 
 mlx>=0.30.0
 mlx-audio>=0.3.1
+
+# Restate the transformers cap from requirements.txt. mlx-audio depends on
+# `transformers` with no upper bound, so installing it after requirements.txt
+# lets pip upgrade transformers past 4.57.x (latest is 5.x), which breaks
+# qwen-custom-voice (`@check_model_inputs()` API change), tada-1b (dataclass
+# `mutable default` enforcement), and luxtts (Whisper init path) in the
+# frozen MLX bundle. Keep this constraint in sync with requirements.txt.
+transformers>=4.36.0,<=4.57.6


### PR DESCRIPTION
## Summary

The 0.4.1 Mac MLX build ships with **transformers 5.5.4** instead of the 4.57.x pinned in `requirements.txt`, which breaks three engines at model-load time:

- **qwen-custom-voice** — `TypeError: check_model_inputs() missing 1 required positional argument: 'func'`
- **tada-1b** — `ValueError: mutable default <class 'list'> for field strides is not allowed`
- **luxtts** — `AssertionError: Unexpected result type: <class 'int'>` in `torch._refs.normal_` during Whisper init

## Root cause

The release workflow installs deps in this order (`.github/workflows/release.yml:59-70`):

```sh
pip install -r backend/requirements.txt        # transformers>=4.36.0,<=4.57.6 → installs 4.57.6
pip install --no-deps chatterbox-tts
pip install --no-deps hume-tada
pip install -r backend/requirements-mlx.txt    # mlx-audio deps include `transformers` with no cap → upgrades to 5.5.4
```

`mlx-audio`'s `Requires` line lists `transformers` with no version constraint. When pip resolves `requirements-mlx.txt`, it sees a transitive `transformers` requirement and happily upgrades the already-installed 4.57.6 to the latest 5.5.4 — silently undoing the cap from `requirements.txt`.

Confirmed by inspecting the extracted PyInstaller bundle on a Mac install:
```
$ cat /var/folders/.../T/_MEI*/transformers/__init__.py | grep __version__
__version__ = "5.5.4"
```

vs. local dev venv (which works fine — all three engines load):
```
$ pip show transformers | head -2
Name: transformers
Version: 4.57.3
```

Windows CPU bundle is unaffected because `requirements-mlx.txt` is gated to MLX builds.

## Fix

Restate the same `transformers>=4.36.0,<=4.57.6` cap in `requirements-mlx.txt`. When pip re-resolves with this constraint visible, it leaves the existing 4.57.6 install in place instead of upgrading.

## Test plan

- [ ] Trigger release build (or run `pip install -r backend/requirements.txt && pip install -r backend/requirements-mlx.txt` in a clean venv) and confirm `pip show transformers` reports 4.57.x not 5.x
- [ ] Build Mac MLX binary, install, and verify qwen-custom-voice / tada-1b / luxtts all load and generate audio
- [ ] Other engines still work (kokoro, chatterbox-multilingual, qwen-tts MLX, etc.)

## Notes

- This is a **patch release candidate** for 0.4.2 — same root cause caused all three engine failures on Mac in 0.4.1
- PR #438's PyInstaller patches are unrelated and remain correct
- Long-term we should switch to a real lockfile (uv) so transitive resolutions can't drift across environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Python dependency constraints for MLX builds, reducing the chance of transitive upgrades breaking bundled model engines. Risk is limited to potential version-resolution conflicts during install.
> 
> **Overview**
> Prevents Mac MLX builds from unintentionally upgrading to `transformers` 5.x by **restating the same `transformers>=4.36.0,<=4.57.6` cap** in `backend/requirements-mlx.txt`.
> 
> Adds inline rationale noting that `mlx-audio`’s unbounded `transformers` dependency can override the pin when installed after `requirements.txt`, breaking several bundled engines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54970abd3f59a9d071a9a1f69e5edfd9e6a0422e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned transformer library versions to ensure stable backend performance and compatibility with machine learning components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->