### PR TITLE
fix(backend): enable long-form Whisper transcription on PyTorch path

### DIFF
--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -357,15 +357,17 @@ class PyTorchSTTBackend:
             )
             inputs = inputs.to(self.device)
 
-            # Generate transcription
-            # If language is provided, force it; otherwise let Whisper auto-detect
+            # Generate transcription.
+            # If language is provided, force it; otherwise let Whisper
+            # auto-detect. Pass language/task directly to generate() instead
+            # of building forced_decoder_ids — get_decoder_prompt_ids defaults
+            # to no_timestamps=True, which injects <|notimestamps|> and
+            # disables the timestamp tokens that return_timestamps=True (and
+            # therefore long-form decoding) depend on.
             generate_kwargs = {}
             if language:
-                forced_decoder_ids = self.processor.get_decoder_prompt_ids(
-                    language=language,
-                    task="transcribe",
-                )
-                generate_kwargs["forced_decoder_ids"] = forced_decoder_ids
+                generate_kwargs["language"] = language
+                generate_kwargs["task"] = "transcribe"
 
             with torch.no_grad():
                 predicted_ids = self.model.generate(

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -342,11 +342,18 @@ class PyTorchSTTBackend:
             # state — forcing offline here (issue #462) broke online users
             # whose `get_decoder_prompt_ids` / tokenizer calls issue
             # legitimate metadata lookups.
-            # Process audio
+            # Process audio.
+            # truncation=False + padding="longest" + return_attention_mask=True
+            # are required for long-form transcription. Without them the
+            # feature extractor silently truncates to 30s (Whisper's native
+            # window) and audio past that point is dropped.
             inputs = self.processor(
                 audio,
                 sampling_rate=16000,
                 return_tensors="pt",
+                truncation=False,
+                padding="longest",
+                return_attention_mask=True,
             )
             inputs = inputs.to(self.device)
 
@@ -363,6 +370,8 @@ class PyTorchSTTBackend:
             with torch.no_grad():
                 predicted_ids = self.model.generate(
                     inputs["input_features"],
+                    attention_mask=inputs["attention_mask"],
+                    return_timestamps=True,
                     **generate_kwargs,
                 )
 


### PR DESCRIPTION
The PyTorch Whisper transcribe() called the HF processor without truncation=False and model.generate() without return_timestamps=True. With those defaults, WhisperFeatureExtractor silently truncates inputs to 30 s (Whisper's native receptive field), so any dictation longer than ~30 s lost its tail.

Setting truncation=False + padding="longest" + return_attention_mask=True on the processor, then forwarding the attention mask plus return_timestamps=True to generate(), flips HF Whisper into long-form mode: autoregressive decoding over rolling 30 s windows.

Verified by round-tripping a 56.6 s Kokoro TTS sample through /transcribe — full text returned including content past the 30 s mark; previously the transcript was cut off roughly halfway through.

MLX backend (mlx_backend.py) is intentionally unchanged: mlx_audio.stt's generate() already implements rolling-window long-form transcription with condition_on_previous_text in the upstream library, so it does not have the same bug. The HF-only kwargs added here would also break the MLX call signature.

Closes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved long-form audio transcription with better preprocessing for more reliable results on extended recordings.
  * Timestamps included in transcription output for easier navigation and editing of transcribed audio.
  * Enhanced language handling to produce more accurate transcriptions when a language is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->