### PR TITLE
feat(engines): add MOSS-TTS-Nano backend (0.1B, 20 langs, CPU realtime)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ COPY backend/requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 RUN pip install --no-cache-dir --prefix=/install --no-deps chatterbox-tts
 RUN pip install --no-cache-dir --prefix=/install --no-deps hume-tada
+RUN pip install --no-cache-dir --prefix=/install --no-deps \
+    git+https://github.com/OpenMOSS/MOSS-TTS-Nano.git
 RUN pip install --no-cache-dir --prefix=/install \
     git+https://github.com/QwenLM/Qwen3-TTS.git
 

--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -38,7 +38,7 @@ const ENGINE_DESCRIPTIONS: Record<string, string> = {
   chatterbox_turbo: 'English, [laugh] [cough] tags',
   tada: 'HumeAI, 700s+ coherent audio',
   kokoro: '82M params, CPU realtime, 8 langs',
-  moss_tts_nano: '0.1B, CPU realtime, 20 langs, 48 kHz',
+  moss_tts_nano: '0.1B, CPU realtime, 19 langs, 48 kHz',
 };
 
 /** Engines that only support English and should force language to 'en' on select. */

--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -27,6 +27,7 @@ const ENGINE_OPTIONS = [
   { value: 'tada:1B', label: 'TADA 1B', engine: 'tada' },
   { value: 'tada:3B', label: 'TADA 3B Multilingual', engine: 'tada' },
   { value: 'kokoro', label: 'Kokoro 82M', engine: 'kokoro' },
+  { value: 'moss_tts_nano', label: 'MOSS-TTS-Nano', engine: 'moss_tts_nano' },
 ] as const;
 
 const ENGINE_DESCRIPTIONS: Record<string, string> = {
@@ -37,13 +38,14 @@ const ENGINE_DESCRIPTIONS: Record<string, string> = {
   chatterbox_turbo: 'English, [laugh] [cough] tags',
   tada: 'HumeAI, 700s+ coherent audio',
   kokoro: '82M params, CPU realtime, 8 langs',
+  moss_tts_nano: '0.1B, CPU realtime, 20 langs, 48 kHz',
 };
 
 /** Engines that only support English and should force language to 'en' on select. */
 const ENGLISH_ONLY_ENGINES = new Set(['luxtts', 'chatterbox_turbo']);
 
 /** Engines that support cloned (reference audio) profiles. */
-const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'tada']);
+const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'tada', 'moss_tts_nano']);
 
 function getAvailableOptions(selectedProfile?: VoiceProfileResponse | null) {
   if (!selectedProfile) return ENGINE_OPTIONS;

--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -69,7 +69,7 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
   kokoro:
     'Kokoro 82M by hexgrad. Tiny 82M-parameter TTS that runs at CPU realtime. Supports 8 languages with pre-built voice styles. Apache 2.0 licensed.',
   'moss-tts-nano':
-    'MOSS-TTS-Nano by OpenMOSS. 0.1B-parameter TTS with voice cloning, 20 languages, 48 kHz stereo output, and CPU realtime on 4 cores. Apache 2.0.',
+    'MOSS-TTS-Nano by OpenMOSS. 0.1B-parameter TTS with voice cloning, 19 languages, 48 kHz stereo output, and CPU realtime on 4 cores. Apache 2.0.',
   'qwen-custom-voice-1.7B':
     'Qwen3-TTS CustomVoice 1.7B by Alibaba. 9 premium preset voices with instruct-based style control for tone, emotion, and prosody. Supports 10 languages.',
   'qwen-custom-voice-0.6B':

--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -68,6 +68,8 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
     'HumeAI TADA 3B Multilingual — built on Llama 3.2 3B. Supports 10 languages with high-fidelity voice cloning via text-acoustic dual alignment.',
   kokoro:
     'Kokoro 82M by hexgrad. Tiny 82M-parameter TTS that runs at CPU realtime. Supports 8 languages with pre-built voice styles. Apache 2.0 licensed.',
+  'moss-tts-nano':
+    'MOSS-TTS-Nano by OpenMOSS. 0.1B-parameter TTS with voice cloning, 20 languages, 48 kHz stereo output, and CPU realtime on 4 cores. Apache 2.0.',
   'qwen-custom-voice-1.7B':
     'Qwen3-TTS CustomVoice 1.7B by Alibaba. 9 premium preset voices with instruct-based style control for tone, emotion, and prosody. Supports 10 languages.',
   'qwen-custom-voice-0.6B':
@@ -404,7 +406,8 @@ export function ModelManagement() {
         m.model_name.startsWith('luxtts') ||
         m.model_name.startsWith('chatterbox') ||
         m.model_name.startsWith('tada') ||
-        m.model_name.startsWith('kokoro'),
+        m.model_name.startsWith('kokoro') ||
+        m.model_name.startsWith('moss-tts-nano'),
     ) ?? [];
   const whisperModels = modelStatus?.models.filter((m) => m.model_name.startsWith('whisper')) ?? [];
 

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -69,7 +69,8 @@ export interface GenerationRequest {
     | 'chatterbox'
     | 'chatterbox_turbo'
     | 'tada'
-    | 'kokoro';
+    | 'kokoro'
+    | 'moss_tts_nano';
   instruct?: string;
   max_chunk_chars?: number;
   crossfade_ms?: number;

--- a/app/src/lib/constants/languages.ts
+++ b/app/src/lib/constants/languages.ts
@@ -11,15 +11,18 @@
 /** All languages that any engine supports. */
 export const ALL_LANGUAGES = {
   ar: 'Arabic',
+  cs: 'Czech',
   da: 'Danish',
   de: 'German',
   el: 'Greek',
   en: 'English',
   es: 'Spanish',
+  fa: 'Persian',
   fi: 'Finnish',
   fr: 'French',
   he: 'Hebrew',
   hi: 'Hindi',
+  hu: 'Hungarian',
   it: 'Italian',
   ja: 'Japanese',
   ko: 'Korean',
@@ -70,6 +73,11 @@ export const ENGINE_LANGUAGES: Record<string, readonly LanguageCode[]> = {
   tada: ['en', 'ar', 'zh', 'de', 'es', 'fr', 'it', 'ja', 'pl', 'pt'],
   kokoro: ['en', 'es', 'fr', 'hi', 'it', 'pt', 'ja', 'zh'],
   qwen_custom_voice: ['zh', 'en', 'ja', 'ko', 'de', 'fr', 'ru', 'pt', 'es', 'it'],
+  moss_tts_nano: [
+    'zh', 'en', 'de', 'es', 'fr', 'ja', 'it',
+    'hu', 'ko', 'ru', 'fa', 'ar', 'pl', 'pt',
+    'cs', 'da', 'sv', 'el', 'tr',
+  ],
 } as const;
 
 /** Helper: get language options for a given engine. */

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -85,46 +85,37 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
 
     try {
       const engine = data.engine || 'qwen';
-      const modelName =
-        engine === 'luxtts'
-          ? 'luxtts'
-          : engine === 'chatterbox'
-            ? 'chatterbox-tts'
-            : engine === 'chatterbox_turbo'
-              ? 'chatterbox-turbo'
-              : engine === 'tada'
-                ? data.modelSize === '3B'
-                  ? 'tada-3b-ml'
-                  : 'tada-1b'
-                : engine === 'kokoro'
-                  ? 'kokoro'
-                  : engine === 'moss_tts_nano'
-                    ? 'moss-tts-nano'
-                    : engine === 'qwen_custom_voice'
-                    ? `qwen-custom-voice-${data.modelSize}`
-                    : `qwen-tts-${data.modelSize}`;
-      const displayName =
-        engine === 'luxtts'
-          ? 'LuxTTS'
-          : engine === 'chatterbox'
-            ? 'Chatterbox TTS'
-            : engine === 'chatterbox_turbo'
-              ? 'Chatterbox Turbo'
-              : engine === 'tada'
-                ? data.modelSize === '3B'
-                  ? 'TADA 3B Multilingual'
-                  : 'TADA 1B'
-                : engine === 'kokoro'
-                  ? 'Kokoro 82M'
-                  : engine === 'moss_tts_nano'
-                    ? 'MOSS-TTS-Nano'
-                    : engine === 'qwen_custom_voice'
-                    ? data.modelSize === '1.7B'
-                      ? 'Qwen CustomVoice 1.7B'
-                      : 'Qwen CustomVoice 0.6B'
-                    : data.modelSize === '1.7B'
-                      ? 'Qwen TTS 1.7B'
-                      : 'Qwen TTS 0.6B';
+
+      type EngineNames = { model: string; display: string };
+      const engineNameMap: Partial<Record<string, EngineNames>> = {
+        luxtts:           { model: 'luxtts',          display: 'LuxTTS' },
+        chatterbox:       { model: 'chatterbox-tts',  display: 'Chatterbox TTS' },
+        chatterbox_turbo: { model: 'chatterbox-turbo', display: 'Chatterbox Turbo' },
+        kokoro:           { model: 'kokoro',           display: 'Kokoro 82M' },
+        moss_tts_nano:    { model: 'moss-tts-nano',    display: 'MOSS-TTS-Nano' },
+      };
+
+      const resolveNames = (eng: string): EngineNames => {
+        const fixed = engineNameMap[eng];
+        if (fixed) return fixed;
+        if (eng === 'tada') {
+          return data.modelSize === '3B'
+            ? { model: 'tada-3b-ml',  display: 'TADA 3B Multilingual' }
+            : { model: 'tada-1b',     display: 'TADA 1B' };
+        }
+        if (eng === 'qwen_custom_voice') {
+          return {
+            model: `qwen-custom-voice-${data.modelSize}`,
+            display: data.modelSize === '1.7B' ? 'Qwen CustomVoice 1.7B' : 'Qwen CustomVoice 0.6B',
+          };
+        }
+        return {
+          model: `qwen-tts-${data.modelSize}`,
+          display: data.modelSize === '1.7B' ? 'Qwen TTS 1.7B' : 'Qwen TTS 0.6B',
+        };
+      };
+
+      const { model: modelName, display: displayName } = resolveNames(engine);
 
       // Check if model needs downloading
       try {

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -27,6 +27,7 @@ const generationSchema = z.object({
       'chatterbox_turbo',
       'tada',
       'kokoro',
+      'moss_tts_nano',
     ])
     .optional(),
 });
@@ -97,7 +98,9 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'tada-1b'
                 : engine === 'kokoro'
                   ? 'kokoro'
-                  : engine === 'qwen_custom_voice'
+                  : engine === 'moss_tts_nano'
+                    ? 'moss-tts-nano'
+                    : engine === 'qwen_custom_voice'
                     ? `qwen-custom-voice-${data.modelSize}`
                     : `qwen-tts-${data.modelSize}`;
       const displayName =
@@ -113,7 +116,9 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'TADA 1B'
                 : engine === 'kokoro'
                   ? 'Kokoro 82M'
-                  : engine === 'qwen_custom_voice'
+                  : engine === 'moss_tts_nano'
+                    ? 'MOSS-TTS-Nano'
+                    : engine === 'qwen_custom_voice'
                     ? data.modelSize === '1.7B'
                       ? 'Qwen CustomVoice 1.7B'
                       : 'Qwen CustomVoice 0.6B'

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -13,6 +13,8 @@ import numpy as np
 
 from ..utils.platform_detect import get_backend_type
 
+MOSS_TTS_NANO_HF_REPO = "OpenMOSS-Team/MOSS-TTS-Nano"
+
 LANGUAGE_CODE_TO_NAME = {
     "zh": "chinese",
     "en": "english",
@@ -169,6 +171,7 @@ TTS_ENGINES = {
     "chatterbox_turbo": "Chatterbox Turbo",
     "tada": "TADA",
     "kokoro": "Kokoro",
+    "moss_tts_nano": "MOSS-TTS-Nano",
 }
 
 
@@ -313,6 +316,18 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             hf_repo_id="hexgrad/Kokoro-82M",
             size_mb=350,
             languages=["en", "es", "fr", "hi", "it", "pt", "ja", "zh"],
+        ),
+        ModelConfig(
+            model_name="moss-tts-nano",
+            display_name="MOSS-TTS-Nano (0.1B, CPU)",
+            engine="moss_tts_nano",
+            hf_repo_id=MOSS_TTS_NANO_HF_REPO,
+            size_mb=400,
+            languages=[
+                "zh", "en", "de", "es", "fr", "ja", "it",
+                "hu", "ko", "ru", "fa", "ar", "pl", "pt",
+                "cs", "da", "sv", "el", "tr",
+            ],
         ),
     ]
 
@@ -575,6 +590,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 
             backend = QwenCustomVoiceBackend()
+        elif engine == "moss_tts_nano":
+            from .moss_tts_nano_backend import MOSSTTSNanoBackend
+
+            backend = MOSSTTSNanoBackend()
         else:
             raise ValueError(f"Unknown TTS engine: {engine}. Supported: {list(TTS_ENGINES.keys())}")
 

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -5,6 +5,18 @@ Wraps NanoTTSService from moss-tts-nano for zero-shot voice cloning.
 0.1B parameters, 48 kHz stereo output, 20 languages, CPU-friendly.
 WeTextProcessing is optional (Chinese text normalization); if absent,
 the tts_robust_normalizer_single_script fallback is used instead.
+
+Concurrency model
+-----------------
+``_service_lock``       – guards reads/writes of ``_service`` and ``_device``,
+                          and serialises ``_load_model_sync``.
+``_active_generations`` – count of synthesis calls currently in flight.
+``_idle``               – Condition (backed by ``_service_lock``) that
+                          ``unload_model`` waits on until the count reaches zero.
+
+Concurrent generations run without holding ``_service_lock`` for the duration
+of the actual ``synthesize()`` call, so throughput is not artificially capped.
+``unload_model`` waits for all in-flight calls to finish before tearing down.
 """
 
 import asyncio
@@ -37,11 +49,13 @@ class MOSSTTSNanoBackend:
     """MOSS-TTS-Nano backend — 0.1B, 48 kHz stereo, 20 languages, CPU-friendly."""
 
     def __init__(self):
-        """Initialise locks and service state; no model is loaded yet."""
+        """Initialise locks, counters, and service state; no model is loaded yet."""
         self._service = None
         self._device = None
         self._model_load_lock = asyncio.Lock()
         self._service_lock = threading.RLock()
+        self._active_generations: int = 0
+        self._idle = threading.Condition(self._service_lock)
 
     def _get_device(self) -> str:
         """Return the best available torch device (CUDA > MPS > XPU > CPU)."""
@@ -107,14 +121,24 @@ class MOSSTTSNanoBackend:
         logger.info("MOSS-TTS-Nano loaded successfully")
 
     def unload_model(self) -> None:
-        """Unload model and free memory, guarded by _service_lock."""
-        with self._service_lock:
-            if self._service is not None:
-                device = self._device
-                self._service = None
-                self._device = None
-                empty_device_cache(device)
-                logger.info("MOSS-TTS-Nano unloaded")
+        """
+        Unload the model and free device memory.
+
+        Waits for all in-flight ``synthesize`` calls to finish before
+        tearing down ``_service`` so that concurrent generations are never
+        interrupted mid-synthesis.
+        """
+        with self._idle:
+            if self._service is None:
+                return
+            # Wait until every concurrent generation has decremented the counter.
+            self._idle.wait_for(lambda: self._active_generations == 0)
+            device = self._device
+            self._service = None
+            self._device = None
+
+        empty_device_cache(device)
+        logger.info("MOSS-TTS-Nano unloaded")
 
     async def create_voice_prompt(
         self,
@@ -160,7 +184,7 @@ class MOSSTTSNanoBackend:
 
         Args:
             text: Text to synthesize.
-            voice_prompt: Dict with ref_audio path.
+            voice_prompt: Dict with ref_audio path and optional ref_text.
             language: BCP-47 language code (ignored at inference; language
                       is inferred from the model's multilingual tokenizer).
             seed: Optional random seed for reproducibility.
@@ -168,6 +192,10 @@ class MOSSTTSNanoBackend:
 
         Returns:
             Tuple of (mono_audio_float32, sample_rate).
+
+        Raises:
+            FileNotFoundError: If ref_audio is provided but the file is missing.
+            RuntimeError: If the service was unloaded between load and generate.
         """
         await self.load_model()
 
@@ -182,20 +210,28 @@ class MOSSTTSNanoBackend:
             """
             Run synthesis on a thread-pool worker.
 
-            Acquires _service_lock to prevent a concurrent unload from
-            invalidating the service reference mid-inference.
+            Increments ``_active_generations`` under ``_service_lock``,
+            releases the lock, calls ``synthesize`` without holding it
+            (so concurrent generations can proceed in parallel), then
+            re-acquires the lock to decrement the counter and notify
+            any waiting ``unload_model`` call.
             """
-            with self._service_lock:
+            # --- register as active, grab local refs ---
+            with self._idle:
                 service = self._service
                 device = self._device
                 if service is None:
                     raise RuntimeError("MOSS-TTS-Nano service is not loaded")
+                self._active_generations += 1
 
+            try:
                 if seed is not None:
                     manual_seed(seed, device)
 
                 logger.info(f"[MOSS-TTS-Nano] Generating: lang={language}")
 
+                # synthesize() runs WITHOUT holding _service_lock so that
+                # concurrent requests are not serialised.
                 result = service.synthesize(
                     text=text,
                     prompt_audio_path=ref_audio,
@@ -203,6 +239,11 @@ class MOSSTTSNanoBackend:
                     mode="voice_clone" if ref_audio else "continuation",
                     seed=seed,
                 )
+            finally:
+                # --- deregister and wake any pending unload ---
+                with self._idle:
+                    self._active_generations -= 1
+                    self._idle.notify_all()
 
             waveform: np.ndarray = result["waveform_numpy"]
             sample_rate: int = int(result["sample_rate"])

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -1,0 +1,177 @@
+"""
+MOSS-TTS-Nano backend implementation.
+
+Wraps NanoTTSService from moss-tts-nano for zero-shot voice cloning.
+0.1B parameters, 48 kHz stereo output, 20 languages, CPU-friendly.
+WeTextProcessing is optional (Chinese text normalization); if absent,
+the tts_robust_normalizer_single_script fallback is used instead.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from . import TTSBackend
+from .base import (
+    is_model_cached,
+    get_torch_device,
+    empty_device_cache,
+    manual_seed,
+    combine_voice_prompts as _combine_voice_prompts,
+    model_load_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+MOSS_TTS_NANO_HF_REPO = "OpenMOSS-Team/MOSS-TTS-Nano"
+MOSS_AUDIO_TOKENIZER_HF_REPO = "OpenMOSS-Team/MOSS-Audio-Tokenizer-Nano"
+
+_REQUIRED_WEIGHT_FILES = ["model.safetensors"]
+
+
+class MOSSTTSNanoBackend:
+    """MOSS-TTS-Nano backend — 0.1B, 48 kHz stereo, 20 languages, CPU-friendly."""
+
+    def __init__(self):
+        self._service = None
+        self._device = None
+        self._model_load_lock = asyncio.Lock()
+
+    def _get_device(self) -> str:
+        return get_torch_device(allow_mps=True, allow_xpu=True)
+
+    def is_loaded(self) -> bool:
+        return self._service is not None
+
+    def _get_model_path(self, model_size: str = "default") -> str:
+        return MOSS_TTS_NANO_HF_REPO
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        return is_model_cached(
+            MOSS_TTS_NANO_HF_REPO,
+            required_files=_REQUIRED_WEIGHT_FILES,
+        )
+
+    async def load_model(self, model_size: str = "default") -> None:
+        """Load MOSS-TTS-Nano model."""
+        if self._service is not None:
+            return
+        async with self._model_load_lock:
+            if self._service is not None:
+                return
+            await asyncio.to_thread(self._load_model_sync)
+
+    def _load_model_sync(self) -> None:
+        """Synchronous model loading."""
+        model_name = "moss-tts-nano"
+        is_cached = self._is_model_cached()
+
+        with model_load_progress(model_name, is_cached):
+            device = self._get_device()
+            self._device = device
+            logger.info(f"Loading MOSS-TTS-Nano on {device}...")
+
+            from moss_tts_nano_runtime import NanoTTSService
+
+            service = NanoTTSService(
+                checkpoint_path=MOSS_TTS_NANO_HF_REPO,
+                audio_tokenizer_path=MOSS_AUDIO_TOKENIZER_HF_REPO,
+                device=device,
+                dtype="auto",
+            )
+            service.load()
+            self._service = service
+
+        logger.info("MOSS-TTS-Nano loaded successfully")
+
+    def unload_model(self) -> None:
+        """Unload model and free memory."""
+        if self._service is not None:
+            device = self._device
+            del self._service
+            self._service = None
+            self._device = None
+            empty_device_cache(device)
+            logger.info("MOSS-TTS-Nano unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> Tuple[dict, bool]:
+        """
+        Create voice prompt from reference audio.
+
+        MOSS-TTS-Nano processes reference audio at generation time
+        (voice_clone mode), so the prompt stores the file path.
+        """
+        voice_prompt = {
+            "ref_audio": str(audio_path),
+            "ref_text": reference_text,
+        }
+        return voice_prompt, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: List[str],
+        reference_texts: List[str],
+    ) -> Tuple[np.ndarray, str]:
+        return await _combine_voice_prompts(audio_paths, reference_texts)
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> Tuple[np.ndarray, int]:
+        """
+        Generate audio using MOSS-TTS-Nano voice cloning.
+
+        Args:
+            text: Text to synthesize.
+            voice_prompt: Dict with ref_audio path.
+            language: BCP-47 language code (ignored at inference; language
+                      is inferred from the model's multilingual tokenizer).
+            seed: Optional random seed for reproducibility.
+            instruct: Unused (protocol compatibility).
+
+        Returns:
+            Tuple of (mono_audio_float32, sample_rate).
+        """
+        await self.load_model()
+
+        ref_audio = voice_prompt.get("ref_audio")
+        if ref_audio and not Path(ref_audio).exists():
+            logger.warning(f"Reference audio not found: {ref_audio}")
+            ref_audio = None
+
+        def _generate_sync() -> Tuple[np.ndarray, int]:
+            if seed is not None:
+                manual_seed(seed, self._device)
+
+            logger.info(f"[MOSS-TTS-Nano] Generating: lang={language}")
+
+            result = self._service.synthesize(
+                text=text,
+                prompt_audio_path=ref_audio,
+                mode="voice_clone" if ref_audio else "continuation",
+                seed=seed,
+            )
+
+            waveform: np.ndarray = result["waveform_numpy"]
+            sample_rate: int = int(result["sample_rate"])
+
+            # Convert stereo (samples, 2) → mono (samples,)
+            if waveform.ndim == 2:
+                waveform = waveform.mean(axis=1)
+
+            audio = waveform.astype(np.float32)
+            return audio, sample_rate
+
+        return await asyncio.to_thread(_generate_sync)

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import threading
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -108,7 +108,7 @@ class MOSSTTSNanoBackend:
         audio_path: str,
         reference_text: str,
         use_cache: bool = True,
-    ) -> Tuple[dict, bool]:
+    ) -> tuple[dict, bool]:
         """
         Create voice prompt from reference audio.
 
@@ -123,9 +123,9 @@ class MOSSTTSNanoBackend:
 
     async def combine_voice_prompts(
         self,
-        audio_paths: List[str],
-        reference_texts: List[str],
-    ) -> Tuple[np.ndarray, str]:
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
         return await _combine_voice_prompts(audio_paths, reference_texts)
 
     async def generate(
@@ -135,7 +135,7 @@ class MOSSTTSNanoBackend:
         language: str = "en",
         seed: Optional[int] = None,
         instruct: Optional[str] = None,
-    ) -> Tuple[np.ndarray, int]:
+    ) -> tuple[np.ndarray, int]:
         """
         Generate audio using MOSS-TTS-Nano voice cloning.
 
@@ -159,7 +159,7 @@ class MOSSTTSNanoBackend:
             ref_audio = None
             ref_text = None
 
-        def _generate_sync() -> Tuple[np.ndarray, int]:
+        def _generate_sync() -> tuple[np.ndarray, int]:
             with self._service_lock:
                 service = self._service
                 device = self._device

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -8,15 +8,18 @@ the tts_robust_normalizer_single_script fallback is used instead.
 
 Concurrency model
 -----------------
-``_service_lock``       – guards reads/writes of ``_service`` and ``_device``,
+``_service_lock``       - guards reads/writes of ``_service`` and ``_device``,
                           and serialises ``_load_model_sync``.
-``_active_generations`` – count of synthesis calls currently in flight.
-``_idle``               – Condition (backed by ``_service_lock``) that
+``_active_generations`` - count of synthesis calls currently in flight.
+``_unloading``          - flag set by ``unload_model`` to close the generation
+                          gate before waiting for in-flight calls to drain.
+``_idle``               - Condition (backed by ``_service_lock``) that
                           ``unload_model`` waits on until the count reaches zero.
 
 Concurrent generations run without holding ``_service_lock`` for the duration
 of the actual ``synthesize()`` call, so throughput is not artificially capped.
-``unload_model`` waits for all in-flight calls to finish before tearing down.
+``unload_model`` sets ``_unloading`` first, then waits for the counter to reach
+zero, preventing new generations from starting after teardown begins.
 """
 
 import asyncio
@@ -32,7 +35,6 @@ from .base import (
     is_model_cached,
     get_torch_device,
     empty_device_cache,
-    manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -46,7 +48,7 @@ _REQUIRED_WEIGHT_FILES = ["model.safetensors"]
 
 
 class MOSSTTSNanoBackend:
-    """MOSS-TTS-Nano backend — 0.1B, 48 kHz stereo, 20 languages, CPU-friendly."""
+    """MOSS-TTS-Nano backend - 0.1B, 48 kHz stereo, 20 languages, CPU-friendly."""
 
     def __init__(self):
         """Initialise locks, counters, and service state; no model is loaded yet."""
@@ -55,6 +57,7 @@ class MOSSTTSNanoBackend:
         self._model_load_lock = asyncio.Lock()
         self._service_lock = threading.RLock()
         self._active_generations: int = 0
+        self._unloading: bool = False
         self._idle = threading.Condition(self._service_lock)
 
     def _get_device(self) -> str:
@@ -124,18 +127,23 @@ class MOSSTTSNanoBackend:
         """
         Unload the model and free device memory.
 
-        Waits for all in-flight ``synthesize`` calls to finish before
-        tearing down ``_service`` so that concurrent generations are never
-        interrupted mid-synthesis.
+        Sets ``_unloading`` to close the generation gate, then waits for all
+        in-flight ``synthesize`` calls to finish before tearing down
+        ``_service``, so that no new generations can start and no running
+        synthesis is interrupted mid-call.
         """
         with self._idle:
             if self._service is None:
                 return
-            # Wait until every concurrent generation has decremented the counter.
-            self._idle.wait_for(lambda: self._active_generations == 0)
-            device = self._device
-            self._service = None
-            self._device = None
+            self._unloading = True
+            try:
+                self._idle.wait_for(lambda: self._active_generations == 0)
+                device = self._device
+                self._service = None
+                self._device = None
+            finally:
+                self._unloading = False
+                self._idle.notify_all()
 
         empty_device_cache(device)
         logger.info("MOSS-TTS-Nano unloaded")
@@ -187,7 +195,7 @@ class MOSSTTSNanoBackend:
             voice_prompt: Dict with ref_audio path and optional ref_text.
             language: BCP-47 language code (ignored at inference; language
                       is inferred from the model's multilingual tokenizer).
-            seed: Optional random seed for reproducibility.
+            seed: Optional random seed passed directly to synthesize().
             instruct: Unused (protocol compatibility).
 
         Returns:
@@ -195,10 +203,8 @@ class MOSSTTSNanoBackend:
 
         Raises:
             FileNotFoundError: If ref_audio is provided but the file is missing.
-            RuntimeError: If the service was unloaded between load and generate.
+            RuntimeError: If the service is unloaded or unloading.
         """
-        await self.load_model()
-
         ref_audio = voice_prompt.get("ref_audio")
         ref_text = voice_prompt.get("ref_text")
         if ref_audio and not Path(ref_audio).exists():
@@ -206,32 +212,32 @@ class MOSSTTSNanoBackend:
                 f"MOSS-TTS-Nano reference audio not found: {ref_audio}"
             )
 
+        await self.load_model()
+
         def _generate_sync() -> tuple[np.ndarray, int]:
             """
             Run synthesis on a thread-pool worker.
 
-            Increments ``_active_generations`` under ``_service_lock``,
-            releases the lock, calls ``synthesize`` without holding it
-            (so concurrent generations can proceed in parallel), then
-            re-acquires the lock to decrement the counter and notify
-            any waiting ``unload_model`` call.
+            Checks ``_unloading`` and increments ``_active_generations`` under
+            ``_idle``, then releases the lock and calls ``synthesize`` without
+            holding it (so concurrent requests run in parallel). Re-acquires
+            the lock to decrement the counter and notify any waiting
+            ``unload_model`` call.
             """
-            # --- register as active, grab local refs ---
             with self._idle:
                 service = self._service
                 device = self._device
-                if service is None:
+                if service is None or self._unloading:
                     raise RuntimeError("MOSS-TTS-Nano service is not loaded")
                 self._active_generations += 1
 
             try:
-                if seed is not None:
-                    manual_seed(seed, device)
-
                 logger.info(f"[MOSS-TTS-Nano] Generating: lang={language}")
 
                 # synthesize() runs WITHOUT holding _service_lock so that
-                # concurrent requests are not serialised.
+                # concurrent requests are not serialised. seed is forwarded
+                # to the service rather than calling process-global manual_seed,
+                # which would corrupt RNG state of concurrent generations.
                 result = service.synthesize(
                     text=text,
                     prompt_audio_path=ref_audio,
@@ -240,7 +246,6 @@ class MOSSTTSNanoBackend:
                     seed=seed,
                 )
             finally:
-                # --- deregister and wake any pending unload ---
                 with self._idle:
                     self._active_generations -= 1
                     self._idle.notify_all()
@@ -248,7 +253,7 @@ class MOSSTTSNanoBackend:
             waveform: np.ndarray = result["waveform_numpy"]
             sample_rate: int = int(result["sample_rate"])
 
-            # Convert stereo (samples, 2) → mono (samples,)
+            # Convert stereo (samples, 2) -> mono (samples,)
             if waveform.ndim == 2:
                 waveform = waveform.mean(axis=1)
 

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -88,12 +88,26 @@ class MOSSTTSNanoBackend:
 
         Uses an asyncio.Lock to serialise concurrent load requests so that
         only one worker thread initialises the service.
+
+        Raises:
+            RuntimeError: If ``unload_model`` is currently draining in-flight
+                generations; callers should retry after the unload completes.
         """
-        if self._service is not None:
-            return
-        async with self._model_load_lock:
+        with self._idle:
+            if self._unloading:
+                raise RuntimeError(
+                    "MOSS-TTS-Nano is currently unloading; retry after unload completes"
+                )
             if self._service is not None:
                 return
+        async with self._model_load_lock:
+            with self._idle:
+                if self._unloading:
+                    raise RuntimeError(
+                        "MOSS-TTS-Nano is currently unloading; retry after unload completes"
+                    )
+                if self._service is not None:
+                    return
             await asyncio.to_thread(self._load_model_sync)
 
     def _load_model_sync(self) -> None:

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -53,7 +53,7 @@ class MOSSTTSNanoBackend:
         return is_model_cached(
             MOSS_TTS_NANO_HF_REPO,
             required_files=_REQUIRED_WEIGHT_FILES,
-        )
+        ) and is_model_cached(MOSS_AUDIO_TOKENIZER_HF_REPO)
 
     async def load_model(self, model_size: str = "default") -> None:
         """Load MOSS-TTS-Nano model."""
@@ -147,9 +147,11 @@ class MOSSTTSNanoBackend:
         await self.load_model()
 
         ref_audio = voice_prompt.get("ref_audio")
+        ref_text = voice_prompt.get("ref_text")
         if ref_audio and not Path(ref_audio).exists():
             logger.warning(f"Reference audio not found: {ref_audio}")
             ref_audio = None
+            ref_text = None
 
         def _generate_sync() -> Tuple[np.ndarray, int]:
             if seed is not None:
@@ -160,6 +162,7 @@ class MOSSTTSNanoBackend:
             result = self._service.synthesize(
                 text=text,
                 prompt_audio_path=ref_audio,
+                prompt_text=ref_text,
                 mode="voice_clone" if ref_audio else "continuation",
                 seed=seed,
             )

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -27,7 +27,7 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
-MOSS_TTS_NANO_HF_REPO = "OpenMOSS-Team/MOSS-TTS-Nano"
+MOSS_TTS_NANO_HF_REPO = "OpenMOSS-Team/MOSS-TTS-Nano-100M"
 MOSS_AUDIO_TOKENIZER_HF_REPO = "OpenMOSS-Team/MOSS-Audio-Tokenizer-Nano"
 
 _REQUIRED_WEIGHT_FILES = ["model.safetensors"]
@@ -37,28 +37,41 @@ class MOSSTTSNanoBackend:
     """MOSS-TTS-Nano backend — 0.1B, 48 kHz stereo, 20 languages, CPU-friendly."""
 
     def __init__(self):
+        """Initialise locks and service state; no model is loaded yet."""
         self._service = None
         self._device = None
         self._model_load_lock = asyncio.Lock()
         self._service_lock = threading.RLock()
 
     def _get_device(self) -> str:
+        """Return the best available torch device (CUDA > MPS > XPU > CPU)."""
         return get_torch_device(allow_mps=True, allow_xpu=True)
 
     def is_loaded(self) -> bool:
+        """Return True if the NanoTTSService has been initialised."""
         return self._service is not None
 
     def _get_model_path(self, model_size: str = "default") -> str:
+        """Return the HuggingFace repo ID used as the checkpoint path."""
         return MOSS_TTS_NANO_HF_REPO
 
     def _is_model_cached(self, model_size: str = "default") -> bool:
+        """
+        Return True only when both the model checkpoint and the audio
+        tokenizer are present in the local HuggingFace cache.
+        """
         return is_model_cached(
             MOSS_TTS_NANO_HF_REPO,
             required_files=_REQUIRED_WEIGHT_FILES,
         ) and is_model_cached(MOSS_AUDIO_TOKENIZER_HF_REPO)
 
     async def load_model(self, model_size: str = "default") -> None:
-        """Load MOSS-TTS-Nano model."""
+        """
+        Async entry-point for model loading.
+
+        Uses an asyncio.Lock to serialise concurrent load requests so that
+        only one worker thread initialises the service.
+        """
         if self._service is not None:
             return
         async with self._model_load_lock:
@@ -126,6 +139,12 @@ class MOSSTTSNanoBackend:
         audio_paths: list[str],
         reference_texts: list[str],
     ) -> tuple[np.ndarray, str]:
+        """
+        Merge multiple reference audio clips into a single voice prompt.
+
+        Delegates to the shared base helper so that all backends handle
+        multi-sample prompts consistently.
+        """
         return await _combine_voice_prompts(audio_paths, reference_texts)
 
     async def generate(
@@ -155,11 +174,17 @@ class MOSSTTSNanoBackend:
         ref_audio = voice_prompt.get("ref_audio")
         ref_text = voice_prompt.get("ref_text")
         if ref_audio and not Path(ref_audio).exists():
-            logger.warning(f"Reference audio not found: {ref_audio}")
-            ref_audio = None
-            ref_text = None
+            raise FileNotFoundError(
+                f"MOSS-TTS-Nano reference audio not found: {ref_audio}"
+            )
 
         def _generate_sync() -> tuple[np.ndarray, int]:
+            """
+            Run synthesis on a thread-pool worker.
+
+            Acquires _service_lock to prevent a concurrent unload from
+            invalidating the service reference mid-inference.
+            """
             with self._service_lock:
                 service = self._service
                 device = self._device

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -9,6 +9,7 @@ the tts_robust_normalizer_single_script fallback is used instead.
 
 import asyncio
 import logging
+import threading
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -39,6 +40,7 @@ class MOSSTTSNanoBackend:
         self._service = None
         self._device = None
         self._model_load_lock = asyncio.Lock()
+        self._service_lock = threading.RLock()
 
     def _get_device(self) -> str:
         return get_torch_device(allow_mps=True, allow_xpu=True)
@@ -65,37 +67,41 @@ class MOSSTTSNanoBackend:
             await asyncio.to_thread(self._load_model_sync)
 
     def _load_model_sync(self) -> None:
-        """Synchronous model loading."""
+        """Synchronous model loading, protected by _service_lock."""
         model_name = "moss-tts-nano"
         is_cached = self._is_model_cached()
 
-        with model_load_progress(model_name, is_cached):
-            device = self._get_device()
-            self._device = device
-            logger.info(f"Loading MOSS-TTS-Nano on {device}...")
+        with self._service_lock:
+            if self._service is not None:
+                return
 
-            from moss_tts_nano_runtime import NanoTTSService
+            with model_load_progress(model_name, is_cached):
+                device = self._get_device()
+                self._device = device
+                logger.info(f"Loading MOSS-TTS-Nano on {device}...")
 
-            service = NanoTTSService(
-                checkpoint_path=MOSS_TTS_NANO_HF_REPO,
-                audio_tokenizer_path=MOSS_AUDIO_TOKENIZER_HF_REPO,
-                device=device,
-                dtype="auto",
-            )
-            service.load()
-            self._service = service
+                from moss_tts_nano_runtime import NanoTTSService
+
+                service = NanoTTSService(
+                    checkpoint_path=MOSS_TTS_NANO_HF_REPO,
+                    audio_tokenizer_path=MOSS_AUDIO_TOKENIZER_HF_REPO,
+                    device=device,
+                    dtype="auto",
+                )
+                service.load()
+                self._service = service
 
         logger.info("MOSS-TTS-Nano loaded successfully")
 
     def unload_model(self) -> None:
-        """Unload model and free memory."""
-        if self._service is not None:
-            device = self._device
-            del self._service
-            self._service = None
-            self._device = None
-            empty_device_cache(device)
-            logger.info("MOSS-TTS-Nano unloaded")
+        """Unload model and free memory, guarded by _service_lock."""
+        with self._service_lock:
+            if self._service is not None:
+                device = self._device
+                self._service = None
+                self._device = None
+                empty_device_cache(device)
+                logger.info("MOSS-TTS-Nano unloaded")
 
     async def create_voice_prompt(
         self,
@@ -154,18 +160,24 @@ class MOSSTTSNanoBackend:
             ref_text = None
 
         def _generate_sync() -> Tuple[np.ndarray, int]:
-            if seed is not None:
-                manual_seed(seed, self._device)
+            with self._service_lock:
+                service = self._service
+                device = self._device
+                if service is None:
+                    raise RuntimeError("MOSS-TTS-Nano service is not loaded")
 
-            logger.info(f"[MOSS-TTS-Nano] Generating: lang={language}")
+                if seed is not None:
+                    manual_seed(seed, device)
 
-            result = self._service.synthesize(
-                text=text,
-                prompt_audio_path=ref_audio,
-                prompt_text=ref_text,
-                mode="voice_clone" if ref_audio else "continuation",
-                seed=seed,
-            )
+                logger.info(f"[MOSS-TTS-Nano] Generating: lang={language}")
+
+                result = service.synthesize(
+                    text=text,
+                    prompt_audio_path=ref_audio,
+                    prompt_text=ref_text,
+                    mode="voice_clone" if ref_audio else "continuation",
+                    seed=seed,
+                )
 
             waveform: np.ndarray = result["waveform_numpy"]
             sample_rate: int = int(result["sample_rate"])

--- a/backend/backends/moss_tts_nano_backend.py
+++ b/backend/backends/moss_tts_nano_backend.py
@@ -89,17 +89,23 @@ class MOSSTTSNanoBackend:
         Uses an asyncio.Lock to serialise concurrent load requests so that
         only one worker thread initialises the service.
 
+        The outer check is intentionally lockless: Python attribute reads are
+        atomic and the authoritative re-check under ``_idle`` inside
+        ``_model_load_lock`` still guards against races with ``unload_model``.
+        Acquiring ``_idle`` (a threading lock) on the event-loop thread would
+        block the loop while a worker thread holds it during ``_load_model_sync``.
+
         Raises:
             RuntimeError: If ``unload_model`` is currently draining in-flight
                 generations; callers should retry after the unload completes.
         """
-        with self._idle:
-            if self._unloading:
-                raise RuntimeError(
-                    "MOSS-TTS-Nano is currently unloading; retry after unload completes"
-                )
-            if self._service is not None:
-                return
+        # Lockless fast-path — safe because the inner double-check is authoritative.
+        if self._unloading:
+            raise RuntimeError(
+                "MOSS-TTS-Nano is currently unloading; retry after unload completes"
+            )
+        if self._service is not None:
+            return
         async with self._model_load_lock:
             with self._idle:
                 if self._unloading:
@@ -267,9 +273,9 @@ class MOSSTTSNanoBackend:
             waveform: np.ndarray = result["waveform_numpy"]
             sample_rate: int = int(result["sample_rate"])
 
-            # Convert stereo (samples, 2) -> mono (samples,)
+            # Convert channels-first (channels, samples) -> mono (samples,)
             if waveform.ndim == 2:
-                waveform = waveform.mean(axis=1)
+                waveform = waveform.mean(axis=0)
 
             audio = waveform.astype(np.float32)
             return audio, sample_rate

--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -289,6 +289,27 @@ def build_server(cuda=False):
             "en_core_web_sm",
             "--hidden-import",
             "loguru",
+            # MOSS-TTS-Nano — 0.1B multilingual TTS, CPU-friendly, Apache 2.0
+            # collect-all is required to bundle assets/audio/*.wav preset files
+            # and the top-level py-modules (moss_tts_nano_runtime,
+            # text_normalization_pipeline, tts_robust_normalizer_single_script)
+            # that PyInstaller's static analysis does not discover automatically.
+            "--hidden-import",
+            "backend.backends.moss_tts_nano_backend",
+            "--hidden-import",
+            "moss_tts_nano",
+            "--hidden-import",
+            "moss_tts_nano.cli",
+            "--hidden-import",
+            "moss_tts_nano_runtime",
+            "--hidden-import",
+            "tts_robust_normalizer_single_script",
+            "--hidden-import",
+            "text_normalization_pipeline",
+            "--collect-all",
+            "moss_tts_nano",
+            "--copy-metadata",
+            "moss-tts-nano",
         ]
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,7 +13,7 @@ class VoiceProfileCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
     language: str = Field(
-        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|hu|fa|cs)$"
     )
     voice_type: Optional[str] = Field(default="cloned", pattern="^(cloned|preset|designed)$")
     preset_engine: Optional[str] = Field(None, max_length=50)
@@ -74,11 +74,11 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$")
+    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|hu|fa|cs)$")
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|moss_tts_nano)$")
     max_chunk_chars: int = Field(
         default=800, ge=100, le=5000, description="Max characters per chunk for long text splitting"
     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,8 +49,9 @@ en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_
 
 # MOSS-TTS-Nano (0.1B multilingual TTS, CPU-friendly, Apache 2.0)
 # Installed --no-deps in setup scripts because it pins torch==2.7.0
-# Sub-dependency sentencepiece is listed here explicitly
+# Sub-dependencies listed explicitly (not pulled transitively via --no-deps):
 sentencepiece>=0.1.99
+WeTextProcessing>=1.0.4.1
 
 # Audio processing
 librosa>=0.10.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -47,6 +47,11 @@ misaki[en,ja,zh]>=0.9.4
 # tries spacy.cli.download() at runtime which crashes frozen builds
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
+# MOSS-TTS-Nano (0.1B multilingual TTS, CPU-friendly, Apache 2.0)
+# Installed --no-deps in setup scripts because it pins torch==2.7.0
+# Sub-dependency sentencepiece is listed here explicitly
+sentencepiece>=0.1.99
+
 # Audio processing
 librosa>=0.10.0
 soundfile>=0.12.0

--- a/justfile
+++ b/justfile
@@ -48,6 +48,8 @@ setup-python:
     {{ pip }} install --no-deps chatterbox-tts
     # HumeAI TADA pins torch>=2.7,<2.8 which conflicts with our torch>=2.1
     {{ pip }} install --no-deps hume-tada
+    # MOSS-TTS-Nano pins torch==2.7.0 which conflicts with our torch>=2.2
+    {{ pip }} install --no-deps git+https://github.com/OpenMOSS/MOSS-TTS-Nano.git
     # Apple Silicon: install MLX backend
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
@@ -89,6 +91,8 @@ setup-python:
     & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
     & "{{ pip }}" install --no-deps chatterbox-tts
     & "{{ pip }}" install --no-deps hume-tada
+    # MOSS-TTS-Nano pins torch==2.7.0 which conflicts with our torch>=2.2
+    & "{{ pip }}" install --no-deps git+https://github.com/OpenMOSS/MOSS-TTS-Nano.git
     & "{{ pip }}" install git+https://github.com/QwenLM/Qwen3-TTS.git
     & "{{ pip }}" install pyinstaller ruff pytest pytest-asyncio -q
     Write-Host "Python environment ready."


### PR DESCRIPTION
## Summary

Integrates **MOSS-TTS-Nano** ([OpenMOSS/MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano)) as a new TTS engine, following the `add-tts-engine` contribution guide phases 0–6.

### Why MOSS-TTS-Nano?

| Property | Value |
|---|---|
| Parameters | 0.1B |
| License | Apache 2.0 |
| Sample rate | 48 kHz stereo |
| Languages | 20 (zh/en/de/es/fr/ja/it/hu/ko/ru/fa/ar/pl/pt/cs/da/sv/el/tr) |
| CPU realtime | Yes (4 cores) |
| GPU support | Yes (CUDA/MPS/XPU) |
| Voice cloning | Yes (prompt audio + reference text) |

The model is the lightest multilingual option in the engine lineup at 0.1B parameters while covering more languages than any existing engine. Apache 2.0 licensed, with no `pynini`/`WeTextProcessing` hard dependency (graceful fallback).

### Changes

**Backend**
- `backend/backends/moss_tts_nano_backend.py` — new `MOSSTTSNanoBackend` implementing the `TTSBackend` protocol; stereo→mono conversion, async load/generate with `asyncio.to_thread`
- `backend/backends/__init__.py` — `TTS_ENGINES` entry, `ModelConfig` registry (400 MB, 19 languages), factory branch
- `backend/models.py` — extend `language` Pydantic pattern with `hu`/`fa`/`cs` (required by MOSS, were missing for all engines)
- `backend/requirements.txt` — add `sentencepiece` (sub-dep, not pulled transitively via `--no-deps`)
- `backend/build_binary.py` — PyInstaller `--hidden-import` + `--collect-all` + `--copy-metadata` directives
- `justfile` / `Dockerfile` — `pip install --no-deps` install to avoid `torch==2.7.0` pin conflict

**Frontend**
- `app/src/lib/api/types.ts` — engine union type
- `app/src/lib/constants/languages.ts` — add `cs`/`fa`/`hu` to `ALL_LANGUAGES`; `ENGINE_LANGUAGES.moss_tts_nano`
- `app/src/lib/hooks/useGenerationForm.ts` — Zod schema, `modelName`, `displayName`
- `app/src/components/Generation/EngineModelSelector.tsx` — engine option, description, `CLONING_ENGINES`
- `app/src/components/ServerSettings/ModelManagement.tsx` — model description, `voiceModels` filter

### Testing

- [x] Python syntax + import static check (all phases 1–5)
- [x] Pydantic `ModelConfig` round-trip validation
- [x] 22-point integration checklist (backend + frontend cross-verified)
- [x] Language codec coverage verified (`hu`/`fa`/`cs` accepted by `GenerationRequest`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MOSS‑TTS‑Nano as a selectable TTS engine with voice‑cloning support across the voice generation UI, model details, and generation requests/forms.
  * Voice profile cloning/compatibility updated to include the new engine.
  * Czech (cs), Persian (fa), and Hungarian (hu) added to language selectors for generation and profiles.

* **Chores**
  * Packaging, build, installer, and runtime steps updated to include MOSS‑TTS‑Nano runtime, assets, and required dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->