### PR TITLE
Fix localhost download redirects behind reverse proxies

### DIFF
--- a/landing/src/app/download/[platform]/route.ts
+++ b/landing/src/app/download/[platform]/route.ts
@@ -15,17 +15,32 @@ const PLATFORM_ALIAS: Record<string, string> = {
   windows: 'windows',
 };
 
+function getPublicOrigin(request: NextRequest): string {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+
+  if (forwardedHost && forwardedProto) {
+    // Behind reverse proxies/CDNs, request.url can be an internal origin
+    // (for example localhost:8080). Prefer forwarded headers so redirects
+    // keep users on the public domain.
+    return `${forwardedProto}://${forwardedHost}`;
+  }
+
+  return new URL(request.url).origin;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ platform: string }> },
 ) {
+  const origin = getPublicOrigin(request);
   const { platform } = await params;
   // No prebuilt Linux binary yet — send straight to the build-from-source page.
   if (platform === 'linux') {
-    return NextResponse.redirect(new URL('/linux-install', request.url), 307);
+    return NextResponse.redirect(new URL('/linux-install', origin), 307);
   }
   const normalized = PLATFORM_ALIAS[platform];
-  const target = new URL('/download', request.url);
+  const target = new URL('/download', origin);
   if (normalized) target.searchParams.set('platform', normalized);
   return NextResponse.redirect(target, 307);
 }


### PR DESCRIPTION
Fixes incorrect download redirects that can point users to internal origins like `https://localhost:8080/download?...` in production.

## What changed
- Updated `landing/src/app/download/[platform]/route.ts`
- Added `getPublicOrigin(request)` helper that prefers:
  - `x-forwarded-proto`
  - `x-forwarded-host`
- Redirect targets now use the public origin instead of `request.url` origin when behind a proxy/CDN.

## Why
In some deployments, `request.url` carries an internal upstream origin (for example localhost). Using forwarded headers ensures end-users stay on the public domain.

## Notes
- No installer/runtime behavior changes.
- This is a redirect-host correctness fix only.

Fixes #496


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirect routing to correctly direct users to platform-specific installation and download pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->