### PR TITLE
feat: add Blackwell GPU arch mismatch diagnostic

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -151,13 +151,24 @@ def check_cuda_compatibility() -> tuple[bool, str | None]:
             # Check for both sm_XX and compute_XX (JIT-compiled) entries
             compute_tag = f"compute_{major}{minor}"
             if sm_tag not in arch_list and compute_tag not in arch_list:
-                return False, (
-                    f"{device_name} (compute capability {capability} / {sm_tag}) "
-                    f"is not supported by this PyTorch build. "
-                    f"Supported architectures: {', '.join(arch_list)}. "
-                    f"Install PyTorch nightly (cu128) for newer GPU support: "
-                    f"pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128"
-                )
+                # Blackwell (sm_120+) requires the cu128 binary; give a
+                # clear, actionable message that names the re-download path.
+                if major >= 12:
+                    msg = (
+                        f"Your GPU ({device_name}, {sm_tag}) requires the "
+                        f"Blackwell CUDA binary. "
+                        f"Go to Settings → Server → GPU Acceleration "
+                        f"to re-download the correct binary."
+                    )
+                else:
+                    msg = (
+                        f"{device_name} (compute capability {capability} / {sm_tag}) "
+                        f"is not supported by this PyTorch build. "
+                        f"Supported architectures: {', '.join(arch_list)}. "
+                        f"Go to Settings → Server → GPU Acceleration "
+                        f"to download a compatible CUDA binary."
+                    )
+                return False, msg
     except AttributeError:
         pass
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -474,6 +474,7 @@ class ModelStatus(BaseModel):
     downloading: bool = False  # True if download is in progress
     size_mb: Optional[float] = None
     loaded: bool = False
+    cuda_arch_warning: Optional[str] = None  # Set when GPU arch mismatches the CUDA binary
 
 
 class ModelStatusListResponse(BaseModel):

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -242,6 +242,18 @@ async def get_model_status():
 
     from ..backends import get_all_model_configs, check_model_loaded
 
+    # Check once — a CUDA arch mismatch affects every model on this machine.
+    cuda_arch_warning: str | None = None
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            from ..backends.base import check_cuda_compatibility
+
+            _ok, cuda_arch_warning = check_cuda_compatibility()
+    except Exception:
+        pass
+
     registry_configs = get_all_model_configs()
     model_configs = [
         {
@@ -359,6 +371,7 @@ async def get_model_status():
                     downloading=is_downloading,
                     size_mb=size_mb,
                     loaded=loaded,
+                    cuda_arch_warning=cuda_arch_warning,
                 )
             )
         except Exception:
@@ -378,6 +391,7 @@ async def get_model_status():
                     downloading=is_downloading,
                     size_mb=None,
                     loaded=loaded,
+                    cuda_arch_warning=cuda_arch_warning,
                 )
             )
 

--- a/backend/utils/platform_detect.py
+++ b/backend/utils/platform_detect.py
@@ -3,17 +3,35 @@ Platform detection for backend selection.
 """
 
 import platform
-from typing import Literal
+from typing import Literal, Optional
 
 
 def is_apple_silicon() -> bool:
     """
     Check if running on Apple Silicon (arm64 macOS).
-    
+
     Returns:
         True if on Apple Silicon, False otherwise
     """
     return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
+def get_cuda_arch() -> Optional[str]:
+    """Return the SM architecture string for the primary CUDA GPU, or None.
+
+    Examples: ``"sm_90"`` for an RTX 4090, ``"sm_120"`` for an RTX 5090
+    (Blackwell).  Returns ``None`` when no CUDA GPU is present or torch is
+    not installed.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        major, minor = torch.cuda.get_device_capability(0)
+        return f"sm_{major}{minor}"
+    except Exception:
+        return None
 
 
 def get_backend_type() -> Literal["mlx", "pytorch"]:


### PR DESCRIPTION
RTX 5000-series (Blackwell, sm_100) GPUs produce a CUDA arch mismatch error during model load that surfaces as a generic crash — confusing for users who just got a new GPU and expect it to work.

This adds detection for the specific error pattern and shows a clear user-facing message: the installed CUDA libraries were compiled for an older architecture and need to be updated. Points to the resolution path instead of leaving the user with a raw stack trace.

Affected: Windows and Linux users with RTX 5080/5090 (Blackwell, compute capability 10.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GPU architecture compatibility detection with customized warning messages based on GPU type
  * Blackwell-class GPU users receive specific instructions to download the correct CUDA binary from Settings

* **Bug Fixes**
  * Improved CUDA compatibility checking with clearer guidance when GPU architecture doesn't match installed CUDA binary
  * More informative error messages for unsupported GPU configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/653)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->