### PR TITLE
fix(cuda): add Linux x86_64 CUDA backend build and platform-aware download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,17 +315,18 @@ jobs:
             backend/dist/voicebox-server-cuda/ \
             --output release-assets/ \
             --cuda-libs-version cu128-v1 \
-            --torch-compat ">=2.7.0,<2.11.0"
+            --torch-compat ">=2.7.0,<2.11.0" \
+            --platform windows-x86_64
 
       - name: Upload archives to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            release-assets/voicebox-server-cuda.tar.gz
-            release-assets/voicebox-server-cuda.tar.gz.sha256
-            release-assets/cuda-libs-cu128-v1.tar.gz
-            release-assets/cuda-libs-cu128-v1.tar.gz.sha256
+            release-assets/voicebox-server-cuda-windows-x86_64.tar.gz
+            release-assets/voicebox-server-cuda-windows-x86_64.tar.gz.sha256
+            release-assets/cuda-libs-cu128-v1-windows-x86_64.tar.gz
+            release-assets/cuda-libs-cu128-v1-windows-x86_64.tar.gz.sha256
             release-assets/cuda-libs.json
           draft: true
         env:
@@ -335,5 +336,75 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: voicebox-server-cuda-windows
+          path: backend/dist/voicebox-server-cuda/
+          retention-days: 7
+
+  build-cuda-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r backend/requirements.txt
+          pip install --no-deps chatterbox-tts
+          pip install --no-deps hume-tada
+
+      - name: Install PyTorch with CUDA 12.8
+        run: |
+          pip install torch==2.7.0+cu128 torchaudio==2.7.0+cu128 \
+            --index-url https://download.pytorch.org/whl/cu128 \
+            --force-reinstall --no-deps
+
+      - name: Verify CUDA libraries are present
+        run: |
+          python -c "import torch; print(f'torch: {torch.__version__}'); print(f'CUDA version: {torch.version.cuda}')"
+
+      - name: Install Qwen3-TTS
+        run: pip install --no-deps git+https://github.com/QwenLM/Qwen3-TTS.git
+
+      - name: Build CUDA server binary (onedir)
+        working-directory: backend
+        env:
+          TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;12.0+PTX"
+        run: python build_binary.py --cuda
+
+      - name: Package into server core + CUDA libs archives
+        run: |
+          python scripts/package_cuda.py \
+            backend/dist/voicebox-server-cuda/ \
+            --output release-assets/ \
+            --cuda-libs-version cu128-v1 \
+            --torch-compat ">=2.7.0,<2.11.0" \
+            --platform linux-x86_64
+
+      - name: Upload archives to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-assets/voicebox-server-cuda-linux-x86_64.tar.gz
+            release-assets/voicebox-server-cuda-linux-x86_64.tar.gz.sha256
+            release-assets/cuda-libs-cu128-v1-linux-x86_64.tar.gz
+            release-assets/cuda-libs-cu128-v1-linux-x86_64.tar.gz.sha256
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload onedir as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: voicebox-server-cuda-linux
           path: backend/dist/voicebox-server-cuda/
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tauri/src-tauri/binaries/*
 tauri/src-tauri/gen/Assets.car
 tauri/src-tauri/gen/voicebox.icns
 tauri/src-tauri/gen/partial.plist
+tauri/src-tauri/gen/schemas/linux-schema.json
 
 # PyInstaller
 *.spec

--- a/backend/services/cuda.py
+++ b/backend/services/cuda.py
@@ -286,8 +286,9 @@ async def _download_cuda_binary_locked(version: Optional[str] = None):
     )
 
     base_url = f"{GITHUB_RELEASES_URL}/{version}"
-    server_archive = "voicebox-server-cuda.tar.gz"
-    libs_archive = f"cuda-libs-{CUDA_LIBS_VERSION}.tar.gz"
+    _plat = "windows-x86_64" if sys.platform == "win32" else "linux-x86_64"
+    server_archive = f"voicebox-server-cuda-{_plat}.tar.gz"
+    libs_archive = f"cuda-libs-{CUDA_LIBS_VERSION}-{_plat}.tar.gz"
 
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:

--- a/scripts/package_cuda.py
+++ b/scripts/package_cuda.py
@@ -101,6 +101,7 @@ def package(
     output_dir: Path,
     cuda_libs_version: str,
     torch_compat: str,
+    platform: str,
 ):
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -140,27 +141,29 @@ def package(
     # Create server core archive
     # Files are stored relative to the archive root (no parent directory prefix)
     # so extracting to backends/cuda/ puts everything at the right level.
-    server_archive = output_dir / "voicebox-server-cuda.tar.gz"
+    server_archive_name = f"voicebox-server-cuda-{platform}.tar.gz"
+    server_archive = output_dir / server_archive_name
     print(f"\nCreating server core archive: {server_archive.name}")
     with tarfile.open(server_archive, "w:gz") as tar:
         for rel_str, full_path in core_files:
             tar.add(full_path, arcname=rel_str)
     server_sha = sha256_file(server_archive)
-    (output_dir / "voicebox-server-cuda.tar.gz.sha256").write_text(
-        f"{server_sha}  voicebox-server-cuda.tar.gz\n"
+    (output_dir / f"{server_archive_name}.sha256").write_text(
+        f"{server_sha}  {server_archive_name}\n"
     )
     print(f"  Size: {server_archive.stat().st_size / (1024**2):.1f} MB")
     print(f"  SHA-256: {server_sha[:16]}...")
 
     # Create CUDA libs archive
-    cuda_libs_archive = output_dir / f"cuda-libs-{cuda_libs_version}.tar.gz"
+    cuda_libs_archive_name = f"cuda-libs-{cuda_libs_version}-{platform}.tar.gz"
+    cuda_libs_archive = output_dir / cuda_libs_archive_name
     print(f"\nCreating CUDA libs archive: {cuda_libs_archive.name}")
     with tarfile.open(cuda_libs_archive, "w:gz") as tar:
         for rel_str, full_path in nvidia_files:
             tar.add(full_path, arcname=rel_str)
     cuda_sha = sha256_file(cuda_libs_archive)
-    (output_dir / f"cuda-libs-{cuda_libs_version}.tar.gz.sha256").write_text(
-        f"{cuda_sha}  cuda-libs-{cuda_libs_version}.tar.gz\n"
+    (output_dir / f"{cuda_libs_archive_name}.sha256").write_text(
+        f"{cuda_sha}  {cuda_libs_archive_name}\n"
     )
     print(f"  Size: {cuda_libs_archive.stat().st_size / (1024**2):.1f} MB")
     print(f"  SHA-256: {cuda_sha[:16]}...")
@@ -168,6 +171,7 @@ def package(
     # Write cuda-libs.json manifest
     manifest = {
         "version": cuda_libs_version,
+        "platform": platform,
         "torch_compat": torch_compat,
         "archive": cuda_libs_archive.name,
         "sha256": cuda_sha,
@@ -217,6 +221,12 @@ def main():
         default=">=2.7.0,<2.11.0",
         help="Torch version compatibility range (default: >=2.6.0,<2.11.0)",
     )
+    parser.add_argument(
+        "--platform",
+        type=str,
+        required=True,
+        help="Platform identifier for archive names (e.g. linux-x86_64, windows-x86_64)",
+    )
     args = parser.parse_args()
 
     if not args.input.is_dir():
@@ -225,7 +235,7 @@ def main():
         sys.exit(1)
 
     output_dir = args.output or args.input.parent
-    package(args.input, output_dir, args.cuda_libs_version, args.torch_compat)
+    package(args.input, output_dir, args.cuda_libs_version, args.torch_compat, args.platform)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The "Download CUDA Backend" feature downloads `voicebox-server-cuda.tar.gz` on all platforms, but only a Windows binary is published in releases. Linux users silently download and extract a Windows `.exe`, which is unusable, leaving them on the CPU backend with no explanation.

## Fix

### Platform-aware archive names (`backend/services/cuda.py`)
Archive names now include the platform:
- Linux: `voicebox-server-cuda-linux-x86_64.tar.gz` / `cuda-libs-cu128-v1-linux-x86_64.tar.gz`
- Windows: `voicebox-server-cuda-windows-x86_64.tar.gz` / `cuda-libs-cu128-v1-windows-x86_64.tar.gz`

### Packaging script (`scripts/package_cuda.py`)
Added a required `--platform` argument that stamps the platform identifier into all output archive and checksum filenames.

### Linux CI build job (`.github/workflows/release.yml`)
Added `build-cuda-linux` on `ubuntu-latest` that:
1. Installs `torch==2.7.0+cu128` from the PyTorch cu128 index
2. Builds the CUDA server binary with PyInstaller (`build_binary.py --cuda`)
3. Packages with `--platform linux-x86_64`
4. Uploads Linux archives to the release draft

No GPU is required in CI — PyInstaller bundles the CUDA `.so` libraries from the pip-installed `nvidia-*` packages at build time, the same way the Windows job bundles `.dll`s on a runner with no GPU.

The existing Windows job is updated to pass `--platform windows-x86_64` to match the new naming scheme.

## Notes
- `cuda-libs` archives are platform-specific (Windows `.dll` vs Linux `.so`)
- The `cuda-libs.json` manifest now includes a `platform` field
- macOS is unaffected (no CUDA backend on macOS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Linux CUDA package builds to the release pipeline
  * Platform-specific CUDA release packages now available for Windows and Linux
  * Release artifacts uploaded per-platform and Linux onedir uploaded as a workflow artifact

* **Improvements**
  * Backend now selects platform-appropriate CUDA artifacts for downloads
  * Package checksums and manifest entries updated to match platform-specific naming

* **Chores**
  * Ignore generated Linux schema JSON from source control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->