### PR TITLE
fix(audio): prevent WKWebView audio session teardown after backgrounding (#41)

### DIFF
--- a/app/src/components/AppFrame/AppFrame.tsx
+++ b/app/src/components/AppFrame/AppFrame.tsx
@@ -1,5 +1,6 @@
 import { useRouterState } from '@tanstack/react-router';
 import { TitleBarDragRegion } from '@/components/TitleBarDragRegion';
+import { AudioKeepAlive } from '@/components/AudioPlayer/AudioKeepAlive';
 import { AudioPlayer } from '@/components/AudioPlayer/AudioPlayer';
 import { StoryTrackEditor } from '@/components/StoriesTab/StoryTrackEditor';
 import { TOP_SAFE_AREA_PADDING } from '@/lib/constants/ui';
@@ -26,6 +27,7 @@ export function AppFrame({ children }: AppFrameProps) {
       className={cn('h-screen bg-background flex flex-col overflow-hidden', TOP_SAFE_AREA_PADDING)}
     >
       <TitleBarDragRegion />
+      <AudioKeepAlive />
       {children}
       {showTrackEditor ? (
         <StoryTrackEditor storyId={story.id} items={story.items} />

--- a/app/src/components/AudioPlayer/AudioKeepAlive.tsx
+++ b/app/src/components/AudioPlayer/AudioKeepAlive.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+import { debug } from '@/lib/utils/debug';
+
+// WKWebView tears down the app's CoreAudio output when idle for long enough,
+// and a JS-level reload (cmd+R) does NOT restore it — only relaunching the
+// Tauri app does. Keeping a silent <audio> element looping forever prevents
+// the OS audio session from ever going dormant.
+//
+// Real silence (zero PCM samples) at full volume is preferred over a muted
+// element: browsers/WebKit can optimize muted media away, which defeats the
+// purpose of holding the session open.
+
+function buildSilentWavUrl(seconds = 1, sampleRate = 8000): string {
+  const numSamples = seconds * sampleRate;
+  const bytes = 44 + numSamples * 2;
+  const buffer = new ArrayBuffer(bytes);
+  const view = new DataView(buffer);
+  const write = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+  };
+  write(0, 'RIFF');
+  view.setUint32(4, bytes - 8, true);
+  write(8, 'WAVE');
+  write(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  write(36, 'data');
+  view.setUint32(40, numSamples * 2, true);
+  return URL.createObjectURL(new Blob([buffer], { type: 'audio/wav' }));
+}
+
+export function AudioKeepAlive() {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const url = buildSilentWavUrl(1, 8000);
+    const el = new Audio(url);
+    el.loop = true;
+    el.volume = 1;
+    el.preload = 'auto';
+    audioRef.current = el;
+
+    const tryPlay = () => {
+      if (!audioRef.current) return;
+      if (!audioRef.current.paused) return;
+      audioRef.current.play().catch((err) => {
+        debug.log('[AudioKeepAlive] play blocked (will retry on next gesture):', err);
+      });
+    };
+
+    tryPlay();
+
+    // Autoplay may be blocked until first user interaction — re-attempt then.
+    const onGesture = () => tryPlay();
+    window.addEventListener('pointerdown', onGesture, { once: false });
+    window.addEventListener('keydown', onGesture, { once: false });
+
+    // If the webview ever pauses the element on background, resume on return.
+    const onWake = () => {
+      if (!document.hidden) tryPlay();
+    };
+    document.addEventListener('visibilitychange', onWake);
+    window.addEventListener('focus', onWake);
+    window.addEventListener('pageshow', onWake);
+
+    return () => {
+      window.removeEventListener('pointerdown', onGesture);
+      window.removeEventListener('keydown', onGesture);
+      document.removeEventListener('visibilitychange', onWake);
+      window.removeEventListener('focus', onWake);
+      window.removeEventListener('pageshow', onWake);
+      el.pause();
+      el.src = '';
+      URL.revokeObjectURL(url);
+      audioRef.current = null;
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Adds an always-on `AudioKeepAlive` component mounted at the app root that plays a silent looping WAV through a plain `<audio>` element, keeping macOS's CoreAudio session warm for the lifetime of the app.
- Fixes the long-standing bug where leaving Voicebox backgrounded for long enough puts the WaveSurfer WebAudio output into a dead state — `play()` resolves, `timeupdate` fires, but no sound reaches the speakers.

## Why

Closes #41. Also addresses the internal "WebAudio playback dies after audio-session interruption" note in `docs/PROJECT_STATUS.md`.

I'd previously tried:

- Swapping WaveSurfer backend away from WebAudio → introduced more bugs, not viable.
- Remounting the player on wake → a freshly-created `AudioContext` is born suspended and doesn't fix the problem.
- Calling `ctx.resume()` on play/visibilitychange (`AudioContext.state` based fix) → **didn't help either**, because the teardown is below the WebAudio layer. Confirmed in this session: once broken, a full `cmd+R` JS reload (which destroys every AudioContext and recreates them) still produces no audio. Only relaunching the Tauri process restores it. That rules out anything at the JS/WebAudio level.

The remaining plausible cause is WKWebView's audio output session getting torn down by the OS after prolonged idle. A known workaround (used by Spotify/YouTube Music web) is to keep at least one audio element perpetually playing silent PCM, which keeps the session bound.

## Implementation

- `app/src/components/AudioPlayer/AudioKeepAlive.tsx` — generates a 1-second silent 8 kHz WAV in memory, wraps it in a blob URL, and loops it through a plain `<audio>` element at full volume (true PCM silence — **not** `muted`, because muted media can be optimized away).
- `app/src/components/AppFrame/AppFrame.tsx` — mounts `<AudioKeepAlive />` once at the root so it's always running.
- Retries `play()` on the first pointer/keydown if autoplay is blocked, and on `visibilitychange`/`focus`/`pageshow` in case the webview ever pauses it.

## Test plan

- [x] Run dev build fresh (`bun tauri dev`), confirm no audible output and no console errors from the keep-alive.
- [x] Play something normally via the main AudioPlayer — verify unaffected.
- [x] Background the app (cmd+tab / minimize / screen lock) for an extended period (30 min+ or long enough to previously trigger the bug). Return to foreground and play a generation. Expect: audio plays without needing to relaunch.
- [x] Check that silent WAV loop doesn't show up in the macOS "app is making sound" indicator as annoying.
- [x] Confirm no regression in the Stories-editor playback path (`useStoryPlayback` uses its own AudioContext and should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a continuously-playing hidden audio element and global event listeners, which could affect autoplay behavior, resource usage, or platform-specific audio handling despite being contained to the app shell.
> 
> **Overview**
> Prevents macOS WKWebView/Tauri audio output from going “dead” after extended idle/backgrounding by mounting a new root-level `AudioKeepAlive` component in `AppFrame`.
> 
> `AudioKeepAlive` generates a silent WAV blob and loops it via a plain `Audio` element, retrying `play()` on user gestures and on wake/visibility events, with cleanup that revokes the blob URL and removes listeners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010c3d5219085cc387d65712c354436063b7fffa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio session persistence to maintain playback continuity when the app is backgrounded, minimizing interruptions during idle periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->