### PR TITLE
fix(dev): add setup script for chatterbox-tts and hume-tada installation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,9 +21,10 @@ qwen-tts>=0.0.5
 linacodec @ git+https://github.com/ysharma3501/LinaCodec.git
 Zipvoice @ git+https://github.com/ysharma3501/LuxTTS.git
 
-# Chatterbox TTS sub-dependencies (chatterbox-tts itself is installed
-# --no-deps in the setup script because it pins numpy<1.26 / torch==2.6
-# which are incompatible with Python 3.12+)
+# Chatterbox TTS sub-dependencies (chatterbox-tts itself must be installed
+# with --no-deps — run scripts/setup-backend.sh or:
+#   pip install --no-deps chatterbox-tts
+# It pins numpy<1.26 / torch==2.6 which conflict with Python 3.12+)
 conformer>=0.3.2
 diffusers>=0.29.0
 omegaconf
@@ -33,8 +34,10 @@ s3tokenizer
 spacy-pkuseg
 pyloudnorm
 
-# HumeAI TADA sub-dependencies (hume-tada itself is installed
-# --no-deps in the setup script because it pins torch>=2.7,<2.8.
+# HumeAI TADA sub-dependencies (hume-tada itself must be installed
+# with --no-deps — run scripts/setup-backend.sh or:
+#   pip install --no-deps hume-tada
+# It pins torch>=2.7,<2.8 which conflicts with voicebox's torch version.
 # descript-audio-codec is NOT installed — it pulls onnx/tensorboard
 # via descript-audiotools.  A lightweight shim in utils/dac_shim.py
 # provides the only class TADA uses: Snake1d.)

--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Setup script for voicebox backend development
+# Mirrors the Dockerfile's Python package installation
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Installing backend dependencies..."
+
+# Install main requirements
+pip install -r "$PROJECT_DIR/backend/requirements.txt"
+
+# Install packages that need --no-deps due to incompatible pinned versions
+# (See comments in requirements.txt for details)
+pip install --no-deps chatterbox-tts
+pip install --no-deps hume-tada
+
+echo "Backend setup complete!"


### PR DESCRIPTION
## Summary

- Add `scripts/setup-backend.sh` that mirrors the Dockerfile's Python setup for local development
- Update `requirements.txt` comments to document the manual `--no-deps` install commands

## Problem

Local development was missing the `pip install --no-deps chatterbox-tts` and `pip install --no-deps hume-tada` steps that the Dockerfile includes (lines 38-39). This caused `ModuleNotFoundError: No module named 'chatterbox'` errors when trying to use the Chatterbox TTS model.

The `--no-deps` flag is required because these packages pin incompatible versions:
- `chatterbox-tts`: pins `numpy<1.26`, `torch==2.6.0`, `transformers==4.46.3`
- `hume-tada`: pins `torch>=2.7,<2.8`

## Test plan

- [ ] Run `./scripts/setup-backend.sh` in a fresh venv
- [ ] Verify `python -c "import chatterbox"` succeeds
- [ ] Verify Chatterbox model can be downloaded and used in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a setup script (`scripts/setup-backend.sh`) to streamline backend installation and dependency resolution for TTS packages.

* **Documentation**
  * Updated installation guidance in requirements documentation to address dependency conflicts for TTS integrations and provide clear setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->