### PR TITLE
fix(offline): patch transformers mistral-regex check to survive HF failures

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -5,6 +5,13 @@ Provides a unified interface for MLX and PyTorch backends,
 and a model config registry that eliminates per-engine dispatch maps.
 """
 
+# Install HF compatibility patches before any backend imports transformers /
+# huggingface_hub. The module runs ``patch_transformers_mistral_regex`` at
+# import time, which wraps transformers' tokenizer load against the
+# unconditional HuggingFace metadata call that otherwise raises on
+# HF_HUB_OFFLINE=1 and on network failures.
+from ..utils import hf_offline_patch  # noqa: F401
+
 import threading
 from dataclasses import dataclass, field
 from typing import Protocol, Optional, Tuple, List

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -20,7 +20,6 @@ ensure_original_qwen_config_cached()
 from . import TTSBackend, STTBackend, LANGUAGE_CODE_TO_NAME, WHISPER_HF_REPOS
 from .base import is_model_cached, combine_voice_prompts as _combine_voice_prompts, model_load_progress
 from ..utils.cache import get_cache_key, get_cached_voice_prompt, cache_voice_prompt
-from ..utils.hf_offline_patch import force_offline_if_cached
 
 
 class MLXTTSBackend:
@@ -99,8 +98,7 @@ class MLXTTSBackend:
 
             logger.info("Loading MLX TTS model %s...", model_size)
 
-            with force_offline_if_cached(is_cached, model_name):
-                self.model = load(model_path)
+            self.model = load(model_path)
 
         self._current_model_size = model_size
         self.model_size = model_size
@@ -311,8 +309,7 @@ class MLXSTTBackend:
             model_name = WHISPER_HF_REPOS.get(model_size, f"openai/whisper-{model_size}")
             logger.info("Loading MLX Whisper model %s...", model_size)
 
-            with force_offline_if_cached(is_cached, progress_model_name):
-                self.model = load(model_name)
+            self.model = load(model_name)
 
         self.model_size = model_size
         logger.info("MLX Whisper model %s loaded successfully", model_size)

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -21,7 +21,6 @@ from .base import (
 )
 from ..utils.cache import get_cache_key, get_cached_voice_prompt, cache_voice_prompt
 from ..utils.audio import load_audio
-from ..utils.hf_offline_patch import force_offline_if_cached
 
 
 class PyTorchTTSBackend:
@@ -106,21 +105,20 @@ class PyTorchTTSBackend:
             from huggingface_hub import constants as hf_constants
             tts_cache_dir = hf_constants.HF_HUB_CACHE
 
-            with force_offline_if_cached(is_cached, model_name):
-                if self.device == "cpu":
-                    self.model = Qwen3TTSModel.from_pretrained(
-                        model_path,
-                        cache_dir=tts_cache_dir,
-                        torch_dtype=torch.float32,
-                        low_cpu_mem_usage=False,
-                    )
-                else:
-                    self.model = Qwen3TTSModel.from_pretrained(
-                        model_path,
-                        cache_dir=tts_cache_dir,
-                        device_map=self.device,
-                        torch_dtype=torch.bfloat16,
-                    )
+            if self.device == "cpu":
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    cache_dir=tts_cache_dir,
+                    torch_dtype=torch.float32,
+                    low_cpu_mem_usage=False,
+                )
+            else:
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    cache_dir=tts_cache_dir,
+                    device_map=self.device,
+                    torch_dtype=torch.bfloat16,
+                )
 
         self._current_model_size = model_size
         self.model_size = model_size
@@ -297,9 +295,8 @@ class PyTorchSTTBackend:
             model_name = WHISPER_HF_REPOS.get(model_size, f"openai/whisper-{model_size}")
             logger.info("Loading Whisper model %s on %s...", model_size, self.device)
 
-            with force_offline_if_cached(is_cached, progress_model_name):
-                self.processor = WhisperProcessor.from_pretrained(model_name)
-                self.model = WhisperForConditionalGeneration.from_pretrained(model_name)
+            self.processor = WhisperProcessor.from_pretrained(model_name)
+            self.model = WhisperForConditionalGeneration.from_pretrained(model_name)
 
         self.model.to(self.device)
         self.model_size = model_size

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -28,7 +28,6 @@ from .base import (
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
-from ..utils.hf_offline_patch import force_offline_if_cached
 
 logger = logging.getLogger(__name__)
 
@@ -105,19 +104,18 @@ class QwenCustomVoiceBackend:
             model_path = self._get_model_path(model_size)
             logger.info("Loading Qwen CustomVoice %s on %s...", model_size, self.device)
 
-            with force_offline_if_cached(is_cached, model_name):
-                if self.device == "cpu":
-                    self.model = Qwen3TTSModel.from_pretrained(
-                        model_path,
-                        torch_dtype=torch.float32,
-                        low_cpu_mem_usage=False,
-                    )
-                else:
-                    self.model = Qwen3TTSModel.from_pretrained(
-                        model_path,
-                        device_map=self.device,
-                        torch_dtype=torch.bfloat16,
-                    )
+            if self.device == "cpu":
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    torch_dtype=torch.float32,
+                    low_cpu_mem_usage=False,
+                )
+            else:
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    device_map=self.device,
+                    torch_dtype=torch.bfloat16,
+                )
 
         self._current_model_size = model_size
         self.model_size = model_size

--- a/backend/tests/test_offline_patch.py
+++ b/backend/tests/test_offline_patch.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for ``patch_transformers_mistral_regex``.
+
+Verifies that our wrapper around
+``transformers.PreTrainedTokenizerBase._patch_mistral_regex`` catches
+exceptions from the unconditional ``huggingface_hub.model_info()`` lookup
+and returns the tokenizer unchanged — matching the success-path behavior
+for non-Mistral repos (transformers 4.57.3, ``tokenization_utils_base.py:2503``).
+
+NOTE: These tests mutate ``transformers.PreTrainedTokenizerBase`` globally;
+run serially, not under ``pytest-xdist`` with per-worker process isolation.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from huggingface_hub.errors import OfflineModeIsEnabled  # noqa: E402
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase  # noqa: E402
+
+import utils.hf_offline_patch as hf_offline_patch  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def restore_mistral_regex():
+    """Snapshot the current ``_patch_mistral_regex`` and restore after each test."""
+    saved = PreTrainedTokenizerBase.__dict__.get("_patch_mistral_regex")
+    saved_flag = hf_offline_patch._mistral_regex_patched
+    try:
+        yield
+    finally:
+        if saved is not None:
+            PreTrainedTokenizerBase._patch_mistral_regex = saved
+        hf_offline_patch._mistral_regex_patched = saved_flag
+
+
+def _apply_patch():
+    hf_offline_patch._mistral_regex_patched = False
+    hf_offline_patch.patch_transformers_mistral_regex()
+
+
+def test_suppresses_offline_mode_is_enabled(monkeypatch):
+    _apply_patch()
+
+    import huggingface_hub
+
+    def raise_offline(*_args, **_kwargs):
+        raise OfflineModeIsEnabled("offline")
+
+    monkeypatch.setattr(huggingface_hub, "model_info", raise_offline)
+
+    sentinel = object()
+    result = PreTrainedTokenizerBase._patch_mistral_regex(
+        sentinel, "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    )
+    assert result is sentinel
+
+
+def test_suppresses_connection_errors(monkeypatch):
+    _apply_patch()
+
+    import huggingface_hub
+
+    def raise_connection(*_args, **_kwargs):
+        raise ConnectionError("network unreachable")
+
+    monkeypatch.setattr(huggingface_hub, "model_info", raise_connection)
+
+    sentinel = object()
+    result = PreTrainedTokenizerBase._patch_mistral_regex(
+        sentinel, "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    )
+    assert result is sentinel
+
+
+def test_passthrough_on_success(monkeypatch):
+    """When model_info returns non-Mistral tags the original falls through and returns the tokenizer unchanged."""
+    _apply_patch()
+
+    import huggingface_hub
+
+    class FakeInfo:
+        tags = ["model-type:qwen", "language:en"]
+
+    monkeypatch.setattr(huggingface_hub, "model_info", lambda *_a, **_kw: FakeInfo())
+
+    sentinel = object()
+    result = PreTrainedTokenizerBase._patch_mistral_regex(
+        sentinel, "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    )
+    assert result is sentinel
+
+
+def test_idempotent():
+    _apply_patch()
+    first = PreTrainedTokenizerBase._patch_mistral_regex
+    hf_offline_patch.patch_transformers_mistral_regex()
+    second = PreTrainedTokenizerBase._patch_mistral_regex
+    assert first.__func__ is second.__func__
+
+
+def test_missing_method_is_noop(monkeypatch):
+    monkeypatch.delattr(PreTrainedTokenizerBase, "_patch_mistral_regex", raising=False)
+    hf_offline_patch._mistral_regex_patched = False
+    hf_offline_patch.patch_transformers_mistral_regex()
+    assert hf_offline_patch._mistral_regex_patched is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/utils/hf_offline_patch.py
+++ b/backend/utils/hf_offline_patch.py
@@ -142,6 +142,57 @@ def force_offline_if_cached(is_cached: bool, model_label: str = ""):
                 _saved_transformers_const = None
 
 
+_mistral_regex_patched = False
+
+
+def patch_transformers_mistral_regex():
+    """Make transformers' tokenizer load robust to HuggingFace metadata failures.
+
+    transformers 4.57.x added ``PreTrainedTokenizerBase._patch_mistral_regex``
+    which unconditionally calls ``huggingface_hub.model_info(repo_id)`` during
+    every non-local tokenizer load to check whether the model is a Mistral
+    variant. That call raises on ``HF_HUB_OFFLINE=1`` and on plain network
+    failures, killing unrelated loads (Qwen TTS, TADA, etc.).
+
+    Voicebox never loads Mistral models, so the rewrite the function would
+    apply is a no-op for us anyway. Wrap the method so any exception from the
+    metadata lookup returns the tokenizer unchanged — matching the success-path
+    behavior for non-Mistral repos (transformers 4.57.3,
+    ``tokenization_utils_base.py:2503``).
+    """
+    global _mistral_regex_patched
+    if _mistral_regex_patched:
+        return
+
+    try:
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    except ImportError:
+        logger.debug("transformers not available, skipping mistral-regex patch")
+        return
+
+    original = getattr(PreTrainedTokenizerBase, "_patch_mistral_regex", None)
+    if original is None:
+        logger.debug(
+            "transformers has no _patch_mistral_regex attribute, skipping patch",
+        )
+        return
+
+    def safe_patch_mistral_regex(cls, tokenizer, pretrained_model_name_or_path, *args, **kwargs):
+        try:
+            return original(tokenizer, pretrained_model_name_or_path, *args, **kwargs)
+        except Exception as exc:
+            logger.debug(
+                "[mistral-regex-patch] suppressed %s for %r, returning tokenizer as-is",
+                type(exc).__name__,
+                pretrained_model_name_or_path,
+            )
+            return tokenizer
+
+    PreTrainedTokenizerBase._patch_mistral_regex = classmethod(safe_patch_mistral_regex)
+    _mistral_regex_patched = True
+    logger.debug("installed _patch_mistral_regex wrapper")
+
+
 def patch_huggingface_hub_offline():
     """Monkey-patch huggingface_hub to force offline mode."""
     try:
@@ -215,4 +266,5 @@ def ensure_original_qwen_config_cached():
 
 if os.environ.get("VOICEBOX_OFFLINE_PATCH", "1") != "0":
     patch_huggingface_hub_offline()
+    patch_transformers_mistral_regex()
     ensure_original_qwen_config_cached()


### PR DESCRIPTION
## Summary

Fixes the "Cannot reach ... offline mode is enabled" crash hitting users on 0.4.4 (#526). Users updating from 0.4.3 expected 0.4.4 to fix this error — it didn't, because 0.4.4's PR #524 only reverted the inference-path guards. The same trap on the load path has been shipping since 0.4.2 and was masked by the more visible inference-path regression.

## Root cause

`transformers` 4.57.x's `PreTrainedTokenizerBase._patch_mistral_regex` calls `huggingface_hub.model_info(repo_id)` **unconditionally** for every non-local tokenizer load, to probe whether the repo is a Mistral variant. That call raises on `HF_HUB_OFFLINE=1`, on network outages, and on blocked HF endpoints. `_patch_mistral_regex` doesn't catch any of it — the exception bubbles out of `from_pretrained` and kills the load.

0.4.2's load-time `force_offline_if_cached` guard (from #503) walked straight into this: on cached online users it flipped `HF_HUB_OFFLINE=1`, converting a healthy load into `OfflineModeIsEnabled`. 0.4.3's inference-path guard got hit first so nobody reported the load-path one. #524 removed the inference guard, users got further into the flow, and now the same error lands on load.

## Fix

- Wrap `_patch_mistral_regex` so any exception from the inner HF metadata check is swallowed and the tokenizer is returned unchanged. Voicebox never loads Mistral models, so the regex rewrite this check gates is a no-op for us anyway — matches the success-path behavior for non-Mistral repos (`tokenization_utils_base.py:2503`).
- Drop `force_offline_if_cached` wraps from every load path (`pytorch_backend` Qwen + Whisper, `qwen_custom_voice_backend`, `mlx_backend` Qwen + Whisper). With the mistral patch in place they provide zero value and only risk re-introducing the same class of bug. Helper + its unit tests stay untouched.
- New test file `backend/tests/test_offline_patch.py` covers `OfflineModeIsEnabled` / `ConnectionError` suppression, success pass-through, idempotence, and the missing-method no-op path.

## Code example

```python
def patch_transformers_mistral_regex():
    original = getattr(PreTrainedTokenizerBase, "_patch_mistral_regex", None)
    if original is None:
        return

    def safe_patch_mistral_regex(cls, tokenizer, pretrained_model_name_or_path, *args, **kwargs):
        try:
            return original(tokenizer, pretrained_model_name_or_path, *args, **kwargs)
        except Exception as exc:
            logger.debug(
                "[mistral-regex-patch] suppressed %s for %r, returning tokenizer as-is",
                type(exc).__name__, pretrained_model_name_or_path,
            )
            return tokenizer

    PreTrainedTokenizerBase._patch_mistral_regex = classmethod(safe_patch_mistral_regex)
```

## Test plan

- [x] `pytest tests/test_offline_patch.py tests/test_offline_guard.py -v` — 11/11 green
- [x] Import-time smoke test: `HF_HUB_OFFLINE=1` + calling `_patch_mistral_regex` on a Qwen repo ID returns the tokenizer unchanged instead of raising
- [ ] Online cached Qwen CustomVoice 1.7B load (the 0.4.4 regression) succeeds
- [ ] Online cached TADA 3B load succeeds (was also reported failing in #526 comments)
- [ ] Offline cached load completes without the 30s `model_info` timeout (closes the 0.4.4 "known caveat")
- [ ] `HF_HUB_OFFLINE=1 just server` load works (skyooo's hf-mirror case)
- [ ] Bundled-binary smoke test: `just build`, run cached Qwen load against the PyInstaller-frozen server to confirm the import-time patch fires inside the frozen runtime

Fixes #526.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model-loading paths and globally monkey-patches `transformers` tokenizer behavior, which could affect all HuggingFace/Transformers loads if the wrapper masks unexpected errors. Changes are targeted to offline/network-failure scenarios and covered by new unit tests.
> 
> **Overview**
> Fixes offline-mode crashes during model/tokenizer loading by adding `patch_transformers_mistral_regex()` in `utils/hf_offline_patch.py`, which wraps `PreTrainedTokenizerBase._patch_mistral_regex` to **swallow HuggingFace `model_info()` failures** and return the tokenizer unchanged.
> 
> Removes `force_offline_if_cached(...)` usage from MLX, PyTorch (Qwen TTS + Whisper), and `qwen_custom_voice_backend` load paths so cached models no longer flip global offline mode during `from_pretrained`/`load`.
> 
> Adds `test_offline_patch.py` to validate the new wrapper (suppresses `OfflineModeIsEnabled`/network errors, passes through on success, is idempotent, and no-ops when the upstream method is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9fe30514cf3fb64e6374f8bd42fd0966c7c2c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model loading now respects standard offline behavior across MLX, PyTorch, and Qwen backends, reducing unexpected network access.
  * Tokenizer initialization for Mistral models now fails gracefully when metadata lookups are unavailable, improving offline robustness.

* **Tests**
  * Added unit tests validating the offline/connection-failure patch and its idempotent, safe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->