### PR TITLE
feat(generation): add Exaggeration and CFG Weight sliders for Chatterbox engine

### DIFF
--- a/app/src/components/Generation/GenerationForm.tsx
+++ b/app/src/components/Generation/GenerationForm.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Slider } from '@/components/ui/slider';
 import { getLanguageOptionsForEngine, type LanguageCode } from '@/lib/constants/languages';
 import { useGenerationForm } from '@/lib/hooks/useGenerationForm';
 import { useProfile } from '@/lib/hooks/useProfiles';
@@ -140,6 +141,65 @@ export function GenerationForm() {
                   </FormItem>
                 )}
               />
+            )}
+
+            {form.watch('engine') === 'chatterbox' && (
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="exaggeration"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex justify-between">
+                        <FormLabel>Exaggeration</FormLabel>
+                        <span className="text-sm text-muted-foreground">
+                          {(field.value ?? 0.5).toFixed(2)}
+                        </span>
+                      </div>
+                      <FormControl>
+                        <Slider
+                          value={[field.value ?? 0.5]}
+                          onValueChange={([v]) => field.onChange(v)}
+                          min={0}
+                          max={1}
+                          step={0.05}
+                          aria-label="Emotion exaggeration intensity"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Controls emotional expressiveness (0 = flat, 1 = highly expressive)
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="cfg_weight"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex justify-between">
+                        <FormLabel>CFG Weight</FormLabel>
+                        <span className="text-sm text-muted-foreground">
+                          {(field.value ?? 0.5).toFixed(2)}
+                        </span>
+                      </div>
+                      <FormControl>
+                        <Slider
+                          value={[field.value ?? 0.5]}
+                          onValueChange={([v]) => field.onChange(v)}
+                          min={0}
+                          max={1}
+                          step={0.05}
+                          aria-label="Classifier-free guidance weight"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Controls speech consistency (0 = loose/varied, 1 = tight/consistent)
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+              </div>
             )}
 
             <div className="grid gap-4 md:grid-cols-3">

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -71,6 +71,8 @@ export interface GenerationRequest {
     | 'tada'
     | 'kokoro';
   instruct?: string;
+  exaggeration?: number;
+  cfg_weight?: number;
   max_chunk_chars?: number;
   crossfade_ms?: number;
   normalize?: boolean;

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -18,6 +18,8 @@ const generationSchema = z.object({
   seed: z.number().int().optional(),
   modelSize: z.enum(['1.7B', '0.6B', '1B', '3B']).optional(),
   instruct: z.string().max(500).optional(),
+  exaggeration: z.number().min(0).max(1).optional(),
+  cfg_weight: z.number().min(0).max(1).optional(),
   engine: z
     .enum([
       'qwen',
@@ -64,6 +66,8 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
       seed: undefined,
       modelSize: '1.7B',
       instruct: '',
+      exaggeration: 0.5,
+      cfg_weight: 0.5,
       engine: (selectedEngine as GenerationFormValues['engine']) || 'qwen',
       ...options.defaultValues,
     },
@@ -139,6 +143,7 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
       // Only Qwen CustomVoice actually honors the instruct kwarg at model level.
       // Base Qwen3-TTS accepts the kwarg but ignores it.
       const supportsInstruct = engine === 'qwen_custom_voice';
+      const supportsExaggeration = engine === 'chatterbox';
       const effectsChain = options.getEffectsChain?.();
       // This now returns immediately with status="generating"
       const result = await generation.mutateAsync({
@@ -149,6 +154,8 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
         model_size: hasModelSizes ? data.modelSize : undefined,
         engine,
         instruct: supportsInstruct ? data.instruct || undefined : undefined,
+        exaggeration: supportsExaggeration ? data.exaggeration : undefined,
+        cfg_weight: supportsExaggeration ? data.cfg_weight : undefined,
         max_chunk_chars: maxChunkChars,
         crossfade_ms: crossfadeMs,
         normalize: normalizeAudio,
@@ -165,6 +172,8 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
         seed: undefined,
         modelSize: data.modelSize,
         instruct: '',
+        exaggeration: data.exaggeration ?? 0.5,
+        cfg_weight: data.cfg_weight ?? 0.5,
         engine: data.engine,
       });
       options.onSuccess?.(result.id);

--- a/backend/backends/chatterbox_backend.py
+++ b/backend/backends/chatterbox_backend.py
@@ -171,6 +171,8 @@ class ChatterboxTTSBackend:
         language: str = "en",
         seed: Optional[int] = None,
         instruct: Optional[str] = None,
+        exaggeration: Optional[float] = None,
+        cfg_weight: Optional[float] = None,
     ) -> Tuple[np.ndarray, int]:
         """
         Generate audio using Chatterbox Multilingual TTS.
@@ -207,8 +209,8 @@ class ChatterboxTTSBackend:
                 text,
                 language_id=language,
                 audio_prompt_path=ref_audio,
-                exaggeration=lang_defaults["exaggeration"],
-                cfg_weight=lang_defaults["cfg_weight"],
+                exaggeration=exaggeration if exaggeration is not None else lang_defaults["exaggeration"],
+                cfg_weight=cfg_weight if cfg_weight is not None else lang_defaults["cfg_weight"],
                 temperature=lang_defaults["temperature"],
                 repetition_penalty=lang_defaults["repetition_penalty"],
             )

--- a/backend/models.py
+++ b/backend/models.py
@@ -79,6 +79,12 @@ class GenerationRequest(BaseModel):
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
     engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    exaggeration: Optional[float] = Field(
+        None, ge=0.0, le=1.0, description="Chatterbox only: emotion exaggeration intensity (0=flat, 1=expressive). Defaults to 0.5."
+    )
+    cfg_weight: Optional[float] = Field(
+        None, ge=0.0, le=1.0, description="Chatterbox only: classifier-free guidance weight controlling speech consistency (0=loose, 1=tight). Defaults to 0.5."
+    )
     max_chunk_chars: int = Field(
         default=800, ge=100, le=5000, description="Max characters per chunk for long text splitting"
     )

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -97,6 +97,8 @@ async def generate_speech(
             mode="generate",
             max_chunk_chars=data.max_chunk_chars,
             crossfade_ms=data.crossfade_ms,
+            exaggeration=data.exaggeration,
+            cfg_weight=data.cfg_weight,
         )
     )
 

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -42,6 +42,8 @@ async def run_generation(
     max_chunk_chars: Optional[int] = None,
     crossfade_ms: Optional[int] = None,
     version_id: Optional[str] = None,
+    exaggeration: Optional[float] = None,
+    cfg_weight: Optional[float] = None,
 ) -> None:
     """Execute TTS inference and persist the result.
 
@@ -83,6 +85,10 @@ async def run_generation(
             gen_kwargs["max_chunk_chars"] = max_chunk_chars
         if crossfade_ms is not None:
             gen_kwargs["crossfade_ms"] = crossfade_ms
+        if engine == "chatterbox" and exaggeration is not None:
+            gen_kwargs["exaggeration"] = exaggeration
+        if engine == "chatterbox" and cfg_weight is not None:
+            gen_kwargs["cfg_weight"] = cfg_weight
 
         audio, sample_rate = await generate_chunked(tts_model, text, voice_prompt, **gen_kwargs)
 

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -211,6 +211,8 @@ async def generate_chunked(
     max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
     crossfade_ms: int = 50,
     trim_fn=None,
+    exaggeration: float | None = None,
+    cfg_weight: float | None = None,
 ) -> Tuple[np.ndarray, int]:
     """Generate audio with automatic chunking for long text.
 
@@ -248,12 +250,18 @@ async def generate_chunked(
 
     if len(chunks) <= 1:
         # Short text — single-shot fast path
+        extra_kwargs: dict = {}
+        if exaggeration is not None:
+            extra_kwargs["exaggeration"] = exaggeration
+        if cfg_weight is not None:
+            extra_kwargs["cfg_weight"] = cfg_weight
         audio, sample_rate = await backend.generate(
             text,
             voice_prompt,
             language,
             seed,
             instruct,
+            **extra_kwargs,
         )
         if trim_fn is not None:
             audio = trim_fn(audio, sample_rate)
@@ -281,12 +289,18 @@ async def generate_chunked(
         # always produces the same output.
         chunk_seed = (seed + i) if seed is not None else None
 
+        chunk_extra_kwargs: dict = {}
+        if exaggeration is not None:
+            chunk_extra_kwargs["exaggeration"] = exaggeration
+        if cfg_weight is not None:
+            chunk_extra_kwargs["cfg_weight"] = cfg_weight
         chunk_audio, chunk_sr = await backend.generate(
             chunk_text,
             voice_prompt,
             language,
             chunk_seed,
             instruct,
+            **chunk_extra_kwargs,
         )
         if trim_fn is not None:
             chunk_audio = trim_fn(chunk_audio, chunk_sr)


### PR DESCRIPTION
## Summary

Closes #491

Surfaces two Chatterbox-specific generation parameters — `exaggeration` and `cfg_weight` — as labeled sliders in the generation form. These values were previously hardcoded to `0.5` in the backend.

## Changes

### Backend
- **`backend/models.py`** — adds `exaggeration: Optional[float]` and `cfg_weight: Optional[float]` fields to `GenerationRequest` (both validated `0.0–1.0`, default `None`)
- **`backend/backends/chatterbox_backend.py`** — `generate()` now accepts `exaggeration`/`cfg_weight` kwargs; falls back to per-language defaults when `None`, preserving existing behaviour
- **`backend/utils/chunked_tts.py`** — `generate_chunked()` threads the two params through to `backend.generate()` using conditional kwargs, so **non-Chatterbox backends are completely unaffected**
- **`backend/routes/generations.py`** — forwards `data.exaggeration` / `data.cfg_weight` to `run_generation()`
- **`backend/services/generation.py`** — accepts the params and injects them into `gen_kwargs` only when `engine == 'chatterbox'`

### Frontend
- **`app/src/lib/api/types.ts`** — adds `exaggeration?: number` and `cfg_weight?: number` to `GenerationRequest`
- **`app/src/lib/hooks/useGenerationForm.ts`** — adds Zod schema fields, default values of `0.5`, conditional submission (Chatterbox only), and form reset
- **`app/src/components/Generation/GenerationForm.tsx`** — renders two labeled sliders (range 0–1, step 0.05, live value readout) beneath the engine selector, visible only when the Chatterbox Multilingual engine is selected

## Behaviour

| Engine | Sliders visible | Params sent to backend |
|---|---|---|
| Chatterbox Multilingual | ✅ | ✅ |
| Chatterbox Turbo | ❌ | ❌ |
| All other engines | ❌ | ❌ |

When no values are explicitly set, the backend falls back to `_LANG_DEFAULTS` (same as before this PR).

## Screenshots

> Sliders appear below the engine selector when **Chatterbox Multilingual** is chosen:

```
Exaggeration          [━━━━━━●──────]  0.50
Controls emotional expressiveness (0 = flat, 1 = highly expressive)

CFG Weight            [━━━━━━●──────]  0.50
Controls speech consistency (0 = loose/varied, 1 = tight/consistent)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added exaggeration and CFG weight control sliders for the Chatterbox TTS engine. These new parameters enable fine-tuned control over speech synthesis quality and output variability, each ranging from 0 to 1. The controls dynamically appear only when the Chatterbox engine is selected in the generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->