### PR TITLE
fix(backend): pin miniaudio for mlx-audio STT (#505)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,10 @@ jobs:
           # fine on transformers 4.57.x in practice (verified in dev), so install
           # them --no-deps. mlx-audio's other runtime deps (huggingface_hub,
           # librosa, numpy, numba, pyloudnorm) are already in requirements.txt;
-          # the rest (sounddevice, miniaudio, protobuf, sentencepiece, pyyaml,
-          # jinja2) are pulled in by other engines.
+          # miniaudio is in requirements-mlx.txt (needed by mlx_audio.stt,
+          # not transitively pulled by anything else — see issue #505); the
+          # rest (sounddevice, protobuf, sentencepiece, pyyaml, jinja2) are
+          # pulled in by other engines.
           pip install --no-deps mlx-lm==0.31.1
           pip install --no-deps mlx-audio==0.4.1
 

--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -3,6 +3,12 @@
 
 mlx>=0.30.0
 
+# miniaudio is a runtime dep of mlx-audio's STT path (mlx_audio.stt).
+# mlx-audio itself is installed --no-deps (see comment below), so we
+# must list miniaudio explicitly here or transcription fails on fresh
+# M1 installs with `ModuleNotFoundError: miniaudio` (issue #505).
+miniaudio>=1.59
+
 # NOTE: mlx-audio is intentionally not listed here. From 0.3.1 onward it
 # declares `transformers==5.0.0rc3` / `>=5.0.0`, which conflicts with the
 # `transformers<=4.57.6` cap in requirements.txt and breaks CI's clean
@@ -10,6 +16,7 @@ mlx>=0.30.0
 # mlx_audio.stt.load) works fine on transformers 4.57.x in practice.
 #
 # Install it via `pip install --no-deps mlx-audio==0.4.1` after this file
-# (see .github/workflows/release.yml). All other mlx-audio runtime deps
-# (huggingface_hub, librosa, miniaudio, mlx-lm, numba, numpy, protobuf,
-# pyloudnorm, sounddevice, tqdm) are already in requirements.txt.
+# (see .github/workflows/release.yml). Most other mlx-audio runtime deps
+# (huggingface_hub, librosa, mlx-lm, numba, numpy, protobuf, pyloudnorm,
+# sounddevice, tqdm) are already in requirements.txt or pulled in by
+# other engines.


### PR DESCRIPTION
## Summary
- Fresh macOS M1 installs failed to transcribe with `ModuleNotFoundError: miniaudio` (#505)
- `mlx-audio` is installed `--no-deps` to avoid its `transformers>=5.x` pin, so its transitive deps have to be declared elsewhere
- `miniaudio` (imported by `mlx_audio.stt`) was not listed in either `requirements.txt` or `requirements-mlx.txt` — the comments in both files wrongly claimed it came from another engine
- Pin it in `requirements-mlx.txt` (Apple Silicon only — PyTorch STT uses HF `transformers` and doesn't need it) and correct the stale comments

Fixes #505

## Test plan
- [ ] Build macOS release via CI and confirm transcription works end-to-end on a fresh install
- [ ] Spot-check that MLX TTS (Qwen via `mlx_audio.tts`) still loads — unchanged path, but same `--no-deps` install
- [ ] Confirm no regression on Linux/Windows builds (they don't install `requirements-mlx.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Apple-Silicon MLX dependency installation to include a missing runtime package and updates related CI comments; no application logic changes.
> 
> **Overview**
> Fixes fresh Apple Silicon installs failing to transcribe by explicitly adding `miniaudio>=1.59` to `backend/requirements-mlx.txt` (since `mlx-audio` is installed with `--no-deps`).
> 
> Updates the release workflow comments in `.github/workflows/release.yml` and `requirements-mlx.txt` to reflect that `miniaudio` is not pulled transitively and must be installed separately for `mlx_audio.stt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 791c0509a995e921b598f9f37166c392380cadb4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio library availability on Apple Silicon builds by explicitly declaring the miniaudio dependency for speech-to-text functionality.

* **Chores**
  * Updated dependency configuration to clarify which packages are explicitly required versus transitively included by other engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->