### PR TITLE
refactor: remove debug console.log statements from hot-path components

### DIFF
--- a/app/src/components/ServerSettings/ModelProgress.tsx
+++ b/app/src/components/ServerSettings/ModelProgress.tsx
@@ -28,8 +28,6 @@ export function ModelProgress({
       return;
     }
 
-    console.log(`[ModelProgress] Connecting SSE for ${modelName}`);
-
     // Subscribe to progress updates via Server-Sent Events
     const eventSource = new EventSource(`${serverUrl}/models/progress/${modelName}`);
 
@@ -40,21 +38,18 @@ export function ModelProgress({
 
         // Close connection if complete or error
         if (data.status === 'complete' || data.status === 'error') {
-          console.log(`[ModelProgress] Download ${data.status} for ${modelName}, closing SSE`);
           eventSource.close();
         }
-      } catch (error) {
-        console.error('Error parsing progress event:', error);
+      } catch {
+        // Ignore malformed SSE frames
       }
     };
 
-    eventSource.onerror = (error) => {
-      console.error(`[ModelProgress] SSE error for ${modelName}:`, error);
+    eventSource.onerror = () => {
       eventSource.close();
     };
 
     return () => {
-      console.log(`[ModelProgress] Cleanup - closing SSE for ${modelName}`);
       eventSource.close();
     };
   }, [serverUrl, modelName, isDownloading]);

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -561,18 +561,10 @@ class ApiClient {
   }
 
   async triggerModelDownload(modelName: string): Promise<{ message: string }> {
-    console.log(
-      '[API] triggerModelDownload called for:',
-      modelName,
-      'at',
-      new Date().toISOString(),
-    );
-    const result = await this.request<{ message: string }>('/models/download', {
+    return this.request<{ message: string }>('/models/download', {
       method: 'POST',
       body: JSON.stringify({ model_name: modelName } as ModelDownloadRequest),
     });
-    console.log('[API] triggerModelDownload response:', result);
-    return result;
   }
 
   async deleteModel(modelName: string): Promise<{ message: string }> {

--- a/app/src/lib/hooks/useModelDownloadToast.tsx
+++ b/app/src/lib/hooks/useModelDownloadToast.tsx
@@ -40,19 +40,9 @@ export function useModelDownloadToast({
   }, []);
 
   useEffect(() => {
-    console.log('[useModelDownloadToast] useEffect triggered', {
-      enabled,
-      serverUrl,
-      modelName,
-      displayName,
-    });
-
     if (!enabled || !serverUrl || !modelName) {
-      console.log('[useModelDownloadToast] Not enabled, skipping');
       return;
     }
-
-    console.log('[useModelDownloadToast] Creating toast and EventSource for:', modelName);
 
     // Create initial toast
     const toastResult = toast({
@@ -70,15 +60,9 @@ export function useModelDownloadToast({
 
     // Subscribe to progress updates via Server-Sent Events
     const eventSourceUrl = `${serverUrl}/models/progress/${modelName}`;
-    console.log('[useModelDownloadToast] Creating EventSource to:', eventSourceUrl);
     const eventSource = new EventSource(eventSourceUrl);
 
-    eventSource.onopen = () => {
-      console.log('[useModelDownloadToast] EventSource connection opened for:', modelName);
-    };
-
     eventSource.onmessage = (event) => {
-      console.log('[useModelDownloadToast] Received SSE message:', event.data);
       try {
         const progress = JSON.parse(event.data) as ModelProgress;
 
@@ -141,11 +125,6 @@ export function useModelDownloadToast({
           const isError = progress.status === 'error';
 
           if (isComplete || isError) {
-            console.log('[useModelDownloadToast] Download finished:', {
-              isComplete,
-              isError,
-              progress: progress.progress,
-            });
             eventSource.close();
             eventSourceRef.current = null;
 
@@ -165,10 +144,8 @@ export function useModelDownloadToast({
 
             // Call callbacks
             if (isComplete && onComplete) {
-              console.log('[useModelDownloadToast] Download complete, calling onComplete callback');
               onComplete();
             } else if (isError && onError) {
-              console.log('[useModelDownloadToast] Download error, calling onError callback');
               onError(progress.error || 'Unknown error');
             }
           }
@@ -178,9 +155,7 @@ export function useModelDownloadToast({
       }
     };
 
-    eventSource.onerror = (error) => {
-      console.error('[useModelDownloadToast] SSE error for:', modelName, error);
-      console.log('[useModelDownloadToast] EventSource readyState:', eventSource.readyState);
+    eventSource.onerror = () => {
       eventSource.close();
       eventSourceRef.current = null;
 
@@ -201,7 +176,6 @@ export function useModelDownloadToast({
 
     // Cleanup on unmount or when disabled
     return () => {
-      console.log('[useModelDownloadToast] Cleanup - closing EventSource for:', modelName);
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;

--- a/app/src/lib/hooks/useStoryPlayback.ts
+++ b/app/src/lib/hooks/useStoryPlayback.ts
@@ -39,10 +39,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
   const getAudioContext = useCallback(() => {
     if (!audioContextRef.current) {
       audioContextRef.current = new AudioContext();
-      console.log(
-        '[StoryPlayback] Created AudioContext, sample rate:',
-        audioContextRef.current.sampleRate,
-      );
 
       // Create master gain node for volume control
       masterGainRef.current = audioContextRef.current.createGain();
@@ -123,31 +119,22 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
       const key = getAudioKey(item);
       if (!audioBuffersRef.current.has(key)) {
         const audioUrl = getAudioUrlForItem(item);
-        console.log('[StoryPlayback] Preloading audio buffer:', key);
 
         const preloadPromise = fetch(audioUrl)
           .then((response) => response.arrayBuffer())
           .then((arrayBuffer) => audioContext.decodeAudioData(arrayBuffer))
           .then((audioBuffer) => {
             audioBuffersRef.current.set(key, audioBuffer);
-            console.log(
-              '[StoryPlayback] Preloaded buffer:',
-              key,
-              'duration:',
-              audioBuffer.duration,
-            );
           })
-          .catch((err) => {
-            console.error('[StoryPlayback] Failed to preload audio:', key, err);
+          .catch(() => {
+            // Failed to preload — item will be skipped during playback
           });
 
         preloadPromises.push(preloadPromise);
       }
     }
 
-    Promise.all(preloadPromises).then(() => {
-      console.log('[StoryPlayback] Preloaded', audioBuffersRef.current.size, 'audio buffers');
-    });
+    Promise.all(preloadPromises);
   }, [items, getAudioContext]);
 
   // Cleanup AudioContext on unmount
@@ -219,7 +206,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
 
   // Stop all sources
   const stopAllSources = useCallback(() => {
-    console.log('[StoryPlayback] Stopping all sources');
     for (const [itemId] of activeSourcesRef.current) {
       stopSource(itemId);
     }
@@ -249,7 +235,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
           const bufferKey = getAudioKey(item);
           const buffer = audioBuffersRef.current.get(bufferKey);
           if (!buffer) {
-            console.warn('[StoryPlayback] Buffer not loaded for:', bufferKey);
             continue;
           }
 
@@ -270,16 +255,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
 
           // If the item should have already started, schedule it to start immediately
           const startAtContextTime = Math.max(currentContextTime, itemStartContextTime);
-
-          console.log('[StoryPlayback] Scheduling source:', {
-            itemId: item.id,
-            generationId: item.generation_id,
-            storyTimeMs,
-            itemStart: item.start_time_ms,
-            offsetIntoBuffer,
-            startAtContextTime,
-            duration,
-          });
 
           const source = audioContext.createBufferSource();
           source.buffer = buffer;
@@ -307,7 +282,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
 
           // Clean up when source ends
           source.onended = () => {
-            console.log('[StoryPlayback] Source ended:', item.id);
             activeSourcesRef.current.delete(item.id);
           };
         }
@@ -348,7 +322,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
       if (currentStoryTime >= totalDuration) {
         // Check if all sources have ended
         if (activeSourcesRef.current.size === 0) {
-          console.log('[StoryPlayback] Reached end');
           useStoryStore.getState().stop();
           return;
         }
@@ -385,7 +358,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
   // Handle play/pause changes - stop sources when paused
   useEffect(() => {
     if (!isPlaying) {
-      console.log('[StoryPlayback] Stopping playback');
       stopAllSources();
     }
   }, [isPlaying, stopAllSources]);
@@ -405,10 +377,6 @@ export function useStoryPlayback(items: StoryItemDetail[] | undefined) {
     const currentContextTime = audioContext.currentTime;
     const currentStoryTime = useStoryStore.getState().currentTimeMs;
 
-    console.log('[StoryPlayback] Setting timing anchors after seek:', {
-      contextTime: currentContextTime,
-      storyTime: currentStoryTime,
-    });
     setPlaybackTiming(currentContextTime, currentStoryTime);
 
     // Stop all existing sources and reschedule from new position

--- a/app/src/stores/storyStore.ts
+++ b/app/src/stores/storyStore.ts
@@ -69,20 +69,6 @@ export const useStoryStore = create<StoryPlaybackState>((set, get) => ({
     const shouldResume = currentState.playbackStoryId === storyId && currentState.currentTimeMs > 0;
     const startTimeMs = shouldResume ? currentState.currentTimeMs : minStartTimeMs;
 
-    console.log('[StoryStore] Play called:', {
-      storyId,
-      itemCount: items.length,
-      items: items.map((i) => ({
-        id: i.generation_id,
-        start: i.start_time_ms,
-        duration: i.duration,
-      })),
-      maxEndTimeMs,
-      minStartTimeMs,
-      startTimeMs,
-      shouldResume,
-    });
-
     set({
       isPlaying: true,
       playbackStoryId: storyId,


### PR DESCRIPTION
Removes leftover `console.log` statements from story playback, the API client, and other components that run on every interaction. These were added during development and not removed before merge.

Two reasons to remove them: (1) console output in production is noise that makes real errors harder to spot, and (2) string interpolation for log messages has a small but real cost in tight loops.