### PR TITLE
fix(backend): bundle unidic-lite for misaki Japanese G2P

### DIFF
--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -287,6 +287,12 @@ def build_server(cuda=False):
             "en_core_web_sm",
             "--hidden-import",
             "en_core_web_sm",
+            # unidic-lite ships the MeCab dictionary used by fugashi (pulled in
+            # by misaki[ja]). The dict lives in unidic_lite/dicdir/ and is
+            # discovered via the package's DICDIR constant, so the data files
+            # must be collected or Japanese Kokoro voices crash at runtime.
+            "--collect-all",
+            "unidic_lite",
             "--hidden-import",
             "loguru",
         ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,6 +46,11 @@ misaki[en,ja,zh]>=0.9.4
 # spacy model for misaki English G2P — must be pre-installed or misaki
 # tries spacy.cli.download() at runtime which crashes frozen builds
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+# fugashi (pulled in by misaki[ja]) needs a MeCab dictionary on disk.
+# unidic-lite ships one inside the wheel (~50MB); the full `unidic` package
+# requires `python -m unidic download` (~526MB) which breaks frozen builds
+# for the same reason en_core_web_sm does.
+unidic-lite>=1.0.8
 
 # Audio processing
 librosa>=0.10.0


### PR DESCRIPTION
## Summary

Fixes #514. Kokoro Japanese voices (`lang_code="j"`) crash on fresh `just setup` with:

```
RuntimeError: Failed initializing MeCab
param.cpp(69) [ifs] no such file or directory: ...\unidic\dicdir\mecabrc
```

`misaki[ja]` pulls in `fugashi`, which needs a MeCab dictionary on disk. The `unidic` package that gets installed ships no data — it expects `python -m unidic download` (~526MB) at runtime, which `just setup` doesn't run and which wouldn't survive PyInstaller anyway.

Swap to `unidic-lite`, which bundles a MeCab-compatible dict inside the wheel (~50MB). Collect it in `build_binary.py` so frozen builds also pick up `unidic_lite/dicdir/`.

Same shape as the existing `en_core_web_sm` pre-install — which was added for this exact class of problem on the English G2P path.

```diff
# backend/requirements.txt
+unidic-lite>=1.0.8

# backend/build_binary.py
+"--collect-all",
+"unidic_lite",
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ~50MB runtime dependency and changes PyInstaller collection rules, which can impact binary size and packaging behavior across platforms.
> 
> **Overview**
> Fixes crashes in Japanese Kokoro/misaki G2P by adding `unidic-lite` to `backend/requirements.txt` so a MeCab dictionary is available without a runtime download.
> 
> Updates the PyInstaller build (`backend/build_binary.py`) to `--collect-all unidic_lite`, ensuring frozen binaries include the bundled dictionary data needed at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f473c0039771b16274ca45d81c477fcaad7e37de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and dependencies to ensure Japanese language support is properly included in packaged application builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->