### PR TITLE
Fix: just setup omits mlx-audio/mlx-lm install on Apple Silicon

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,6 +52,14 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        # mlx-audio / mlx-lm declare transformers>=5.x, which conflicts with the
+        # transformers<=4.57.6 cap in requirements.txt. The runtime APIs Voicebox
+        # uses work on transformers 4.57.x, so install them --no-deps. Mirrors the
+        # install step in .github/workflows/release.yml; without this a fresh
+        # Apple Silicon `just setup` ships a venv with no mlx_audio module and
+        # MLX model loads fail with "ModuleNotFoundError: No module named 'mlx_audio'".
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q


### PR DESCRIPTION
## Problem

A fresh `just setup` on Apple Silicon produces a venv missing the `mlx_audio` module. Any MLX model load — e.g. downloading Whisper for dictation — then fails with:

```
ModuleNotFoundError: No module named 'mlx_audio'
```

In the app this surfaces as a model download that appears to stall on "Connecting to download…": the background download task raises immediately, but the progress UI is never moved off its initial state, so it looks like a hung/slow download rather than an error.

## Root cause

`backend/requirements-mlx.txt` intentionally **excludes** `mlx-audio` — from 0.3.1 it declares `transformers>=5.x`, which conflicts with the `transformers<=4.57.6` cap in `requirements.txt`. That file's own comment says to install it separately with `pip install --no-deps mlx-audio==0.4.1`, pointing to `.github/workflows/release.yml`.

`release.yml` does exactly that. But `setup-python` in the `justfile` — the path every contributor and local builder uses — installs `requirements-mlx.txt` and stops. Release builds get `mlx-audio`; local dev/build setups silently do not.

## Fix

Add the two `--no-deps` installs to the Apple Silicon branch of `setup-python`, mirroring `release.yml`:

```
pip install --no-deps mlx-lm==0.31.1
pip install --no-deps mlx-audio==0.4.1
```

Windows `setup-python` is unaffected (no MLX path). One file changed (`justfile`).

## Testing

On an M-series Mac, after applying the fix:

- `python -c "import mlx_audio, mlx_lm"` succeeds.
- The `whisper-turbo` model (`openai/whisper-large-v3-turbo`, 1.62 GB) downloads and loads:
  ```
  INFO: Marked whisper-turbo as complete
  INFO: MLX Whisper model turbo loaded successfully
  ```

## Note on the PR checklist

`CONTRIBUTING.md` asks contributors to update `CHANGELOG.md`, but `CHANGELOG.md`'s header states it is compiled automatically and must not be edited manually. I left it untouched accordingly — flagging the doc inconsistency in case the checklist wording should be revisited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python environment setup for Apple Silicon systems to install specific package versions with enhanced dependency management, preventing potential runtime conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->