### PR TITLE
refactor: make IPEX optional and enable native Intel XPU detection for PyTorch 2.9+

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -163,18 +163,17 @@ def _get_gpu_status() -> str:
     elif backend_type == "mlx":
         return "Metal (Apple Silicon via MLX)"
 
-    # Intel XPU (Arc / Data Center) via IPEX
-    try:
-        import intel_extension_for_pytorch  # noqa: F401
-
-        if hasattr(torch, "xpu") and torch.xpu.is_available():
-            try:
-                xpu_name = torch.xpu.get_device_name(0)
-            except Exception:
-                xpu_name = "Intel GPU"
-            return f"XPU ({xpu_name})"
-    except ImportError:
-        pass
+    # Intel XPU (Arc / Data Center) — native PyTorch 2.4+ support; IPEX optional
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        try:
+            import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
+        except ImportError:
+            pass
+        try:
+            xpu_name = torch.xpu.get_device_name(0)
+        except Exception:
+            xpu_name = "Intel GPU"
+        return f"XPU ({xpu_name})"
 
     return "None (CPU only)"
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -167,7 +167,7 @@ def _get_gpu_status() -> str:
     if hasattr(torch, "xpu") and torch.xpu.is_available():
         try:
             import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
-        except ImportError:
+        except Exception:
             pass
         try:
             xpu_name = torch.xpu.get_device_name(0)

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -102,13 +102,12 @@ def get_torch_device(
         return "cuda"
 
     if allow_xpu:
-        try:
-            import intel_extension_for_pytorch  # noqa: F401
-
-            if hasattr(torch, "xpu") and torch.xpu.is_available():
-                return "xpu"
-        except ImportError:
-            pass
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            try:
+                import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
+            except ImportError:
+                pass
+            return "xpu"
 
     if allow_directml:
         try:

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -105,7 +105,7 @@ def get_torch_device(
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             try:
                 import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
-            except ImportError:
+            except Exception:
                 pass
             return "xpu"
 

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -67,17 +67,17 @@ async def health():
 
     has_xpu = False
     xpu_name = None
-    try:
-        import intel_extension_for_pytorch as ipex  # noqa: F401 -- side-effect import enables XPU
-
-        if hasattr(torch, "xpu") and torch.xpu.is_available():
-            has_xpu = True
-            try:
-                xpu_name = torch.xpu.get_device_name(0)
-            except Exception:
-                xpu_name = "Intel GPU"
-    except ImportError:
-        pass
+    # Native XPU support in PyTorch 2.4+; IPEX optional for enhanced performance
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        has_xpu = True
+        try:
+            import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
+        except ImportError:
+            pass
+        try:
+            xpu_name = torch.xpu.get_device_name(0)
+        except Exception:
+            xpu_name = "Intel GPU"
 
     has_directml = False
     directml_name = None

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -72,7 +72,7 @@ async def health():
         has_xpu = True
         try:
             import intel_extension_for_pytorch  # noqa: F401 -- enhances XPU perf if available
-        except ImportError:
+        except Exception:
             pass
         try:
             xpu_name = torch.xpu.get_device_name(0)


### PR DESCRIPTION

This pull request refactors how Intel XPU (Arc / Data Center) support is detected and reported across the backend. The main improvement is to make the import of `intel_extension_for_pytorch` (IPEX) optional, acknowledging that native XPU support is now integrated into the official PyTorch stack (since v2.5).

This change addresses a critical issue where the latest Intel oneAPI drivers (which support PyTorch 2.9+) cause conflicts with older IPEX versions (v2.8 and below). By prioritizing native detection, the logic becomes more robust and future-proof.

**Device detection and reporting improvements:**

* **Native Priority:** Updated XPU detection logic in `backend/app.py` to check for native PyTorch XPU support first (`torch.xpu.is_available()`), removing the hard dependency on `intel_extension_for_pytorch` for modern environments.
* **Optional IPEX:** Refactored `get_torch_device` in `backend/backends/base.py` to make the IPEX import optional. It now only attempts to load IPEX for legacy support (v2.4 - v2.8) or enhanced performance if present, otherwise falling back to native `"xpu"`.
* **Updated Health Checks:** Adjusted the health check endpoint in `backend/routes/health.py` to report XPU status based on native support, ensuring accurate hardware reporting regardless of whether IPEX is installed.
* **Driver Compatibility:** Fixed crashes occurring with the newest Intel GPU drivers by decoupling the core functionality from the IPEX import.

**References:**
Intel has officially announced the retirement of the IPEX extension, recommending the use of native PyTorch XPU support going forward:
[Intel® Extension for PyTorch (IPEX) End of Life](https://intel.github.io/intel-extension-for-pytorch/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Intel GPU (XPU) detection across backend services by decoupling native device availability checks from optional extensions, resulting in more reliable and consistent XPU presence reporting.
  * Added a safe fallback for device naming so unavailable queries show a clear "Intel GPU" placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->