### PR TITLE
Dev.1: 重大福利：支持 Intel Arc A770 及其它 GPU

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thank you for your interest in contributing to Voicebox! This document provides 
   python --version  # Should be 3.11 or higher
   ```
 
-- **[Rust](https://rustup.rs)** - For Tauri desktop app (installed automatically by Tauri CLI)
+- **[Rust](https://rustup.rs)** - For the Tauri desktop app (install separately with `rustup`)
   ```bash
   rustc --version  # Check if installed
   ```
@@ -33,7 +33,7 @@ Thank you for your interest in contributing to Voicebox! This document provides 
 
 ### Development Setup
 
-Install [just](https://github.com/casey/just) (`brew install just`, `cargo install just`, or `winget install Casey.Just`), then:
+Install [just](https://github.com/casey/just) (`brew install just`, `cargo install just`, or `winget install Casey.Just` on Windows), then:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/voicebox.git
@@ -68,6 +68,14 @@ just --list        # see all available commands
 #### Windows Notes
 
 The justfile works natively on Windows via PowerShell. No WSL or Git Bash required. On Windows with an NVIDIA GPU, `just setup` automatically installs CUDA-enabled PyTorch for GPU acceleration.
+
+Install Rust before running `just dev` or `just build`:
+
+```powershell
+winget install -e --id Rustlang.Rustup
+```
+
+Restart PowerShell after installation so `cargo.exe` and `rustc.exe` are on `PATH`.
 
 ### Model Downloads
 

--- a/README.Wang.md
+++ b/README.Wang.md
@@ -1,3 +1,9 @@
+# 重大福利：支持 Intel Arc A770 及其它 GPU
+## 仅支持开发者模式运行：
+`just setup`
+`just dev`
+
+
 # Voicebox Work Summary - 2026-04-28
 
 ## Goal
@@ -261,3 +267,5 @@ Expected fields:
 - There is no separate `just dev --xpu` or IPEX launch flag. The correct path is the normal `just dev` flow.
 - Current local modifications are in `README.Wang.md`, `backend/app.py`, `backend/backends/base.py`, `backend/routes/health.py`, and `justfile`.
 - No commit was created in this session; this summary describes the current local diff and the validated runtime behavior.
+
+C:\AI\intel-ai\voicebox\tauri\src-tauri\target\release\bundle\msi

--- a/README.Wang.md
+++ b/README.Wang.md
@@ -1,0 +1,263 @@
+# Voicebox Work Summary - 2026-04-28
+
+## Goal
+
+Enable local Voicebox development on Windows with Intel Arc A770 using PyTorch XPU, diagnose the false CPU fallback, and make the normal `just dev` path work without any special runtime flag.
+
+## Environment
+
+- Repository: `voicebox`
+- Branch: `dev.1`
+- OS: Windows
+- GPU: `Intel(R) Arc(TM) A770 Graphics`
+- Effective runtime Python environment: `backend/venv`
+- Important note: Voicebox `justfile` uses `backend/venv`, not the workspace root `.venv`
+
+## Problems Observed
+
+- The initial XPU wheel install emitted pip dependency resolver warnings for `chatterbox-tts` and `hume-tada`.
+- `backend/venv` originally contained CPU-only PyTorch (`2.11.0+cpu`).
+- `intel_extension_for_pytorch` could not be installed from the PyTorch XPU index in this environment.
+- Even after `torch.xpu` could see the Arc A770, Voicebox still reported CPU in some runtime paths.
+- The `/health` endpoint initially reported `gpu_available: false` and `gpu_type: null` even though raw XPU execution worked.
+
+## Root Cause
+
+- Voicebox still assumed Intel XPU required a successful `intel_extension_for_pytorch` import before treating `torch.xpu` as usable.
+- In this environment, the current PyTorch XPU wheels already expose a working `torch.xpu` runtime without that extra package.
+- That stale import gate existed in three places:
+	- `backend/backends/base.py`
+	- `backend/app.py`
+	- `backend/routes/health.py`
+- The Windows Intel Arc setup path in `justfile` also tried to install `intel-extension-for-pytorch`, which failed and was not needed for the validated runtime.
+
+## Why The Pip Warnings Were Not The Real Failure
+
+- Voicebox intentionally installs `chatterbox-tts` and `hume-tada` with `--no-deps` in `justfile`.
+- `backend/requirements.txt` manually provides the subdependencies Voicebox actually wants.
+- `chatterbox-tts` upstream pins older versions like `torch==2.6.0`, `torchaudio==2.6.0`, `diffusers==0.29.0`, and specific transformer versions.
+- `hume-tada` upstream pins `torch>=2.7,<2.8` and expects `descript-audio-codec`.
+- Because Voicebox intentionally overrides those upstream pins, the resolver warnings after swapping to XPU wheels were expected and did not mean the XPU install had failed.
+
+## Commands Run Today
+
+### 1. Install XPU PyTorch In The Voicebox Backend Environment
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+```
+
+Result:
+
+- Install succeeded.
+- pip printed dependency warnings, but the XPU wheel install itself completed.
+
+### 2. Attempt To Install IPEX Separately
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/pip.exe install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu
+```
+
+Result:
+
+```text
+ERROR: Could not find a version that satisfies the requirement intel-extension-for-pytorch (from versions: none)
+ERROR: No matching distribution found for intel-extension-for-pytorch
+```
+
+### 3. Verify Raw Torch XPU Visibility
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/python.exe -c "import json, torch; info={'torch': torch.__version__, 'cuda': getattr(torch.version, 'cuda', None), 'has_xpu': hasattr(torch, 'xpu'), 'xpu_available': torch.xpu.is_available(), 'xpu_count': torch.xpu.device_count(), 'xpu_name': torch.xpu.get_device_name(0) if torch.xpu.device_count() else None}; print(json.dumps(info, indent=2))"
+```
+
+Validated state after the XPU wheel install:
+
+- `torch`: `2.11.0+xpu`
+- `cuda`: `null`
+- `has_xpu`: `true`
+- `xpu_available`: `true`
+- `xpu_count`: `1`
+- `xpu_name`: `Intel(R) Arc(TM) A770 Graphics`
+
+### 4. Verify XPU Can Execute Tensors
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/python.exe -c "import torch; x=torch.tensor([1.0,2.0]).to('xpu'); y=(x*2).cpu(); print(y.tolist())"
+```
+
+Result:
+
+```text
+[2.0, 4.0]
+```
+
+This proved the Arc A770 was already usable through `torch.xpu` even without `intel_extension_for_pytorch`.
+
+### 5. Verify The Voicebox Device Selector
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/python.exe -c "from backend.backends.base import get_torch_device; print(get_torch_device(allow_xpu=True, allow_directml=True))"
+```
+
+Result after the code fix:
+
+```text
+xpu
+```
+
+### 6. Verify The User-Facing GPU Label
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+./backend/venv/Scripts/python.exe -c "from backend.app import _get_gpu_status; print(_get_gpu_status())"
+```
+
+Result after the code fix:
+
+```text
+XPU (Intel(R) Arc(TM) A770 Graphics)
+```
+
+### 7. Start The Backend Normally Through Just
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+just dev-backend
+```
+
+Observed startup:
+
+```text
+INFO:     Uvicorn running on http://127.0.0.1:17493
+```
+
+### 8. Validate The Health Endpoint
+
+```powershell
+curl -sf http://127.0.0.1:17493/health
+```
+
+Relevant fields after the health route fix:
+
+```json
+{
+	"status": "healthy",
+	"gpu_available": true,
+	"gpu_type": "XPU (Intel(R) Arc(TM) A770 Graphics)",
+	"vram_used_mb": 0.0,
+	"backend_type": "pytorch",
+	"backend_variant": "xpu"
+}
+```
+
+## Code Changes Made Today
+
+### 1. `backend/backends/base.py`
+
+Change:
+
+- Removed the hard dependency on `intel_extension_for_pytorch` from `get_torch_device(... allow_xpu=True)`.
+- Kept the real XPU check as `hasattr(torch, "xpu") and torch.xpu.is_available()`.
+- Broadened the guard from `except ImportError` to `except Exception` so probe failures do not force a false CPU fallback.
+
+Before:
+
+```python
+import intel_extension_for_pytorch  # noqa: F401
+if hasattr(torch, "xpu") and torch.xpu.is_available():
+		return "xpu"
+```
+
+After:
+
+```python
+if hasattr(torch, "xpu") and torch.xpu.is_available():
+		return "xpu"
+```
+
+### 2. `backend/app.py`
+
+Change:
+
+- Removed the same stale IPEX gate from `_get_gpu_status()`.
+- The runtime status label now reports the Arc A770 directly from `torch.xpu`.
+
+### 3. `backend/routes/health.py`
+
+Change:
+
+- Removed the same stale IPEX gate from the `/health` endpoint.
+- The public health JSON now correctly reports XPU availability and `backend_variant: "xpu"`.
+
+### 4. `justfile`
+
+Change:
+
+- Removed the Windows Intel Arc step that attempted to install `intel-extension-for-pytorch` from the XPU index.
+- Removed the same stale manual installation hint from the CPU fallback message.
+- Kept the Arc setup path installing only the XPU-enabled PyTorch packages.
+
+Before:
+
+```powershell
+./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+./backend/venv/Scripts/pip.exe install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu
+```
+
+After:
+
+```powershell
+./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+```
+
+### 5. `README.Wang.md`
+
+Change:
+
+- Replaced the temporary Arc launch note with this full technical work log.
+
+## Verified Outcomes
+
+- Raw `torch.xpu` runtime is working on the Arc A770.
+- Voicebox device selection now returns `xpu`.
+- Voicebox GPU status string now reports `XPU (Intel(R) Arc(TM) A770 Graphics)`.
+- The normal `just dev-backend` path starts successfully.
+- The `/health` endpoint now reports `gpu_available: true` and `backend_variant: "xpu"`.
+- No special runtime flag is required for Intel Arc after these code changes.
+
+## Current Run Instructions
+
+```powershell
+cd C:/AI/intel-ai/voicebox
+just dev
+```
+
+Optional verification:
+
+```powershell
+curl -sf http://127.0.0.1:17493/health
+```
+
+Expected fields:
+
+```json
+{
+	"gpu_available": true,
+	"gpu_type": "XPU (Intel(R) Arc(TM) A770 Graphics)",
+	"backend_type": "pytorch",
+	"backend_variant": "xpu"
+}
+```
+
+## Final Notes
+
+- Always validate Voicebox against `backend/venv`; the workspace root `.venv` is a different interpreter.
+- There is no separate `just dev --xpu` or IPEX launch flag. The correct path is the normal `just dev` flow.
+- Current local modifications are in `README.Wang.md`, `backend/app.py`, `backend/backends/base.py`, `backend/routes/health.py`, and `justfile`.
+- No commit was created in this session; this summary describes the current local diff and the validated runtime behavior.

--- a/backend/app.py
+++ b/backend/app.py
@@ -195,17 +195,15 @@ def _get_gpu_status() -> str:
     elif backend_type == "mlx":
         return "Metal (Apple Silicon via MLX)"
 
-    # Intel XPU (Arc / Data Center) via IPEX
+    # Intel XPU (Arc / Data Center)
     try:
-        import intel_extension_for_pytorch  # noqa: F401
-
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             try:
                 xpu_name = torch.xpu.get_device_name(0)
             except Exception:
                 xpu_name = "Intel GPU"
             return f"XPU ({xpu_name})"
-    except ImportError:
+    except Exception:
         pass
 
     return "None (CPU only)"

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -103,11 +103,9 @@ def get_torch_device(
 
     if allow_xpu:
         try:
-            import intel_extension_for_pytorch  # noqa: F401
-
             if hasattr(torch, "xpu") and torch.xpu.is_available():
                 return "xpu"
-        except ImportError:
+        except Exception:
             pass
 
     if allow_directml:

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -68,15 +68,13 @@ async def health():
     has_xpu = False
     xpu_name = None
     try:
-        import intel_extension_for_pytorch as ipex  # noqa: F401 -- side-effect import enables XPU
-
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             has_xpu = True
             try:
                 xpu_name = torch.xpu.get_device_name(0)
             except Exception:
                 xpu_name = "Intel GPU"
-    except ImportError:
+    except Exception:
         pass
 
     has_directml = False

--- a/docs/content/docs/developer/setup.mdx
+++ b/docs/content/docs/developer/setup.mdx
@@ -42,13 +42,15 @@ Ensure you have these installed:
     [Install Rust](https://rustup.rs)
     ```bash
     rustc --version
+    # Windows: winget install -e --id Rustlang.Rustup
     ```
   </Card>
   <Card title="Just" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 7V4h3"/><path d="M7 4h14v6h-2V6H7V4Z"/><path d="M4 10v10h16V10H4Z"/></svg>}>
     [Install Just](https://github.com/casey/just)
     ```bash
     brew install just  # macOS
-    cargo install just # Linux/Windows
+    cargo install just # Linux
+    winget install Casey.Just # Windows
     ```
   </Card>
 </Cards>

--- a/justfile
+++ b/justfile
@@ -79,12 +79,10 @@ setup-python:
     } elseif ($hasIntelArc) { \
         Write-Host "Intel Arc GPU detected — installing PyTorch with XPU support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu; \
-        & "{{ pip }}" install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu; \
     } else { \
         Write-Host "No NVIDIA or Intel Arc GPU detected — using CPU-only PyTorch."; \
         Write-Host "If you have an Intel Arc GPU, install XPU support manually:"; \
         Write-Host "  pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu"; \
-        Write-Host "  pip install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu"; \
     }
     & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
     & "{{ pip }}" install --no-deps chatterbox-tts

--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ setup-js:
 
 # Start backend (if not already running) + frontend for development
 [unix]
-dev: _ensure-venv _ensure-sidecar
+dev: _ensure-venv _ensure-rust _ensure-sidecar
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -121,7 +121,7 @@ dev: _ensure-venv _ensure-sidecar
     cd {{ tauri_dir }} && bun run tauri dev
 
 [windows]
-dev: _ensure-venv _ensure-sidecar
+dev: _ensure-venv _ensure-rust _ensure-bun _ensure-sidecar
     $backendJob = $null; \
     try { $null = Invoke-WebRequest -Uri "http://127.0.0.1:17493/health" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop; Write-Host "Backend already running on http://localhost:17493" } catch { \
         Write-Host "Starting backend on http://localhost:17493 ..."; \
@@ -129,7 +129,14 @@ dev: _ensure-venv _ensure-sidecar
         Start-Sleep -Seconds 2; \
     }; \
     Write-Host "Starting Tauri desktop app..."; \
-    try { Set-Location "{{ tauri_dir }}"; bun run tauri dev } finally { if ($backendJob) { taskkill /PID $backendJob.Id /T /F 2>$null | Out-Null } }
+    try { \
+        $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+        $bunBin = Join-Path $env:USERPROFILE ".bun\\bin"; \
+        if (Test-Path (Join-Path $cargoBin "cargo.exe")) { $env:PATH = "$cargoBin;$env:PATH" }; \
+        if (Test-Path (Join-Path $bunBin "bun.exe")) { $env:PATH = "$bunBin;$env:PATH" }; \
+        Set-Location "{{ tauri_dir }}"; \
+        bun run tauri dev \
+    } finally { if ($backendJob) { taskkill /PID $backendJob.Id /T /F 2>$null | Out-Null } }
 
 # Start backend only
 [unix]
@@ -142,11 +149,15 @@ dev-backend: _ensure-venv
 
 # Start Tauri desktop app only (backend must be running separately)
 [unix]
-dev-frontend: _ensure-sidecar
+dev-frontend: _ensure-rust _ensure-sidecar
     cd {{ tauri_dir }} && bun run tauri dev
 
 [windows]
-dev-frontend: _ensure-sidecar
+dev-frontend: _ensure-rust _ensure-bun _ensure-sidecar
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+    $bunBin = Join-Path $env:USERPROFILE ".bun\\bin"; \
+    if (Test-Path (Join-Path $cargoBin "cargo.exe")) { $env:PATH = "$cargoBin;$env:PATH" }; \
+    if (Test-Path (Join-Path $bunBin "bun.exe")) { $env:PATH = "$bunBin;$env:PATH" }; \
     Set-Location "{{ tauri_dir }}"; bun run tauri dev
 
 # Start backend (if not already running) + web app (no Tauri)
@@ -178,7 +189,12 @@ dev-web: _ensure-venv
         Start-Sleep -Seconds 2; \
     }; \
     Write-Host "Starting web app..."; \
-    try { Set-Location "{{ web_dir }}"; bun run dev } finally { if ($backendJob) { taskkill /PID $backendJob.Id /T /F 2>$null | Out-Null } }
+    try { \
+        $bunBin = Join-Path $env:USERPROFILE ".bun\\bin"; \
+        if (Test-Path (Join-Path $bunBin "bun.exe")) { $env:PATH = "$bunBin;$env:PATH" }; \
+        Set-Location "{{ web_dir }}"; \
+        bun run dev \
+    } finally { if ($backendJob) { taskkill /PID $backendJob.Id /T /F 2>$null | Out-Null } }
 
 # Kill all dev processes
 [unix]
@@ -203,8 +219,10 @@ build-server: _ensure-venv
     PATH="{{ venv_bin }}:$PATH" ./scripts/build-server.sh
 
 [windows]
-build-server: _ensure-venv
+build-server: _ensure-venv _ensure-rust
     $ErrorActionPreference = "Stop"; \
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+    if (Test-Path (Join-Path $cargoBin "cargo.exe")) { $env:PATH = "$cargoBin;$env:PATH" }; \
     $env:PATH = "{{ venv_bin }};$env:PATH"; \
     & "{{ python }}" backend/build_binary.py; \
     if ($LASTEXITCODE -ne 0) { throw "build_binary.py failed with exit code $LASTEXITCODE" }; \
@@ -215,8 +233,10 @@ build-server: _ensure-venv
 
 # Build CUDA server binary and place in app data dir for local testing
 [windows]
-build-server-cuda: _ensure-venv
+build-server-cuda: _ensure-venv _ensure-rust
     $ErrorActionPreference = "Stop"; \
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+    if (Test-Path (Join-Path $cargoBin "cargo.exe")) { $env:PATH = "$cargoBin;$env:PATH" }; \
     $env:PATH = "{{ venv_bin }};$env:PATH"; \
     & "{{ python }}" backend/build_binary.py --cuda; \
     if ($LASTEXITCODE -ne 0) { throw "build_binary.py --cuda failed with exit code $LASTEXITCODE" }; \
@@ -232,11 +252,13 @@ build-local: build-server build-server-cuda build-tauri
 
 # Build Tauri desktop app
 [unix]
-build-tauri:
+build-tauri: _ensure-rust
     cd {{ tauri_dir }} && bun run tauri build
 
 [windows]
-build-tauri:
+build-tauri: _ensure-rust
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+    if (Test-Path (Join-Path $cargoBin "cargo.exe")) { $env:PATH = "$cargoBin;$env:PATH" }; \
     Set-Location "{{ tauri_dir }}"; bun run tauri build
 
 # Build web app
@@ -413,7 +435,44 @@ _ensure-venv:
 _ensure-venv:
     if (-not (Test-Path "{{ venv }}")) { Write-Host "Python venv not found. Run: just setup"; exit 1 }
 
+[private, unix]
+_ensure-rust:
+    #!/usr/bin/env bash
+    if ! command -v cargo >/dev/null 2>&1 || ! command -v rustc >/dev/null 2>&1; then
+        echo "Rust/Cargo not found. Install Rust from https://rustup.rs and restart your shell."
+        exit 1
+    fi
+
+[private, windows]
+_ensure-rust:
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\\bin"; \
+    $cargoExe = Join-Path $cargoBin "cargo.exe"; \
+    $rustcExe = Join-Path $cargoBin "rustc.exe"; \
+    $hasPathTools = (Get-Command cargo -ErrorAction SilentlyContinue) -and (Get-Command rustc -ErrorAction SilentlyContinue); \
+    $hasRustupTools = (Test-Path $cargoExe) -and (Test-Path $rustcExe); \
+    if (-not $hasPathTools -and -not $hasRustupTools) { \
+        Write-Host "Rust/Cargo not found. Install rustup: winget install -e --id Rustlang.Rustup"; \
+        Write-Host "Restart your shell after installation so cargo.exe is on PATH."; \
+        exit 1; \
+    }
+
+[private, windows]
+_ensure-bun:
+    $bunBin = Join-Path $env:USERPROFILE ".bun\\bin"; \
+    $bunExe = Join-Path $bunBin "bun.exe"; \
+    $hasPathTool = Get-Command bun -ErrorAction SilentlyContinue; \
+    if (-not $hasPathTool -and -not (Test-Path $bunExe)) { \
+        Write-Host "Bun not found. Install Bun from https://bun.sh and reopen your terminal."; \
+        exit 1; \
+    }
+
 # Ensure Tauri dev sidecar placeholder exists
-[private]
+[private, unix]
 _ensure-sidecar:
+    bun run setup:dev
+
+[private, windows]
+_ensure-sidecar: _ensure-bun
+    $bunBin = Join-Path $env:USERPROFILE ".bun\\bin"; \
+    if (Test-Path (Join-Path $bunBin "bun.exe")) { $env:PATH = "$bunBin;$env:PATH" }; \
     bun run setup:dev


### PR DESCRIPTION
# 重大福利：支持 Intel Arc A770 及其它 GPU
## 仅支持开发者模式运行：
`just setup`
`just dev`


# Voicebox Work Summary - 2026-04-28

## Goal

Enable local Voicebox development on Windows with Intel Arc A770 using PyTorch XPU, diagnose the false CPU fallback, and make the normal `just dev` path work without any special runtime flag.

## Environment

- Repository: `voicebox`
- Branch: `dev.1`
- OS: Windows
- GPU: `Intel(R) Arc(TM) A770 Graphics`
- Effective runtime Python environment: `backend/venv`
- Important note: Voicebox `justfile` uses `backend/venv`, not the workspace root `.venv`

## Problems Observed

- The initial XPU wheel install emitted pip dependency resolver warnings for `chatterbox-tts` and `hume-tada`.
- `backend/venv` originally contained CPU-only PyTorch (`2.11.0+cpu`).
- `intel_extension_for_pytorch` could not be installed from the PyTorch XPU index in this environment.
- Even after `torch.xpu` could see the Arc A770, Voicebox still reported CPU in some runtime paths.
- The `/health` endpoint initially reported `gpu_available: false` and `gpu_type: null` even though raw XPU execution worked.

## Root Cause

- Voicebox still assumed Intel XPU required a successful `intel_extension_for_pytorch` import before treating `torch.xpu` as usable.
- In this environment, the current PyTorch XPU wheels already expose a working `torch.xpu` runtime without that extra package.
- That stale import gate existed in three places:
	- `backend/backends/base.py`
	- `backend/app.py`
	- `backend/routes/health.py`
- The Windows Intel Arc setup path in `justfile` also tried to install `intel-extension-for-pytorch`, which failed and was not needed for the validated runtime.

## Why The Pip Warnings Were Not The Real Failure

- Voicebox intentionally installs `chatterbox-tts` and `hume-tada` with `--no-deps` in `justfile`.
- `backend/requirements.txt` manually provides the subdependencies Voicebox actually wants.
- `chatterbox-tts` upstream pins older versions like `torch==2.6.0`, `torchaudio==2.6.0`, `diffusers==0.29.0`, and specific transformer versions.
- `hume-tada` upstream pins `torch>=2.7,<2.8` and expects `descript-audio-codec`.
- Because Voicebox intentionally overrides those upstream pins, the resolver warnings after swapping to XPU wheels were expected and did not mean the XPU install had failed.

## Commands Run Today

### 1. Install XPU PyTorch In The Voicebox Backend Environment

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
```

Result:

- Install succeeded.
- pip printed dependency warnings, but the XPU wheel install itself completed.

### 2. Attempt To Install IPEX Separately

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/pip.exe install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu
```

Result:

```text
ERROR: Could not find a version that satisfies the requirement intel-extension-for-pytorch (from versions: none)
ERROR: No matching distribution found for intel-extension-for-pytorch
```

### 3. Verify Raw Torch XPU Visibility

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/python.exe -c "import json, torch; info={'torch': torch.__version__, 'cuda': getattr(torch.version, 'cuda', None), 'has_xpu': hasattr(torch, 'xpu'), 'xpu_available': torch.xpu.is_available(), 'xpu_count': torch.xpu.device_count(), 'xpu_name': torch.xpu.get_device_name(0) if torch.xpu.device_count() else None}; print(json.dumps(info, indent=2))"
```

Validated state after the XPU wheel install:

- `torch`: `2.11.0+xpu`
- `cuda`: `null`
- `has_xpu`: `true`
- `xpu_available`: `true`
- `xpu_count`: `1`
- `xpu_name`: `Intel(R) Arc(TM) A770 Graphics`

### 4. Verify XPU Can Execute Tensors

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/python.exe -c "import torch; x=torch.tensor([1.0,2.0]).to('xpu'); y=(x*2).cpu(); print(y.tolist())"
```

Result:

```text
[2.0, 4.0]
```

This proved the Arc A770 was already usable through `torch.xpu` even without `intel_extension_for_pytorch`.

### 5. Verify The Voicebox Device Selector

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/python.exe -c "from backend.backends.base import get_torch_device; print(get_torch_device(allow_xpu=True, allow_directml=True))"
```

Result after the code fix:

```text
xpu
```

### 6. Verify The User-Facing GPU Label

```powershell
cd C:/AI/intel-ai/voicebox
./backend/venv/Scripts/python.exe -c "from backend.app import _get_gpu_status; print(_get_gpu_status())"
```

Result after the code fix:

```text
XPU (Intel(R) Arc(TM) A770 Graphics)
```

### 7. Start The Backend Normally Through Just

```powershell
cd C:/AI/intel-ai/voicebox
just dev-backend
```

Observed startup:

```text
INFO:     Uvicorn running on http://127.0.0.1:17493
```

### 8. Validate The Health Endpoint

```powershell
curl -sf http://127.0.0.1:17493/health
```

Relevant fields after the health route fix:

```json
{
	"status": "healthy",
	"gpu_available": true,
	"gpu_type": "XPU (Intel(R) Arc(TM) A770 Graphics)",
	"vram_used_mb": 0.0,
	"backend_type": "pytorch",
	"backend_variant": "xpu"
}
```

## Code Changes Made Today

### 1. `backend/backends/base.py`

Change:

- Removed the hard dependency on `intel_extension_for_pytorch` from `get_torch_device(... allow_xpu=True)`.
- Kept the real XPU check as `hasattr(torch, "xpu") and torch.xpu.is_available()`.
- Broadened the guard from `except ImportError` to `except Exception` so probe failures do not force a false CPU fallback.

Before:

```python
import intel_extension_for_pytorch  # noqa: F401
if hasattr(torch, "xpu") and torch.xpu.is_available():
		return "xpu"
```

After:

```python
if hasattr(torch, "xpu") and torch.xpu.is_available():
		return "xpu"
```

### 2. `backend/app.py`

Change:

- Removed the same stale IPEX gate from `_get_gpu_status()`.
- The runtime status label now reports the Arc A770 directly from `torch.xpu`.

### 3. `backend/routes/health.py`

Change:

- Removed the same stale IPEX gate from the `/health` endpoint.
- The public health JSON now correctly reports XPU availability and `backend_variant: "xpu"`.

### 4. `justfile`

Change:

- Removed the Windows Intel Arc step that attempted to install `intel-extension-for-pytorch` from the XPU index.
- Removed the same stale manual installation hint from the CPU fallback message.
- Kept the Arc setup path installing only the XPU-enabled PyTorch packages.

Before:

```powershell
./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
./backend/venv/Scripts/pip.exe install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu
```

After:

```powershell
./backend/venv/Scripts/pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
```

### 5. `README.Wang.md`

Change:

- Replaced the temporary Arc launch note with this full technical work log.

## Verified Outcomes

- Raw `torch.xpu` runtime is working on the Arc A770.
- Voicebox device selection now returns `xpu`.
- Voicebox GPU status string now reports `XPU (Intel(R) Arc(TM) A770 Graphics)`.
- The normal `just dev-backend` path starts successfully.
- The `/health` endpoint now reports `gpu_available: true` and `backend_variant: "xpu"`.
- No special runtime flag is required for Intel Arc after these code changes.

## Current Run Instructions

```powershell
cd C:/AI/intel-ai/voicebox
just dev
```

Optional verification:

```powershell
curl -sf http://127.0.0.1:17493/health
```

Expected fields:

```json
{
	"gpu_available": true,
	"gpu_type": "XPU (Intel(R) Arc(TM) A770 Graphics)",
	"backend_type": "pytorch",
	"backend_variant": "xpu"
}
```

## Final Notes

- Always validate Voicebox against `backend/venv`; the workspace root `.venv` is a different interpreter.
- There is no separate `just dev --xpu` or IPEX launch flag. The correct path is the normal `just dev` flow.
- Current local modifications are in `README.Wang.md`, `backend/app.py`, `backend/backends/base.py`, `backend/routes/health.py`, and `justfile`.
- No commit was created in this session; this summary describes the current local diff and the validated runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Intel Arc XPU device detection to properly report GPU availability without requiring additional manual setup steps.

* **Documentation**
  * Enhanced developer setup guides with improved Rust and build tool installation instructions for Windows users.
  * Added comprehensive technical documentation for Intel Arc A770 XPU configuration and validation.

* **Chores**
  * Improved build tooling reliability on Windows with automatic tool availability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->