### PR TITLE
fix(docker): add ROCm GPU support via compose overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN pip install --no-cache-dir --upgrade pip
 
 COPY backend/requirements.txt .
 
+# ROCm version to pull PyTorch wheels for. Default is 6.3 (supports RDNA1/2/3).
+# Set ROCM_VERSION=7.2 for RDNA 4 (RX 9000 series) support.
+ARG ROCM_VERSION=6.3
+
 # When building the ROCm variant, install the ROCm-enabled PyTorch wheels
 # first so that the subsequent requirements.txt install sees them as already
 # satisfying the torch/torchaudio constraints and leaves them in place.
@@ -52,7 +56,7 @@ COPY backend/requirements.txt .
 RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
       pip install --no-cache-dir --prefix=/install \
         torch torchaudio \
-        --index-url https://download.pytorch.org/whl/rocm6.3; \
+        --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}"; \
     fi
 
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
@@ -70,9 +74,10 @@ ARG PYTORCH_VARIANT=cpu
 
 # ROCm device access requires the container user to belong to the render
 # and video groups. GIDs are parameterised to match the host; Ubuntu 22.04+
-# defaults are used here. Override at build time if your host differs:
-#   docker compose ... --build-arg RENDER_GID=$(getent group render | cut -d: -f3)
-#   docker compose ... --build-arg VIDEO_GID=$(getent group video  | cut -d: -f3)
+# defaults are used here. Override via env vars (docker-compose.rocm.yml
+# passes them through automatically):
+#   export RENDER_GID=$(getent group render | cut -d: -f3)
+#   export VIDEO_GID=$(getent group video  | cut -d: -f3)
 ARG RENDER_GID=992
 ARG VIDEO_GID=44
 RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # ============================================================
-# Voicebox — Local TTS Server with Web UI (CPU)
+# Voicebox — Local TTS Server with Web UI
 # 3-stage build: Frontend → Python deps → Runtime
+#
+# Build variants:
+#   CPU (default):  docker compose up --build
+#   ROCm (AMD GPU): docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
 # ============================================================
+
+# Top-level ARG so it is visible to all stages.
+ARG PYTORCH_VARIANT=cpu
 
 # === Stage 1: Build frontend ===
 FROM oven/bun:1 AS frontend
@@ -24,6 +31,9 @@ RUN cd web && bunx --bun vite build
 # === Stage 2: Build Python dependencies ===
 FROM python:3.11-slim AS backend-builder
 
+# Re-declare ARG inside the stage (Docker scoping requirement).
+ARG PYTORCH_VARIANT=cpu
+
 WORKDIR /build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -34,6 +44,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir --upgrade pip
 
 COPY backend/requirements.txt .
+
+# When building the ROCm variant, install the ROCm-enabled PyTorch wheels
+# first so that the subsequent requirements.txt install sees them as already
+# satisfying the torch/torchaudio constraints and leaves them in place.
+# The CPU path skips this step and installs torch from PyPI as before.
+RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      pip install --no-cache-dir --prefix=/install \
+        torch torchaudio \
+        --index-url https://download.pytorch.org/whl/rocm6.3; \
+    fi
+
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 RUN pip install --no-cache-dir --prefix=/install --no-deps chatterbox-tts
 RUN pip install --no-cache-dir --prefix=/install --no-deps hume-tada
@@ -44,9 +65,29 @@ RUN pip install --no-cache-dir --prefix=/install \
 # === Stage 3: Runtime ===
 FROM python:3.11-slim
 
+# Re-declare ARG inside the stage (Docker scoping requirement).
+ARG PYTORCH_VARIANT=cpu
+
+# ROCm device access requires the container user to belong to the render
+# and video groups. GIDs are parameterised to match the host; Ubuntu 22.04+
+# defaults are used here. Override at build time if your host differs:
+#   docker compose ... --build-arg RENDER_GID=$(getent group render | cut -d: -f3)
+#   docker compose ... --build-arg VIDEO_GID=$(getent group video  | cut -d: -f3)
+ARG RENDER_GID=992
+ARG VIDEO_GID=44
+RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      groupadd -f -g ${RENDER_GID} render && \
+      groupadd -f -g ${VIDEO_GID}  video; \
+    fi
+
 # Create non-root user for security
 RUN groupadd -r voicebox && \
     useradd -r -g voicebox -m -s /bin/bash voicebox
+
+# ROCm: add voicebox user to render+video so it can open /dev/kfd and /dev/dri.
+RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      usermod -aG render,video voicebox; \
+    fi
 
 WORKDIR /app
 

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -8,13 +8,17 @@
 #   2. Current user in the 'render' and 'video' groups:
 #        sudo usermod -aG render,video $USER   (then log out/in)
 #
-# If the container fails to open /dev/kfd with "permission denied", the GIDs of
-# the render and video groups on your host differ from the Ubuntu 22.04 defaults
-# used in the Dockerfile (render=992, video=44). Pass the correct values at
-# build time:
-#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build \
-#     --build-arg RENDER_GID=$(getent group render | cut -d: -f3) \
-#     --build-arg VIDEO_GID=$(getent group video  | cut -d: -f3)
+# If the render/video GIDs on your host differ from the Ubuntu 22.04 defaults
+# (render=992, video=44), export them before running compose so the build arg
+# and group_add values both stay in sync automatically:
+#   export RENDER_GID=$(getent group render | cut -d: -f3)
+#   export VIDEO_GID=$(getent group video  | cut -d: -f3)
+#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
+#
+# ROCm version (ROCM_VERSION):
+#   Default is 6.3 (supports RDNA1/2/3). For RDNA 4 (RX 9000 series) use 7.2:
+#   export ROCM_VERSION=7.2
+#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
 
 services:
   voicebox:
@@ -22,6 +26,11 @@ services:
       context: .
       args:
         PYTORCH_VARIANT: rocm
+        # These build args read from env vars so a single export covers both the
+        # Dockerfile group creation and the runtime group_add below.
+        RENDER_GID: ${RENDER_GID:-992}
+        VIDEO_GID: ${VIDEO_GID:-44}
+        ROCM_VERSION: ${ROCM_VERSION:-6.3}
 
     # Pass the AMD GPU device nodes into the container.
     # /dev/kfd  — ROCm compute interface (required for GPU inference)
@@ -32,17 +41,18 @@ services:
 
     # Grant access to the render and video groups so the non-root user
     # inside the container can open the GPU device nodes.
-    # Numeric GIDs work even when group names differ between host and container.
-    # Check yours with: getent group render video | cut -d: -f3
+    # These reference the same env vars used in build.args above so a
+    # single export keeps Dockerfile groups and runtime group_add in sync.
     group_add:
-      - "992"   # render — Ubuntu 22.04+ default; adjust if different on your host
-      - "44"    # video  — Ubuntu 22.04+ default; adjust if different on your host
+      - "${RENDER_GID:-992}"   # render
+      - "${VIDEO_GID:-44}"     # video
 
     environment:
       # HSA_OVERRIDE_GFX_VERSION forces the ROCm runtime to treat the GPU as a
       # specific GFX version when auto-detection fails or the GPU is newer than
       # the ROCm release. app.py sets 10.3.0 (RDNA2) by default; override here
       # for your GPU family:
+      #   RDNA4 / RX 9000 series:              12.0.0  (requires ROCM_VERSION=7.2)
       #   RDNA3 / RX 7000 series / Strix Halo: 11.0.0
       #   RDNA2 / RX 6000 series:              10.3.0
       #   RDNA1 / RX 5000 series:              10.1.0

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -1,0 +1,54 @@
+# ROCm (AMD GPU) overlay for Voicebox
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
+#
+# Prerequisites on the host:
+#   1. ROCm drivers installed — https://rocm.docs.amd.com/projects/install-on-linux
+#   2. Current user in the 'render' and 'video' groups:
+#        sudo usermod -aG render,video $USER   (then log out/in)
+#
+# If the container fails to open /dev/kfd with "permission denied", the GIDs of
+# the render and video groups on your host differ from the Ubuntu 22.04 defaults
+# used in the Dockerfile (render=992, video=44). Pass the correct values at
+# build time:
+#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build \
+#     --build-arg RENDER_GID=$(getent group render | cut -d: -f3) \
+#     --build-arg VIDEO_GID=$(getent group video  | cut -d: -f3)
+
+services:
+  voicebox:
+    build:
+      context: .
+      args:
+        PYTORCH_VARIANT: rocm
+
+    # Pass the AMD GPU device nodes into the container.
+    # /dev/kfd  — ROCm compute interface (required for GPU inference)
+    # /dev/dri  — DRM render nodes (required for display/memory access)
+    devices:
+      - /dev/kfd
+      - /dev/dri
+
+    # Grant access to the render and video groups so the non-root user
+    # inside the container can open the GPU device nodes.
+    # Numeric GIDs work even when group names differ between host and container.
+    # Check yours with: getent group render video | cut -d: -f3
+    group_add:
+      - "992"   # render — Ubuntu 22.04+ default; adjust if different on your host
+      - "44"    # video  — Ubuntu 22.04+ default; adjust if different on your host
+
+    environment:
+      # HSA_OVERRIDE_GFX_VERSION forces the ROCm runtime to treat the GPU as a
+      # specific GFX version when auto-detection fails or the GPU is newer than
+      # the ROCm release. app.py sets 10.3.0 (RDNA2) by default; override here
+      # for your GPU family:
+      #   RDNA3 / RX 7000 series / Strix Halo: 11.0.0
+      #   RDNA2 / RX 6000 series:              10.3.0
+      #   RDNA1 / RX 5000 series:              10.1.0
+      #   Vega / GCN5:                          9.0.0
+      - HSA_OVERRIDE_GFX_VERSION=11.0.0
+
+      # Tune the ROCm memory allocator to reduce fragmentation during
+      # multi-engine inference (TTS + STT + LLM running concurrently).
+      - PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.8,max_split_size_mb:512

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Voicebox — CPU build (default)
+# For AMD ROCm GPU acceleration use the overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
+
 services:
   voicebox:
     build: .


### PR DESCRIPTION
Fixes #618.

## Root cause

The Docker image installs CPU-only PyTorch from PyPI by default (`torch>=2.2.0` resolves to the CPU wheel). Even when users correctly pass `/dev/kfd` and `/dev/dri` device nodes into the container (as the reporter did), `torch.cuda.is_available()` returns `False` and the GPU is reported as `None (CPU only)` — because the compute library inside the wheel has no ROCm support.

## Changes

### `Dockerfile`
- Adds a `PYTORCH_VARIANT` build arg (default: `cpu`).
- When `PYTORCH_VARIANT=rocm`, installs ROCm 6.3 PyTorch wheels from `download.pytorch.org/whl/rocm6.3` **before** `requirements.txt` runs. pip sees the ROCm build as already satisfying `torch>=2.2.0` and does not overwrite it with the CPU wheel.
- Creates `render` and `video` groups with parameterised GIDs (`RENDER_GID` / `VIDEO_GID`, defaulting to Ubuntu 22.04 values: 992 / 44) and adds the `voicebox` user to both, so it can open `/dev/kfd` and `/dev/dri` as a non-root user.
- The CPU default path is **unchanged** — no extra build time, no image size increase.

### `docker-compose.rocm.yml` _(new)_
Compose overlay that wires everything together:
- `PYTORCH_VARIANT: rocm` build arg
- `/dev/kfd` + `/dev/dri` device passthrough
- `group_add` for render (`992`) and video (`44`) with instructions for overriding on non-Ubuntu hosts
- `HSA_OVERRIDE_GFX_VERSION=11.0.0` for RDNA3/Strix Halo (comment lists values for RDNA2/RDNA1/Vega)
- `PYTORCH_HIP_ALLOC_CONF` tuned for multi-engine inference

### `docker-compose.yml`
Added a one-line comment pointing to the ROCm overlay.

## Usage

```bash
docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
```

If `/dev/kfd` permission is denied, override the GIDs to match the host:
```bash
docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build \
  --build-arg RENDER_GID=$(getent group render | cut -d: -f3) \
  --build-arg VIDEO_GID=$(getent group video  | cut -d: -f3)
```

`HSA_OVERRIDE_GFX_VERSION` in `docker-compose.rocm.yml` defaults to `11.0.0` (RDNA3). Edit it to match your GPU if needed (comment in the file lists common values).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AMD GPU (ROCm) build variant and a compose override to enable GPU-accelerated deployments with appropriate runtime device access and group mappings.
* **Documentation**
  * Updated setup guidance and comments explaining how to enable and configure ROCm/GPU builds and runtime prerequisites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->