### PR TITLE
feat(backends): add Supertonic-3 TTS backend (ONNX, CPU, 31 langs)

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -215,6 +215,7 @@ TTS_ENGINES = {
     "chatterbox_turbo": "Chatterbox Turbo",
     "tada": "TADA",
     "kokoro": "Kokoro",
+    "supertonic": "Supertonic-3",
 }
 
 LLM_ENGINES = {
@@ -363,6 +364,18 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             hf_repo_id="hexgrad/Kokoro-82M",
             size_mb=350,
             languages=["en", "es", "fr", "hi", "it", "pt", "ja", "zh"],
+        ),
+        ModelConfig(
+            model_name="supertonic-3",
+            display_name="Supertonic-3 (ONNX, CPU, 31 langs)",
+            engine="supertonic",
+            hf_repo_id="Supertone/supertonic-3",
+            size_mb=400,
+            languages=[
+                "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es",
+                "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv",
+                "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi",
+            ],
         ),
     ]
 
@@ -704,6 +717,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .kokoro_backend import KokoroTTSBackend
 
             backend = KokoroTTSBackend()
+        elif engine == "supertonic":
+            from .supertonic_backend import SupertonicTTSBackend
+
+            backend = SupertonicTTSBackend()
         elif engine == "qwen_custom_voice":
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 

--- a/backend/backends/supertonic_backend.py
+++ b/backend/backends/supertonic_backend.py
@@ -1,0 +1,173 @@
+"""
+Supertonic-3 TTS backend implementation.
+
+Wraps the Supertonic-3 model (Supertone/supertonic-3 on HuggingFace) — a fast
+ONNX-based multilingual TTS that runs entirely on CPU. ~66-99M params, 31
+languages, ~167x realtime on consumer hardware.
+
+Supertonic uses pre-built voice style files (M1-M5, F1-F5), not zero-shot
+cloning from arbitrary audio. Voice prompts are preset references.
+
+Cache layout differs from other backends: Supertonic downloads to
+~/.cache/supertonic3/ rather than the HuggingFace Hub cache, so we detect
+cached state by inspecting that directory directly.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from . import TTSBackend
+from .base import (
+    combine_voice_prompts as _combine_voice_prompts,
+    model_load_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+SUPERTONIC_HF_REPO = "Supertone/supertonic-3"
+SUPERTONIC_DEFAULT_VOICE = "M1"
+SUPERTONIC_FALLBACK_SAMPLE_RATE = 44100  # Resolved from tts.sample_rate at runtime when possible
+
+SUPERTONIC_VOICES = [
+    ("M1", "Male 1", "male", "multi"),
+    ("M2", "Male 2", "male", "multi"),
+    ("M3", "Male 3", "male", "multi"),
+    ("M4", "Male 4", "male", "multi"),
+    ("M5", "Male 5", "male", "multi"),
+    ("F1", "Female 1", "female", "multi"),
+    ("F2", "Female 2", "female", "multi"),
+    ("F3", "Female 3", "female", "multi"),
+    ("F4", "Female 4", "female", "multi"),
+    ("F5", "Female 5", "female", "multi"),
+]
+
+SUPERTONIC_LANGUAGES = [
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es",
+    "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv",
+    "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi",
+]
+
+
+def _supertonic_cache_dir() -> Path:
+    return Path(os.path.expanduser("~/.cache/supertonic3"))
+
+
+class SupertonicTTSBackend:
+    """Supertonic-3 TTS backend — ONNX, CPU, 31 langs, preset voices."""
+
+    def __init__(self):
+        self._tts = None
+        self.model_size = "default"
+
+    def is_loaded(self) -> bool:
+        return self._tts is not None
+
+    def _get_model_path(self, model_size: str) -> str:
+        return SUPERTONIC_HF_REPO
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        """Supertonic ships ONNX bundles to ~/.cache/supertonic3/."""
+        cache = _supertonic_cache_dir()
+        if not cache.exists():
+            return False
+        # Any of the four ONNX files indicates the bundle was unpacked.
+        for name in ("vocoder.onnx", "text_encoder.onnx", "duration_predictor.onnx", "vector_estimator.onnx"):
+            if any(cache.rglob(name)):
+                return True
+        return False
+
+    async def load_model(self, model_size: str = "default") -> None:
+        if self._tts is not None:
+            return
+        await asyncio.to_thread(self._load_model_sync)
+
+    def _load_model_sync(self):
+        model_name = "supertonic"
+        is_cached = self._is_model_cached()
+
+        # supertonic downloads via huggingface_hub, so HF tqdm progress fires
+        # through model_load_progress even though the destination dir is custom.
+        with model_load_progress(model_name, is_cached):
+            from supertonic import TTS
+
+            logger.info("Loading Supertonic-3 (ONNX, CPU)...")
+            self._tts = TTS(auto_download=True)
+
+        logger.info("Supertonic-3 loaded successfully")
+
+    def unload_model(self) -> None:
+        if self._tts is not None:
+            del self._tts
+            self._tts = None
+            logger.info("Supertonic-3 unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> tuple[dict, bool]:
+        """
+        Supertonic does not support zero-shot cloning from arbitrary audio.
+        Voice prompts are always preset references; the cloned-profile path
+        falls back to the default voice.
+        """
+        return {
+            "voice_type": "preset",
+            "preset_engine": "supertonic",
+            "preset_voice_id": SUPERTONIC_DEFAULT_VOICE,
+        }, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
+        sr = self._sample_rate()
+        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=sr)
+
+    def _sample_rate(self) -> int:
+        if self._tts is not None:
+            sr = getattr(self._tts, "sample_rate", None)
+            if isinstance(sr, (int, float)) and sr > 0:
+                return int(sr)
+        return SUPERTONIC_FALLBACK_SAMPLE_RATE
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> tuple[np.ndarray, int]:
+        await self.load_model()
+
+        voice_name = (
+            voice_prompt.get("preset_voice_id")
+            or voice_prompt.get("supertonic_voice")
+            or SUPERTONIC_DEFAULT_VOICE
+        )
+        lang = language if language in SUPERTONIC_LANGUAGES else "en"
+
+        def _generate_sync():
+            if seed is not None:
+                # Supertonic's vector estimator samples noisy latents via np.random.randn.
+                np.random.seed(seed)
+
+            style = self._tts.get_voice_style(voice_name=voice_name)
+            wav, _duration = self._tts.synthesize(text, voice_style=style, lang=lang)
+
+            audio = np.asarray(wav, dtype=np.float32)
+            if audio.ndim > 1:
+                audio = audio.squeeze()
+            if audio.ndim == 0:
+                audio = audio.reshape(1)
+            return audio, self._sample_rate()
+
+        return await asyncio.to_thread(_generate_sync)

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,7 +18,7 @@ class VoiceProfileCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
     language: str = Field(
-        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|bg|cs|et|hr|hu|id|lt|lv|ro|sk|sl|uk|vi)$"
     )
     voice_type: Optional[str] = Field(default="cloned", pattern="^(cloned|preset|designed)$")
     preset_engine: Optional[str] = Field(None, max_length=50)
@@ -81,11 +81,11 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$")
+    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|bg|cs|et|hr|hu|id|lt|lv|ro|sk|sl|uk|vi)$")
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|supertonic)$")
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -317,7 +317,7 @@ class MCPClientBindingResponse(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|supertonic)$",
     )
     default_personality: bool = False
     last_seen_at: Optional[datetime] = None
@@ -336,7 +336,7 @@ class MCPClientBindingUpsert(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|supertonic)$",
     )
     default_personality: bool = False
 
@@ -355,7 +355,7 @@ class SpeakRequest(BaseModel):
     )
     engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|supertonic)$",
     )
     personality: Optional[bool] = Field(
         None,
@@ -363,7 +363,7 @@ class SpeakRequest(BaseModel):
     )
     language: Optional[str] = Field(
         None,
-        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
+        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|bg|cs|et|hr|hu|id|lt|lv|ro|sk|sl|uk|vi)$",
     )
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,6 +43,11 @@ torchaudio
 # Kokoro TTS (lightweight 82M-param engine)
 kokoro>=0.9.4
 misaki[en,ja,zh]>=0.9.4
+
+# Supertonic-3 TTS (ONNX, CPU, 31 languages, ~400MB).
+# Models download to ~/.cache/supertonic3/ on first run via huggingface_hub.
+supertonic>=1.2.3
+onnxruntime>=1.19.0
 # spacy model for misaki English G2P — must be pre-installed or misaki
 # tries spacy.cli.download() at runtime which crashes frozen builds
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -89,6 +89,21 @@ async def list_preset_voices(engine: str):
                 for vid, name, gender, lang in KOKORO_VOICES
             ],
         }
+    if engine == "supertonic":
+        from ..backends.supertonic_backend import SUPERTONIC_VOICES
+
+        return {
+            "engine": engine,
+            "voices": [
+                {
+                    "voice_id": vid,
+                    "name": name,
+                    "gender": gender,
+                    "language": lang,
+                }
+                for vid, name, gender, lang in SUPERTONIC_VOICES
+            ],
+        }
     if engine == "qwen_custom_voice":
         from ..backends.qwen_custom_voice_backend import QWEN_CUSTOM_VOICES
 

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -68,6 +68,11 @@ def _get_preset_voice_ids(engine: str) -> set[str]:
 
         return {voice_id for voice_id, _name, _gender, _lang in KOKORO_VOICES}
 
+    if engine == "supertonic":
+        from ..backends.supertonic_backend import SUPERTONIC_VOICES
+
+        return {voice_id for voice_id, _name, _gender, _lang in SUPERTONIC_VOICES}
+
     if engine == "qwen_custom_voice":
         from ..backends.qwen_custom_voice_backend import QWEN_CUSTOM_VOICES
 


### PR DESCRIPTION
## Summary

Adds a new TTS backend for **Supertonic-3** — a ~66-99M-param multilingual TTS that runs entirely on CPU via ONNX Runtime.

- 10 preset voices (M1-M5, F1-F5)
- 31 languages supported out-of-the-box
- ~167× realtime on consumer CPU
- 44.1 kHz output

The implementation follows the existing pattern (Kokoro-style preset-voice backend) and conforms to the `TTSBackend` Protocol — no new abstractions introduced.

## Implementation notes

- **Cache location** — Supertonic downloads to \`~/.cache/supertonic3/\` rather than the HuggingFace Hub cache, so \`_is_model_cached()\` inspects that directory directly for the four ONNX components (\`vocoder.onnx\`, \`text_encoder.onnx\`, \`duration_predictor.onnx\`, \`vector_estimator.onnx\`).
- **Progress tracking** — Download still goes through \`huggingface_hub\`, so the existing \`model_load_progress\` tqdm patch captures progress as for other backends.
- **Sample rate** — Resolved at runtime from \`tts.sample_rate\` (44.1 kHz); a fallback constant is kept defensively.
- **Voice prompts** — Preset-only, mirroring Kokoro. The cloned-profile fallback returns the default voice.
- **Language regex** — \`models.py\` extended with 13 ISO codes Supertonic supports beyond the current set (\`bg, cs, et, hr, hu, id, lt, lv, ro, sk, sl, uk, vi\`). Existing engines are unaffected.

## Files

- \`backend/backends/supertonic_backend.py\` — new
- \`backend/backends/__init__.py\` — ModelConfig + TTS_ENGINES entry + factory dispatch
- \`backend/models.py\` — engine regex + language regex
- \`backend/routes/profiles.py\` — \`/profiles/presets/supertonic\` endpoint
- \`backend/services/profiles.py\` — preset voice validation
- \`backend/requirements.txt\` — \`supertonic>=1.2.3\`, \`onnxruntime>=1.19.0\`

## Test plan

- [x] Smoke tested locally in a clean Python 3.12 venv
  - [x] Model auto-download (~385 MB) to \`~/.cache/supertonic3/\`
  - [x] \`tts.sample_rate\` is 44100 (matches code expectations)
  - [x] \`tts.synthesize(...)\` returns \`np.ndarray\` shape \`(1, N)\` float32, range within \`[-1, 1]\`
  - [x] English generation
  - [x] French generation (\`lang=\"fr\"\`)
  - [x] Alternate voice (F3) generation
  - [x] \`_is_model_cached()\` detects the populated cache correctly
- [ ] Integration test via Voicebox server (\`just setup\` + \`/generate\` API call)
- [ ] UI exposure in \`app/src/components/Generation/EngineModelSelector.tsx\` — **not yet done**, can be a follow-up PR if you'd like to keep the backend change isolated.

## Notes for review

- This PR intentionally does not touch the UI engine picker. Once the backend lands, surfacing it in the dropdown is a one-line tsx change. Happy to fold it in or do it separately, whichever you prefer.
- Related: this is a step toward what #419 ('Reduce engine sprawl') eventually wants. The current approach is purely additive — no refactor of the existing factory dispatch. Open to revisiting if the registry/first-class split discussed there happens first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Supertonic-3 as a new text-to-speech engine option supporting 31 languages
  * Integrated preset voice selection for Supertonic synthesis
  * Updated system request validation and backend infrastructure to support the new engine

* **Dependencies**
  * Added required packages for Supertonic-3 support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/670)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->