### PR TITLE
fix(build): install mlx-audio/mlx-lm with --no-deps to bypass transformers 5.x conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
         if: matrix.backend == 'mlx'
         run: |
           pip install -r backend/requirements-mlx.txt
+          # mlx-audio>=0.3.1 and mlx-lm>=0.31.1 both declare transformers>=5.x,
+          # which conflicts with our 4.57.x cap. The runtime APIs we use work
+          # fine on transformers 4.57.x in practice (verified in dev), so install
+          # them --no-deps. mlx-audio's other runtime deps (huggingface_hub,
+          # librosa, numpy, numba, pyloudnorm) are already in requirements.txt;
+          # the rest (sounddevice, miniaudio, protobuf, sentencepiece, pyyaml,
+          # jinja2) are pulled in by other engines.
+          pip install --no-deps mlx-lm==0.31.1
+          pip install --no-deps mlx-audio==0.4.1
 
       - name: Build Python server (Linux/macOS)
         if: matrix.platform != 'windows-latest'

--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -2,12 +2,14 @@
 # These should only be installed on aarch64-apple-darwin platforms
 
 mlx>=0.30.0
-mlx-audio>=0.3.1
 
-# Restate the transformers cap from requirements.txt. mlx-audio depends on
-# `transformers` with no upper bound, so installing it after requirements.txt
-# lets pip upgrade transformers past 4.57.x (latest is 5.x), which breaks
-# qwen-custom-voice (`@check_model_inputs()` API change), tada-1b (dataclass
-# `mutable default` enforcement), and luxtts (Whisper init path) in the
-# frozen MLX bundle. Keep this constraint in sync with requirements.txt.
-transformers>=4.36.0,<=4.57.6
+# NOTE: mlx-audio is intentionally not listed here. From 0.3.1 onward it
+# declares `transformers==5.0.0rc3` / `>=5.0.0`, which conflicts with the
+# `transformers<=4.57.6` cap in requirements.txt and breaks CI's clean
+# resolver. The mlx-audio API surface we use (mlx_audio.tts.load,
+# mlx_audio.stt.load) works fine on transformers 4.57.x in practice.
+#
+# Install it via `pip install --no-deps mlx-audio==0.4.1` after this file
+# (see .github/workflows/release.yml). All other mlx-audio runtime deps
+# (huggingface_hub, librosa, miniaudio, mlx-lm, numba, numpy, protobuf,
+# pyloudnorm, sounddevice, tqdm) are already in requirements.txt.


### PR DESCRIPTION
## Summary

The fix in #481 (cap `transformers<=4.57.6` in `requirements-mlx.txt`) didn't actually resolve in CI — pip backtracked through every transformers version and exited with `ResolutionImpossible`. Local install worked only because mlx-audio 0.4.1 was already present and pip didn't re-resolve.

```
ERROR: Cannot install -r backend/requirements-mlx.txt (line 13) and transformers because these package versions have conflicting dependencies.
The conflict is caused by:
    transformers 4.36.0 depends on huggingface-hub<1.0 and >=0.19.3
    tokenizers 0.14.1 depends on huggingface_hub<0.18 and >=0.16.4
```

## Root cause

`mlx-audio>=0.3.1` declares `transformers==5.0.0rc3` (0.3.1) or `>=5.0.0` (0.4.x). `mlx-lm==0.31.1` (mlx-audio's transitive dep) also declares `transformers>=5.0.0`. Both are unsatisfiable with `transformers<=4.57.6`.

In practice the mlx-audio API surface we use (`mlx_audio.tts.load`, `mlx_audio.stt.load`) works fine on transformers 4.57.x — verified by user across all engines on a Mac MLX dev install. The 5.x cap on these packages is conservative metadata, not a hard runtime requirement for our use cases.

## Fix

- Drop `mlx-audio` from `requirements-mlx.txt` (it can't be pip-resolved with our transformers cap)
- Install `mlx-audio==0.4.1` and `mlx-lm==0.31.1` with `--no-deps` in `release.yml`, after the rest of the deps are in place
- All transitive runtime deps (`huggingface_hub`, `librosa`, `numpy`, `numba`, `pyloudnorm`, `sounddevice`, `miniaudio`, `protobuf`, `sentencepiece`, `pyyaml`, `jinja2`, `tqdm`) are already pulled in by `requirements.txt` or other engines — verified against the working dev venv.

## Test plan

- [ ] CI release build succeeds for macOS MLX
- [ ] All four MLX-affected engines load and generate audio in the resulting bundle:
  - qwen-tts MLX (the engine that already worked)
  - qwen-custom-voice (was broken in 0.4.1)
  - tada-1b (was broken in 0.4.1)
  - luxtts (was broken in 0.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the macOS MLX release build dependency installation strategy, which can affect reproducibility and whether release CI succeeds. Low runtime risk, but a mis-specified version or missing transitive dependency could still break the MLX bundle at build time.
> 
> **Overview**
> Fixes CI dependency resolution for the Apple Silicon (MLX) release build by **removing `mlx-audio` from `backend/requirements-mlx.txt`** and installing `mlx-lm==0.31.1` and `mlx-audio==0.4.1` explicitly with `--no-deps` in `release.yml`.
> 
> Adds documentation/comments explaining the `transformers<=4.57.6` cap conflict with MLX packages that declare `transformers>=5.x`, and relies on already-pinned deps from `requirements.txt`/other engines to satisfy `mlx-audio` runtime needs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a53baf4350561fa0e3827a530f192b2b2018bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MLX backend dependency installation to explicitly pin `mlx-lm` and `mlx-audio` versions and prevent conflicting dependency resolutions. Simplified backend requirements file by removing redundant constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->