### PR TITLE
Align app shared types with API models and silence TS deprecation warning

### DIFF
--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,24 +1,13 @@
-// Shared TypeScript types for the voicebox application
+// Shared app-level type aliases.
+// Keep these aliases in sync with the generated API contract types.
+import type {
+  GenerationResponse,
+  VoiceProfileResponse,
+} from '@/lib/api/types';
 
-export interface VoiceProfile {
-  id: string;
-  name: string;
-  description?: string;
-  language: string;
-  createdAt: string;
-  updatedAt: string;
-}
+export type VoiceProfile = VoiceProfileResponse;
 
-export interface Generation {
-  id: string;
-  profileId: string;
-  text: string;
-  language: string;
-  audioPath: string;
-  duration: number;
-  seed?: number;
-  createdAt: string;
-}
+export type Generation = GenerationResponse;
 
 export interface ServerConfig {
   url: string;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
 
     /* Path aliases */
     "baseUrl": ".",


### PR DESCRIPTION
This PR applies two non-breaking maintenance fixes in the app layer.

## What changed
- Replaced duplicate local shared types with aliases to canonical API contract types in app/src/types/index.ts
  - VoiceProfile -> VoiceProfileResponse
  - Generation -> GenerationResponse
- Added ignoreDeprecations: "6.0" to app/tsconfig.json to silence the TypeScript baseUrl deprecation diagnostic.

## Why
- Prevents drift between local shared types and generated API models.
- Removes noisy TypeScript diagnostics without changing runtime behavior.

## Impact
- No installer/runtime behavior changes.
- Type safety and maintainability improved.

## Validation
- VS Code diagnostics checked after change: no errors reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal updates to maintain compatibility and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->