### PR TITLE
fix(audio): preprocess reference samples instead of rejecting them

### DIFF
--- a/backend/tests/test_audio_preprocess.py
+++ b/backend/tests/test_audio_preprocess.py
@@ -58,6 +58,15 @@ def test_silence_is_trimmed_with_padding_kept():
     assert len(out) >= int(3.0 * SR), "speech body should be preserved"
 
 
+def test_clean_audio_is_not_padded_past_original_length():
+    # Well-recorded audio with no edge silence shouldn't get longer after
+    # preprocessing — otherwise a 29.9 s upload could be pushed past the
+    # 30 s max_duration ceiling downstream.
+    audio = _tone(3.0, amp=0.3)
+    out = preprocess_reference_audio(audio, SR)
+    assert len(out) <= len(audio)
+
+
 def test_empty_input_returns_empty():
     out = preprocess_reference_audio(np.zeros(0, dtype=np.float32), SR)
     assert out.size == 0

--- a/backend/tests/test_audio_preprocess.py
+++ b/backend/tests/test_audio_preprocess.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for reference-audio preprocessing.
+
+Covers :func:`backend.utils.audio.preprocess_reference_audio` and
+:func:`backend.utils.audio.validate_and_load_reference_audio`.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.audio import (  # noqa: E402
+    preprocess_reference_audio,
+    validate_and_load_reference_audio,
+)
+
+
+SR = 24000
+
+
+def _tone(duration_s: float, amp: float = 0.3, freq: float = 220.0) -> np.ndarray:
+    n = int(duration_s * SR)
+    t = np.arange(n, dtype=np.float32) / SR
+    return (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def test_peak_cap_scales_hot_input():
+    audio = _tone(3.0, amp=0.99)
+    out = preprocess_reference_audio(audio, SR)
+    assert np.abs(out).max() <= 0.951
+
+
+def test_peak_cap_leaves_moderate_input_untouched():
+    audio = _tone(3.0, amp=0.5)
+    out = preprocess_reference_audio(audio, SR)
+    assert np.isclose(np.abs(out).max(), 0.5, atol=1e-3)
+
+
+def test_dc_offset_removed():
+    audio = _tone(3.0, amp=0.3) + 0.1
+    out = preprocess_reference_audio(audio, SR)
+    assert abs(float(np.mean(out))) < 1e-3
+
+
+def test_silence_is_trimmed_with_padding_kept():
+    silence = np.zeros(int(SR * 1.0), dtype=np.float32)
+    speech = _tone(3.0, amp=0.3)
+    audio = np.concatenate([silence, speech, silence])
+    out = preprocess_reference_audio(audio, SR)
+    # Most of the 2s of leading/trailing silence should be gone, but the
+    # 3s of speech plus ~200ms of padding should remain.
+    assert len(audio) - len(out) >= SR, "expected >=1s of silence trimmed"
+    assert len(out) >= int(3.0 * SR), "speech body should be preserved"
+
+
+def test_empty_input_returns_empty():
+    out = preprocess_reference_audio(np.zeros(0, dtype=np.float32), SR)
+    assert out.size == 0
+
+
+def test_validate_accepts_previously_rejected_hot_file(tmp_path):
+    audio = _tone(3.0, amp=0.995)
+    path = tmp_path / "hot.wav"
+    sf.write(str(path), audio, SR)
+
+    ok, err, out_audio, out_sr = validate_and_load_reference_audio(str(path))
+
+    assert ok, f"expected pass, got error: {err}"
+    assert out_audio is not None
+    assert out_sr == SR
+    assert np.abs(out_audio).max() <= 0.951
+
+
+def test_validate_still_rejects_silent_input(tmp_path):
+    audio = np.zeros(int(SR * 3.0), dtype=np.float32)
+    path = tmp_path / "silent.wav"
+    sf.write(str(path), audio, SR)
+
+    ok, err, _, _ = validate_and_load_reference_audio(str(path))
+
+    assert not ok
+    assert err is not None
+    assert "too short" in err.lower() or "quiet" in err.lower()
+
+
+def test_validate_rejects_too_short(tmp_path):
+    audio = _tone(0.5, amp=0.3)
+    path = tmp_path / "short.wav"
+    sf.write(str(path), audio, SR)
+
+    ok, err, _, _ = validate_and_load_reference_audio(str(path))
+
+    assert not ok
+    assert "too short" in (err or "").lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -203,7 +203,7 @@ def preprocess_reference_audio(
     audio: np.ndarray,
     sample_rate: int,
     peak_target: float = 0.95,
-    trim_top_db: float = 30.0,
+    trim_top_db: float = 40.0,
     edge_padding_ms: int = 100,
 ) -> np.ndarray:
     """
@@ -221,9 +221,14 @@ def preprocess_reference_audio(
         peak_target: Peak amplitude cap in [0, 1]. Applied only if the input
             peak exceeds this value.
         trim_top_db: Silence threshold for edge trimming, in dB below peak.
-            Conservative (30 dB) so soft speech at the edges isn't clipped off.
-        edge_padding_ms: Milliseconds of padding retained at each edge after
-            trimming, so TTS engines have a brief silence to anchor on.
+            40 dB sits below normal speech dynamic range (≈30 dB) so soft
+            trailing syllables are preserved, while still catching obvious
+            leading/trailing silence. Lower values are more aggressive;
+            librosa's own default is 60.
+        edge_padding_ms: Milliseconds of padding to add back at each edge
+            *only if* trimming shortened the waveform, so TTS engines have a
+            brief silence to anchor on without ever making the output longer
+            than the input.
 
     Returns:
         Preprocessed audio array (float32).
@@ -236,8 +241,13 @@ def preprocess_reference_audio(
     audio = audio - float(np.mean(audio))
 
     trimmed, _ = librosa.effects.trim(audio, top_db=trim_top_db)
-    if trimmed.size > 0:
-        pad = int(sample_rate * edge_padding_ms / 1000)
+    if 0 < trimmed.size < audio.size:
+        pad_each = int(sample_rate * edge_padding_ms / 1000)
+        # Never pad past the original length — for near-max-duration uploads
+        # an unconditional pad would push them over the 30 s ceiling and
+        # trigger a spurious "too long" rejection.
+        headroom = (audio.size - trimmed.size) // 2
+        pad = min(pad_each, max(headroom, 0))
         if pad > 0:
             trimmed = np.pad(trimmed, (pad, pad), mode="constant")
         audio = trimmed

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -199,6 +199,56 @@ def trim_tts_output(
     return trimmed
 
 
+def preprocess_reference_audio(
+    audio: np.ndarray,
+    sample_rate: int,
+    peak_target: float = 0.95,
+    trim_top_db: float = 30.0,
+    edge_padding_ms: int = 100,
+) -> np.ndarray:
+    """
+    Clean up a reference-audio sample before validation/storage.
+
+    Removes DC offset, trims leading/trailing silence, and caps the peak so a
+    slightly-hot recording doesn't get rejected downstream as "clipping". The
+    goal is to accept reasonable real-world recordings — not to repair badly
+    distorted ones. True clipping artifacts inside the waveform can't be
+    recovered by peak scaling and will still sound bad.
+
+    Args:
+        audio: Mono audio array.
+        sample_rate: Sample rate of ``audio`` in Hz.
+        peak_target: Peak amplitude cap in [0, 1]. Applied only if the input
+            peak exceeds this value.
+        trim_top_db: Silence threshold for edge trimming, in dB below peak.
+            Conservative (30 dB) so soft speech at the edges isn't clipped off.
+        edge_padding_ms: Milliseconds of padding retained at each edge after
+            trimming, so TTS engines have a brief silence to anchor on.
+
+    Returns:
+        Preprocessed audio array (float32).
+    """
+    audio = audio.astype(np.float32, copy=False)
+
+    if audio.size == 0:
+        return audio
+
+    audio = audio - float(np.mean(audio))
+
+    trimmed, _ = librosa.effects.trim(audio, top_db=trim_top_db)
+    if trimmed.size > 0:
+        pad = int(sample_rate * edge_padding_ms / 1000)
+        if pad > 0:
+            trimmed = np.pad(trimmed, (pad, pad), mode="constant")
+        audio = trimmed
+
+    peak = float(np.abs(audio).max())
+    if peak > peak_target and peak > 0:
+        audio = audio * (peak_target / peak)
+
+    return audio
+
+
 def validate_reference_audio(
     audio_path: str,
     min_duration: float = 2.0,
@@ -207,13 +257,13 @@ def validate_reference_audio(
 ) -> Tuple[bool, Optional[str]]:
     """
     Validate reference audio for voice cloning.
-    
+
     Args:
         audio_path: Path to audio file
         min_duration: Minimum duration in seconds
         max_duration: Maximum duration in seconds
         min_rms: Minimum RMS level
-        
+
     Returns:
         Tuple of (is_valid, error_message)
     """
@@ -231,26 +281,28 @@ def validate_and_load_reference_audio(
 ) -> Tuple[bool, Optional[str], Optional[np.ndarray], Optional[int]]:
     """
     Validate and load reference audio in a single pass.
-    
+
+    Applies :func:`preprocess_reference_audio` before checks so that
+    slightly-hot recordings aren't rejected as clipping. Duration and RMS
+    checks run on the preprocessed waveform.
+
     Returns:
         Tuple of (is_valid, error_message, audio_array, sample_rate)
     """
     try:
         audio, sr = load_audio(audio_path)
+        audio = preprocess_reference_audio(audio, sr)
         duration = len(audio) / sr
-        
+
         if duration < min_duration:
             return False, f"Audio too short (minimum {min_duration} seconds)", None, None
         if duration > max_duration:
             return False, f"Audio too long (maximum {max_duration} seconds)", None, None
-        
+
         rms = np.sqrt(np.mean(audio**2))
         if rms < min_rms:
             return False, "Audio is too quiet or silent", None, None
-        
-        if np.abs(audio).max() > 0.99:
-            return False, "Audio is clipping (reduce input gain)", None, None
-        
+
         return True, None, audio, sr
     except Exception as e:
         return False, f"Error validating audio: {str(e)}", None, None


### PR DESCRIPTION
## Summary

Uploaded or recorded voice samples were rejected outright when peak > 0.99 ("Audio is clipping (reduce input gain)"). That error isn't actionable — the in-app recorder has no pre-gain control, and an already-captured file can't be re-taken by the user. Several users have bounced off this (#456).

The Settings "Normalize audio" toggle doesn't help: it only applies to *generated TTS output*, not sample ingestion.

This PR adds a small always-on preprocessor that runs right after `librosa.load` in the sample-validation path:

- **DC-offset removal**
- **Edge silence trim** — conservative (`top_db=30`), keeps 100 ms of padding at each edge so TTS engines have a brief silence to anchor on
- **Peak cap at 0.95** — scale down if and only if the input peak exceeds 0.95

Duration and RMS checks now run on the preprocessed waveform, so slightly-hot recordings that used to fail are now accepted and stored with safe headroom.

Out of scope (considered and declined): LUFS loudness normalization, per-engine resampling tuning, auto-denoise. All three risk over-processing well-recorded samples or pull in model dependencies — can be follow-ups if needed.

## Caveat

True in-waveform clipping artifacts (distortion already baked into the waveform) can't be repaired by peak scaling. The preprocessor prevents *downstream* re-clipping during multi-sample combination and TTS inference, which is where the user-visible error was originating.

## Tests

New unit-test file `backend/tests/test_audio_preprocess.py` (there were no existing unit tests for `audio.py`). Covers:

- Peak cap scales hot input, leaves moderate input untouched
- DC offset removed
- Silence trim with padding preserved
- Empty input handled
- Previously-rejected hot file now validates
- Silent / too-short files still rejected

## Test plan

- [ ] Upload a sample with peak ≥ 0.99 — should be accepted (previously rejected with "Audio is clipping").
- [ ] Record a sample in-app with a few seconds of silence at the start — stored WAV should have the silence trimmed.
- [ ] Upload a clean, well-recorded sample (peak < 0.95) — byte-compared content should be effectively unchanged apart from DC removal.
- [ ] Silent file (all zeros) — still rejected.
- [ ] Too-short file (<2s) — still rejected.
- [ ] Generate TTS using a profile created from a previously-hot sample across Qwen, Chatterbox Multilingual, and LuxTTS — verify no clipping/distortion in output.

Fixes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reference-audio validation path to modify waveform data (trim/DC removal/peak scaling) before duration/RMS checks, which may affect what gets accepted/stored and could impact downstream voice-cloning quality. Scope is contained to sample ingestion plus new unit coverage, with no auth/security implications.
> 
> **Overview**
> Reference-audio ingestion now **preprocesses uploaded/recorded samples** before validation by removing DC offset, trimming leading/trailing silence (with small edge padding), and scaling peaks down to a 0.95 cap.
> 
> `validate_and_load_reference_audio` applies this preprocessing before duration/RMS checks and removes the prior hard rejection on peak > 0.99 (“clipping”). New unit tests cover the preprocessing behavior and ensure hot files now pass while silent/too-short inputs still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49cc6afbb53dbe8ff69a16f20c6c55e1aca6715. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reference-audio preprocessing step that trims silence, removes DC offset, and peak‑caps loud inputs.

* **Tests**
  * Added comprehensive tests for preprocessing and validation covering peak capping, DC offset removal, trimming/padding, empty/too‑short/silent inputs, and acceptance of previously rejected high‑peak files.

* **Bug Fixes**
  * Validation now runs on preprocessed audio; high‑amplitude files are normalized rather than rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->