### PR TITLE
fix(release): notarize and staple macOS DMGs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,12 @@ jobs:
           TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([a-z0-9_-]*\).*/\1/p')
           DMG_DIR="tauri/src-tauri/target/${TARGET}/release/bundle/dmg"
           shopt -s nullglob
-          for dmg in "${DMG_DIR}"/*.dmg; do
+          dmgs=("${DMG_DIR}"/*.dmg)
+          if [ ${#dmgs[@]} -eq 0 ]; then
+            echo "::error::No DMGs found in ${DMG_DIR} — tauri bundler output path may have changed"
+            exit 1
+          fi
+          for dmg in "${dmgs[@]}"; do
             echo "::group::Notarize $(basename "$dmg")"
             xcrun notarytool submit "$dmg" \
               --key "$KEY_PATH" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,9 @@ jobs:
           KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
           TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([a-z0-9_-]*\).*/\1/p')
           DMG_DIR="tauri/src-tauri/target/${TARGET}/release/bundle/dmg"
+          # Match the release tag tauri-action resolved from tauri.conf.json's
+          # version field; GITHUB_REF_NAME is a branch name under workflow_dispatch.
+          RELEASE_TAG="v$(jq -r '.version' tauri/src-tauri/tauri.conf.json)"
           shopt -s nullglob
           dmgs=("${DMG_DIR}"/*.dmg)
           if [ ${#dmgs[@]} -eq 0 ]; then
@@ -258,7 +261,7 @@ jobs:
               --wait --timeout 20m
             xcrun stapler staple "$dmg"
             spctl -a -t open --context context:primary-signature -vv "$dmg"
-            gh release upload "${GITHUB_REF_NAME}" "$dmg" --clobber \
+            gh release upload "${RELEASE_TAG}" "$dmg" --clobber \
               --repo "${GITHUB_REPOSITORY}"
             echo "::endgroup::"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,38 @@ jobs:
           args: ${{ matrix.args }}
           includeUpdaterJson: true
 
+      # Tauri's bundler signs the .app and notarizes it, but the .dmg wrapper
+      # ships unnotarized. Gatekeeper rejects that on macOS 15 Sequoia (caught
+      # by Homebrew Cask CI) and causes "app isn't signed" dialogs on older
+      # Intel Macs when Apple's notarization servers are slow (see issue #509).
+      # Submit the .dmg to notarytool, staple the ticket, and overwrite the
+      # release asset uploaded by tauri-action.
+      - name: Notarize and staple DMG (macOS)
+        if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-15-intel'
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([a-z0-9_-]*\).*/\1/p')
+          DMG_DIR="tauri/src-tauri/target/${TARGET}/release/bundle/dmg"
+          shopt -s nullglob
+          for dmg in "${DMG_DIR}"/*.dmg; do
+            echo "::group::Notarize $(basename "$dmg")"
+            xcrun notarytool submit "$dmg" \
+              --key "$KEY_PATH" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait --timeout 20m
+            xcrun stapler staple "$dmg"
+            spctl -a -t open --context context:primary-signature -vv "$dmg"
+            gh release upload "${GITHUB_REF_NAME}" "$dmg" --clobber \
+              --repo "${GITHUB_REPOSITORY}"
+            echo "::endgroup::"
+          done
+
   build-cuda-windows:
     runs-on: windows-latest
     permissions:


### PR DESCRIPTION
## The bug

Tauri's bundler signs the `.app` and notarizes it, but ships the `.dmg` wrapper **unnotarized**. The `.app` inside has a stapled notarization ticket. The DMG itself does not.

This breaks real users on real macOS versions:

- **macOS 15 Sequoia** (one-version-behind, still widely used): Gatekeeper rejects the DMG outright. Users can't open the app without digging into System Settings > Privacy & Security. Fresh Sequoia users hit this every time.
- **Older Intel Macs on flaky networks** (issue #509): Gatekeeper falls back to contacting Apple's notarization servers at mount time to validate the app's ticket. When those calls time out or fail, users see "the app is not signed" dialogs even though it is.

Homebrew Cask CI surfaced this when PR [Homebrew/homebrew-cask#260314](https://github.com/Homebrew/homebrew-cask/pull/260314) (the `brew install voicebox` cask) ran against their test matrix:

| Runner | Result |
|--------|--------|
| macOS 14 Sonoma, arm | pass |
| macOS 14 Sonoma, intel | pass |
| **macOS 15 Sequoia, arm** | **fail** |
| **macOS 15 Sequoia, intel** | **fail** |
| macOS 26 Tahoe, arm | pass |
| macOS 26 Tahoe, intel | pass |

Both Sequoia runners fail with:

```
Scan completed, but failed because the software is not signed by a
distributor that meets the system Gatekeeper requirements.
```

Verified locally:

```
$ spctl -a -t open --context context:primary-signature -vv Voicebox_0.4.2_aarch64.dmg
rejected
source=Unnotarized Developer ID
origin=Developer ID Application: James Pine (YB4V2VA9YY)
```

## The fix

Add a post-bundle step to `release.yml` that submits each DMG to `notarytool`, staples the ticket, and overwrites the draft-release asset `tauri-action` already uploaded. Uses the same `APPLE_API_KEY` / `APPLE_API_ISSUER` secrets that are already wired up for `.app` notarization.

```yaml
- name: Notarize and staple DMG (macOS)
  if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-15-intel'
  env:
    APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY }}
    APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
    TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([a-z0-9_-]*\).*/\1/p')
    for dmg in tauri/src-tauri/target/"$TARGET"/release/bundle/dmg/*.dmg; do
      xcrun notarytool submit "$dmg" \
        --key "$KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
        --wait --timeout 20m
      xcrun stapler staple "$dmg"
      spctl -a -t open --context context:primary-signature -vv "$dmg"
      gh release upload "${GITHUB_REF_NAME}" "$dmg" --clobber \
        --repo "${GITHUB_REPOSITORY}"
    done
```

Adds ~5 to 10 minutes per macOS job for the notarytool round-trip. Windows and CUDA builds are untouched.

## Why Tauri doesn't already do this

Tauri 2.9.5's bundler calls `notarytool` on the `.app` before wrapping it in the DMG. It does not re-submit the DMG. That's fine if users only ever run the `.app` from a Gatekeeper-trusted source, but fails the moment macOS validates the DMG wrapper itself (install-time on Sequoia, offline validation fallback on older hardware).

## After this lands

Shipping 0.4.3 with this fix unblocks the Homebrew cask PR and closes issue #509. Existing in-app updater flows are unaffected (updater uses `.app.tar.gz`, which has the already-notarized `.app`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes the release pipeline on macOS by adding a `notarytool` round-trip and overwriting uploaded release assets, which can introduce new failure modes or timing issues in CI/release publishing.
> 
> **Overview**
> Adds a post-bundle step in `release.yml` to **submit generated macOS `.dmg` artifacts to Apple notarization, staple the ticket, verify with `spctl`, and re-upload the DMG to the GitHub release (clobbering the asset uploaded by `tauri-action`)** for both Apple Silicon and Intel macOS runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a6c99ecaf5115d0c5cbd39db761c1187240a4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a macOS-only release step that notarizes, staples, and verifies built disk images to meet Apple requirements.
  * After successful notarization, the workflow replaces release artifacts so macOS users receive verified installers; the job is scoped to macOS runners and fails if no macOS installer artifacts are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->