### PR TITLE
Fix broken pipe crashes during model loading

### DIFF
--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -5,6 +5,7 @@ PyTorch backend implementation for TTS and STT.
 from typing import Optional, List, Tuple
 import asyncio
 import logging
+from pathlib import Path
 import torch
 import numpy as np
 
@@ -264,7 +265,19 @@ class PyTorchSTTBackend:
 
     def _is_model_cached(self, model_size: str) -> bool:
         hf_repo = WHISPER_HF_REPOS.get(model_size, f"openai/whisper-{model_size}")
-        return is_model_cached(hf_repo)
+        if not is_model_cached(hf_repo):
+            return False
+        try:
+            from huggingface_hub import constants as hf_constants
+
+            snapshots_dir = Path(hf_constants.HF_HUB_CACHE) / ("models--" + hf_repo.replace("/", "--")) / "snapshots"
+            return all(any(snapshots_dir.rglob(fname)) for fname in (
+                "config.json",
+                "preprocessor_config.json",
+                "tokenizer_config.json",
+            ))
+        except Exception:
+            return False
 
     async def load_model_async(self, model_size: Optional[str] = None):
         """
@@ -279,6 +292,9 @@ class PyTorchSTTBackend:
         if self.model is not None and self.model_size == model_size:
             return
 
+        if self.model is not None and self.model_size != model_size:
+            self.unload_model()
+
         await asyncio.to_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
@@ -291,12 +307,18 @@ class PyTorchSTTBackend:
 
         with model_load_progress(progress_model_name, is_cached):
             from transformers import WhisperProcessor, WhisperForConditionalGeneration
+            from huggingface_hub import constants as hf_constants
 
             model_name = WHISPER_HF_REPOS.get(model_size, f"openai/whisper-{model_size}")
             logger.info("Loading Whisper model %s on %s...", model_size, self.device)
 
-            self.processor = WhisperProcessor.from_pretrained(model_name)
-            self.model = WhisperForConditionalGeneration.from_pretrained(model_name)
+            # Keep processor files and model weights in the same cache root.
+            # Otherwise a partial/split cache can make WhisperProcessor miss
+            # preprocessor_config.json even when model weights are present.
+            stt_cache_dir = hf_constants.HF_HUB_CACHE
+
+            self.processor = WhisperProcessor.from_pretrained(model_name, cache_dir=stt_cache_dir)
+            self.model = WhisperForConditionalGeneration.from_pretrained(model_name, cache_dir=stt_cache_dir)
 
         self.model.to(self.device)
         self.model_size = model_size

--- a/backend/pyi_rth_numpy_compat.py
+++ b/backend/pyi_rth_numpy_compat.py
@@ -32,6 +32,53 @@ import sys
 import threading
 
 
+def _install_torch_numpy_fallback(torch, np, ctypes):
+    """Install a torch.from_numpy fallback that works when torch rejects numpy."""
+    if getattr(torch, "_vb_from_numpy_patched", False):
+        return False
+
+    orig_from_numpy = torch.from_numpy
+
+    # Explicit numpy -> torch dtype map. Silent fallback to float32 on
+    # unknown dtypes would reinterpret the memcpy'd bytes as fp32 and
+    # silently corrupt data (e.g. fp16 tensors from some TTS engines),
+    # so we raise instead.
+    dtype_map = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+        "int8": torch.int8,
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "int64": torch.int64,
+        "uint8": torch.uint8,
+        "bool": torch.bool,
+        "complex64": torch.complex64,
+        "complex128": torch.complex128,
+    }
+
+    def _safe_from_numpy(arr, *args, _orig=orig_from_numpy, _c=ctypes, _np=np, _t=torch, _map=dtype_map, **kwargs):
+        try:
+            return _orig(arr, *args, **kwargs)
+        except RuntimeError as err:
+            a = _np.ascontiguousarray(arr)
+            key = str(a.dtype)
+            if key not in _map:
+                raise TypeError(
+                    f"pyi_rth_numpy_compat: unsupported numpy dtype "
+                    f"{key!r} in torch.from_numpy fallback; add an "
+                    f"explicit mapping rather than silently copying "
+                    f"bytes into the wrong dtype."
+                ) from err
+            out = _t.empty(list(a.shape), dtype=_map[key])
+            _c.memmove(out.data_ptr(), a.ctypes.data, a.nbytes)
+            return out
+
+    torch.from_numpy = _safe_from_numpy
+    torch._vb_from_numpy_patched = True
+    return True
+
+
 def _patch_torch_from_numpy():
     import time
 
@@ -46,47 +93,7 @@ def _patch_torch_from_numpy():
             import ctypes
             import numpy as np
 
-            _orig = torch.from_numpy
-
-            # Explicit numpy → torch dtype map. Silent fallback to float32 on
-            # unknown dtypes would reinterpret the memcpy'd bytes as fp32 and
-            # silently corrupt data (e.g. fp16 tensors from some TTS engines),
-            # so we raise instead.
-            dtype_map = {
-                "float16": _t.float16,
-                "float32": _t.float32,
-                "float64": _t.float64,
-                "int8": _t.int8,
-                "int16": _t.int16,
-                "int32": _t.int32,
-                "int64": _t.int64,
-                "uint8": _t.uint8,
-                "bool": _t.bool,
-                "complex64": _t.complex64,
-                "complex128": _t.complex128,
-            }
-
-            def _safe_from_numpy(
-                arr, _orig=_orig, _c=ctypes, _np=np, _t=torch, _map=dtype_map
-            ):
-                try:
-                    return _orig(arr)
-                except RuntimeError:
-                    a = _np.ascontiguousarray(arr)
-                    key = str(a.dtype)
-                    if key not in _map:
-                        raise TypeError(
-                            f"pyi_rth_numpy_compat: unsupported numpy dtype "
-                            f"{key!r} in torch.from_numpy fallback; add an "
-                            f"explicit mapping rather than silently copying "
-                            f"bytes into the wrong dtype."
-                        )
-                    out = _t.empty(list(a.shape), dtype=_map[key])
-                    _c.memmove(out.data_ptr(), a.ctypes.data, a.nbytes)
-                    return out
-
-            torch.from_numpy = _safe_from_numpy
-            torch._vb_from_numpy_patched = True
+            _install_torch_numpy_fallback(torch, np, ctypes)
         except Exception:
             pass
         return

--- a/backend/tests/test_pyi_numpy_compat.py
+++ b/backend/tests/test_pyi_numpy_compat.py
@@ -1,0 +1,97 @@
+"""Regression tests for the PyInstaller numpy/torch compatibility hook."""
+
+import ctypes
+
+import pytest
+
+from backend.pyi_rth_numpy_compat import _install_torch_numpy_fallback
+
+
+class _FakeArray:
+    def __init__(self, values, dtype="float32"):
+        self.dtype = dtype
+        self.shape = (len(values),)
+        self._buffer = (ctypes.c_float * len(values))(*values)
+        self.nbytes = ctypes.sizeof(self._buffer)
+        self.ctypes = type("_Ctypes", (), {"data": ctypes.addressof(self._buffer)})()
+
+    def values(self):
+        return list(self._buffer)
+
+
+class _FakeNP:
+    @staticmethod
+    def ascontiguousarray(arr):
+        return arr
+
+
+class _FakeTensor:
+    def __init__(self, shape):
+        self._buffer = (ctypes.c_float * shape[0])()
+
+    def data_ptr(self):
+        return ctypes.addressof(self._buffer)
+
+    def values(self):
+        return list(self._buffer)
+
+
+class _FakeTorch:
+    float16 = "float16"
+    float32 = "float32"
+    float64 = "float64"
+    int8 = "int8"
+    int16 = "int16"
+    int32 = "int32"
+    int64 = "int64"
+    uint8 = "uint8"
+    bool = "bool"
+    complex64 = "complex64"
+    complex128 = "complex128"
+
+    def __init__(self):
+        self._vb_from_numpy_patched = False
+        self.empty_calls = []
+        self.last_tensor = None
+
+    def from_numpy(self, _arr):
+        raise RuntimeError("Numpy is not available")
+
+    def empty(self, shape, dtype):
+        self.empty_calls.append((shape, dtype))
+        self.last_tensor = _FakeTensor(shape)
+        return self.last_tensor
+
+
+def test_install_torch_numpy_fallback_copies_bytes_after_runtime_error():
+    fake_torch = _FakeTorch()
+    arr = _FakeArray([1.0, 2.0, 3.0, 4.0])
+
+    installed = _install_torch_numpy_fallback(fake_torch, _FakeNP, ctypes)
+    out = fake_torch.from_numpy(arr)
+
+    assert installed is True
+    assert fake_torch._vb_from_numpy_patched is True
+    assert out is fake_torch.last_tensor
+    assert fake_torch.empty_calls == [([4], "float32")]
+    assert out.values() == arr.values()
+
+
+def test_install_torch_numpy_fallback_is_idempotent():
+    fake_torch = _FakeTorch()
+
+    assert _install_torch_numpy_fallback(fake_torch, _FakeNP, ctypes) is True
+    assert _install_torch_numpy_fallback(fake_torch, _FakeNP, ctypes) is False
+
+
+def test_install_torch_numpy_fallback_rejects_unsupported_dtype():
+    fake_torch = _FakeTorch()
+    arr = _FakeArray([1.0], dtype="bfloat16")
+
+    _install_torch_numpy_fallback(fake_torch, _FakeNP, ctypes)
+
+    with pytest.raises(TypeError, match="unsupported numpy dtype 'bfloat16'") as exc_info:
+        fake_torch.from_numpy(arr)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "Numpy is not available"


### PR DESCRIPTION
## Summary
- Fix the PyInstaller NumPy/Torch runtime hook so the torch.from_numpy fallback actually installs
- Harden Whisper cache detection so incomplete caches are not treated as ready
- Load Whisper processor/model files from the same Hugging Face cache root
- Add regression coverage for the PyInstaller NumPy compatibility hook

## Related issues
Fixes/relates to #606
Relates to #304
Relates to #537

## Verification
- `uv run --project backend pytest backend/tests/test_pyi_numpy_compat.py -q`
- `python3 -m py_compile backend/pyi_rth_numpy_compat.py backend/backends/pytorch_backend.py backend/tests/test_pyi_numpy_compat.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Whisper speech-to-text caching and model loading reliability, including stronger cache verification and safer model reload when switching sizes
  * Safer NumPy→Torch fallback handling with clearer error behavior for unsupported dtypes

* **Tests**
  * Added/expanded regression tests covering the NumPy/Torch fallback behavior, idempotency, and unsupported-dtype errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->