### PR TITLE
fix(mlx): point Qwen 0.6B at the published mlx-community repo

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -177,7 +177,7 @@ def _get_qwen_model_configs() -> list[ModelConfig]:
     backend_type = get_backend_type()
     if backend_type == "mlx":
         repo_1_7b = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
-        repo_0_6b = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"  # 0.6B not available in MLX, falls back
+        repo_0_6b = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
     else:
         repo_1_7b = "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
         repo_0_6b = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -45,11 +45,9 @@ class MLXTTSBackend:
         Returns:
             HuggingFace Hub model ID for MLX
         """
-        # MLX model mapping
         mlx_model_map = {
             "1.7B": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16",
-            # 0.6B not yet converted to MLX format
-            "0.6B": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16",  # Fallback to 1.7B
+            "0.6B": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16",
         }
 
         if model_size not in mlx_model_map:

--- a/backend/tests/test_qwen_download.py
+++ b/backend/tests/test_qwen_download.py
@@ -175,7 +175,7 @@ async def main():
     print("   ✅ Server is running")
 
     # Test model
-    model_name = "qwen-tts-0.6B"  # Note: 0.6B currently maps to 1.7B on MLX
+    model_name = "qwen-tts-0.6B"
     
     # Check current status
     print(f"\n📊 Checking status of {model_name}...")

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -309,11 +309,7 @@ Still reported. Users get stuck downloads, can't resume, offline mode edge cases
 
 **Fix path:** PR #443 addresses infinite offline retry. CustomVoice-specific download failures (#475, #445) need triage — likely related to frozen-binary import fixes in PR #438. TADA cluster (#336, #348) and macOS ARM import regressions (#287, #275, #304) need a dedicated triage pass.
 
-**Qwen 0.6B-downloads-1.7B reports:** **#485** (2026-04-19), **#423** (macOS M1), **#329**. Platform-dependent:
-
-- **On MLX (Apple Silicon) — not a bug.** `mlx-community` only publishes 1.7B-Base-bf16 weights, so the 0.6B Base option intentionally resolves to the same repo (`backend/backends/__init__.py:180` — `# 0.6B not available in MLX, falls back`). UX gap: the selector offers a size that doesn't exist on the active backend. Fix: (a) hide the 0.6B option on MLX, or (b) label it "0.6B (uses 1.7B on Apple Silicon)".
-- **On PyTorch (Windows/Linux/CUDA/ROCm/XPU/CPU) — real bug if reported.** Both 0.6B and 1.7B have distinct repos (`Qwen/Qwen3-TTS-12Hz-0.6B-Base` vs `-1.7B-Base`). Triage each report by platform before merging into the MLX cluster.
-- **Qwen CustomVoice (either platform)** — no fallback, both sizes always have dedicated repos.
+**Qwen 0.6B-downloads-1.7B reports:** **#485** (2026-04-19), **#423** (macOS M1), **#329**. Originally a stale-fallback bug: `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` wasn't published when MLX support shipped, so the 0.6B slot was aliased to the 1.7B repo. The 0.6B bf16 conversion is live now and both `backend/backends/mlx_backend.py` and `backend/backends/__init__.py` point at their correct repos. Qwen CustomVoice is unaffected — it runs via PyTorch on all platforms, both sizes always have dedicated repos.
 
 ### Language Requests (ongoing)
 
@@ -393,7 +389,7 @@ Notable:
 | **#306** ("voice model"), **#389** ("New model"), **#473** ("New functionality") | Title-only issues, no content. Request details or close. |
 | **#309** | Uninstall/cleanup question. Answer and close. |
 | **#241** | "How to use in Colab" — support question, not a bug. |
-| **#423** / **#485** / **#329** | Platform-dependent. On MLX: not a bug (0.6B weights don't exist upstream, fallback is intentional — fix UX). On PyTorch: real bug if reproducible. Classify each by reporter's platform before deduping. |
+| **#423** / **#485** / **#329** | Stale MLX fallback to 1.7B repo — fixed; 0.6B bf16 conversion now live on `mlx-community`, registry points at correct repo on both backends. |
 | **#336** / **#348** | TADA download/registration cluster — triage together. |
 | **#287** / **#275** / **#304** | macOS ARM import regressions on new version — likely one root cause. |
 | **#292**, **#349** | Possibly already fixed by merged PRs (#321/#412 and #345). Verify + close. |

--- a/docs/content/docs/overview/troubleshooting.mdx
+++ b/docs/content/docs/overview/troubleshooting.mdx
@@ -446,20 +446,6 @@ Restart the app to create a fresh database.
   huggingface-cli download Qwen/Qwen3-TTS-12Hz-1.7B-Base
   ```
 
-### Qwen 0.6B Downloads the Same Files as 1.7B on Apple Silicon
-
-**Symptoms:**
-- You select Qwen 0.6B on an Apple Silicon Mac and the download is the same size as 1.7B
-- Generation speed and VRAM usage match 1.7B, not the expected smaller model
-
-**Explanation:**
-This is intentional, not a bug. The MLX community only publishes `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16` — there is no 0.6B MLX build. Voicebox's model registry falls back to the 1.7B weights when 0.6B is selected on MLX (see `backend/backends/__init__.py`).
-
-**Solution:**
-- On Apple Silicon, both size options use the 1.7B model — pick either.
-- If you specifically need a smaller model, switch to **Kokoro 82M** (~350 MB) or **LuxTTS** (~300 MB) — both CPU-realtime.
-- On Windows/Linux with PyTorch, 0.6B and 1.7B are distinct repos and behave differently.
-
 ### Wrong Model Version
 
 **Symptoms:**


### PR DESCRIPTION
## Summary

- Point Qwen 0.6B at `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` instead of falling back to the 1.7B repo.
- Drop the obsolete "0.6B downloads the same as 1.7B" troubleshooting entry.
- Clean up the stale triage note in PROJECT_STATUS.md.

## Why

When the MLX backend shipped, `mlx-community` hadn't converted the 0.6B base yet, so the 0.6B slot was aliased to the 1.7B repo as a temporary fallback (`# 0.6B not available in MLX, falls back`). That conversion is now live (1.4k downloads, published 2026-01-22), so Apple Silicon users picking 0.6B should get the actual 0.6B weights — ~1.2 GB instead of ~3.5 GB — with the corresponding speed/memory win.

Reported in #485, also covers the older #423 / #329 reports.

Qwen CustomVoice is unaffected — it runs via PyTorch on all platforms and both sizes already have dedicated repos.

## Test plan

- [ ] On Apple Silicon: delete any cached 0.6B model, select "Qwen TTS 0.6B" in the app, confirm the downloaded repo ID is `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` (not the 1.7B one) and the download size is ~1.2 GB.
- [ ] Generation works end-to-end with the 0.6B MLX model.
- [ ] 1.7B selection still resolves to the 1.7B MLX repo.
- [ ] On PyTorch (Windows/Linux): no behavior change — 0.6B and 1.7B already pointed at distinct `Qwen/...` repos.

Fixes #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which HuggingFace repo is downloaded/loaded for Qwen 0.6B on the MLX backend, which can affect cache reuse and download behavior for existing users. Logic is small and localized but touches core model resolution paths.
> 
> **Overview**
> Fixes Apple Silicon (MLX) model resolution so selecting **Qwen TTS 0.6B** downloads/loads `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` instead of incorrectly aliasing to the 1.7B repo.
> 
> Updates the MLX backend’s model-size mapping and the backend-aware model registry accordingly, adjusts the Qwen download test to remove the stale fallback note, and cleans up docs by removing/rewriting troubleshooting and project-status guidance that assumed the fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70ec328a7ee6d3e669b998f1db19943c49da015. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Qwen 0.6B model to correctly download dedicated 0.6B weights instead of falling back to 1.7B model on all platforms.

* **Documentation**
  * Updated troubleshooting guide to reflect resolution of the 0.6B/1.7B model mapping issue.
  * Removed obsolete workarounds and explanations related to the incorrect model fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->