### PR TITLE
fix: the justfile syntax errror, GPU information cannot be read

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,10 +69,10 @@ setup-python:
     }
     Write-Host "Installing Python dependencies..."
     & "{{ python }}" -m pip install --upgrade pip -q
-    $gpus = Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name
-    Write-Host "Detected GPUs: $($gpus -join ', ')"
-    $hasNvidia = ($gpus | Where-Object { $_ -match 'NVIDIA' }).Count -gt 0
-    $hasIntelArc = ($gpus | Where-Object { $_ -match 'Arc' }).Count -gt 0
+    $gpus = Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name; \
+    Write-Host "Detected GPUs: $($gpus -join ', ')"; \
+    $hasNvidia = ($gpus | Where-Object { $_ -match 'NVIDIA' }).Count -gt 0; \
+    $hasIntelArc = ($gpus | Where-Object { $_ -match 'Arc' }).Count -gt 0; \
     if ($hasNvidia) { \
         Write-Host "NVIDIA GPU detected — installing PyTorch with CUDA support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128; \


### PR DESCRIPTION
The absence of `\` prevents the GPU information cannot be read.(Windows)
i don't know JUST. you can ignore this issue if it can work in other development environment. ;D

