### PR TITLE
feat: add GitHub Pages deployment for docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -20,6 +18,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -41,6 +41,9 @@ jobs:
           path: docs/out
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install docs dependencies
+        working-directory: docs
+        run: bun install --frozen-lockfile
+
+      - name: Build docs
+        working-directory: docs
+        run: bun run build
+        env:
+          NEXT_STATIC_EXPORT: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,7 +1,11 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-export const { GET } = createFromSource(source, {
+const search = createFromSource(source, {
   // https://docs.orama.com/docs/orama-js/supported-languages
   language: 'english',
 });
+
+export const GET = process.env.NEXT_STATIC_EXPORT
+  ? search.staticGET
+  : search.GET;

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -6,6 +6,8 @@ const search = createFromSource(source, {
   language: 'english',
 });
 
-export const GET = process.env.NEXT_STATIC_EXPORT
+const isStaticExport = process.env.NEXT_STATIC_EXPORT === 'true';
+
+export const GET = isStaticExport
   ? search.staticGET
   : search.GET;

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -2,13 +2,17 @@ import { createMDX } from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 
+const isStaticExport = process.env.NEXT_STATIC_EXPORT === 'true';
+
 /** @type {import('next').NextConfig} */
 const config = {
-  output: 'export',
-  basePath: '/voicebox',
-  images: { unoptimized: true },
+  ...(isStaticExport && {
+    output: 'export',
+    basePath: '/voicebox',
+    images: { unoptimized: true },
+  }),
   reactStrictMode: true,
-  ...(!process.env.NEXT_STATIC_EXPORT && {
+  ...(!isStaticExport && {
     async rewrites() {
       return [
         {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,15 +4,20 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
+  output: 'export',
+  basePath: '/voicebox',
+  images: { unoptimized: true },
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: '/docs/:path*.mdx',
-        destination: '/llms.mdx/docs/:path*',
-      },
-    ];
-  },
+  ...(!process.env.NEXT_STATIC_EXPORT && {
+    async rewrites() {
+      return [
+        {
+          source: '/docs/:path*.mdx',
+          destination: '/llms.mdx/docs/:path*',
+        },
+      ];
+    },
+  }),
   webpack: (config) => {
     config.experiments = {
       ...config.experiments,


### PR DESCRIPTION
Automates documentation deployment to GitHub Pages on pushes to `main`.

Previously, docs had to be deployed manually or weren't deployed at all. This adds a workflow that builds and publishes the docs site automatically, so the published docs stay in sync with the codebase without any manual step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation site is now automatically deployed to GitHub Pages when documentation is updated.

* **Chores**
  * Implemented GitHub Actions workflow for automated documentation deployment.
  * Updated documentation configuration for static site export with optimization settings.
  * Updated search API functionality to support static export mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/655)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->