### PR TITLE
Fix/docker permision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ RUN pip install --no-cache-dir --prefix=/install \
 FROM python:3.11-slim
 
 # Create non-root user for security
-RUN groupadd -r voicebox && \
-    useradd -r -g voicebox -m -s /bin/bash voicebox
-
+RUN groupadd -r -g 1000 voicebox && \
+    useradd -r -g voicebox -u 1000 -m -s /bin/bash voicebox
 WORKDIR /app
 
 # Install only runtime system dependencies
@@ -68,6 +67,10 @@ COPY --from=frontend --chown=voicebox:voicebox /build/web/dist /app/frontend/
 # Create data directories owned by non-root user
 RUN mkdir -p /app/data/generations /app/data/profiles /app/data/cache \
     && chown -R voicebox:voicebox /app/data
+
+# Create HuggingFace cache directory for the named volume
+RUN mkdir -p /home/voicebox/.cache/huggingface \
+    && chown -R voicebox:voicebox /home/voicebox/.cache/huggingface
 
 # Switch to non-root user
 USER voicebox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,15 @@ services:
 
     deploy:
       resources:
+
+        # GPU passthrough
+        #reservations:
+        #  devices:
+        #   - driver: nvidia
+        #     count: all
+        #     capabilities: [gpu]
+
+        # Resource limits
         limits:
           cpus: '4'
           memory: 8G


### PR DESCRIPTION
I resolve this Docker problem:
#542 

**Fix permission issues and add GPU support**
The original Dockerfile creates the voicebox user with a system-assigned UID, which causes permission errors in two places:

1. HuggingFace cache — Docker initializes named volumes as root when the target directory doesn't exist in the image, so the voicebox user can't write to it.

2. Bind-mounted output directory — The unpredictable UID doesn't match the host user, causing soundfile to fail when saving generated audio.

**Changes:**

- Pin voicebox to UID/GID 1000 so bind-mounts work without manual chown on the host.

- Pre-create /home/voicebox/.cache/huggingface with correct ownership so the named volume inherits the right permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container user setup with deterministic ID assignment for improved consistency
  * Initialized HuggingFace model cache directory in container environment
  * Added optional NVIDIA GPU support configuration to deployment settings (currently disabled)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->