### PR TITLE
Fix/download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Voicebox is a **local-first voice cloning studio** — a free and open-source al
 
 | Platform              | Download                                               |
 | --------------------- | ------------------------------------------------------ |
-| macOS (Apple Silicon) | [Download DMG](https://voicebox.sh/download/mac-arm)   |
-| macOS (Intel)         | [Download DMG](https://voicebox.sh/download/mac-intel) |
-| Windows               | [Download MSI](https://voicebox.sh/download/windows)   |
+| macOS (Apple Silicon) | [Download DMG](https://github.com/jamiepine/voicebox/releases/download/v0.4.1/Voicebox_0.4.1_aarch64.dmg)   |
+| macOS (Intel)         | [Download DMG](https://github.com/jamiepine/voicebox/releases/download/v0.4.1/Voicebox_0.4.1_x64.dmg) |
+| Windows               | [Download MSI](https://github.com/jamiepine/voicebox/releases/download/v0.4.1/Voicebox_0.4.1_x64_en-US.msi)   |
 | Docker                | `docker compose up`                                    |
 
 > **[View all binaries →](https://github.com/jamiepine/voicebox/releases/latest)**


### PR DESCRIPTION
This pull request updates the download links in the `README.md` file to point directly to the latest release assets on GitHub, ensuring users get the correct and most recent installers for each platform.

Before, links were redirecting to localhost. 

Documentation updates:

* Updated the download URLs for macOS (Apple Silicon), macOS (Intel), and Windows in the `README.md` to reference the latest GitHub release assets for version 0.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated README download links to point directly to v0.4.1 release assets hosted on GitHub
* Added separate, platform-specific macOS installers for both Apple Silicon and Intel architectures
* Updated Windows installer download link to access the v0.4.1 release
* Provides users with direct, streamlined access to the correct installer for their system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->