### PR TITLE
feat: compose follows the selected language

### DIFF
--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -58,7 +58,7 @@ export function FloatingGenerateBox({
   const composeMutation = useMutation({
     mutationFn: async () => {
       if (!selectedProfileId) throw new Error('No profile selected');
-      return apiClient.composeWithPersonality(selectedProfileId);
+      return apiClient.composeWithPersonality(selectedProfileId, form.getValues('language'));
     },
     onError: (err: Error) => {
       toast({

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -136,9 +136,10 @@ class ApiClient {
   // the generate textarea. Rewrite now happens server-side inside
   // `/generate` when `personality: true` is passed in the request body.
 
-  async composeWithPersonality(profileId: string): Promise<PersonalityTextResponse> {
+  async composeWithPersonality(profileId: string, language: LanguageCode): Promise<PersonalityTextResponse> {
     return this.request<PersonalityTextResponse>(`/profiles/${profileId}/compose`, {
       method: 'POST',
+      body: JSON.stringify({ language: language }),
     });
   }
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -793,3 +793,11 @@ class AvailableEffectsResponse(BaseModel):
     """Response listing all available effect types."""
 
     effects: List[AvailableEffect]
+
+
+class ComposeRequest(BaseModel):
+    """Body for POST /profiles/{id}/compose."""
+    language: str = Field(
+        default="en",
+        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
+    )

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -377,6 +377,7 @@ async def update_profile_effects(
 )
 async def compose_in_character(
     profile_id: str,
+    data: models.ComposeRequest,
     db: Session = Depends(get_db),
 ):
     """Produce a fresh utterance in the profile's character voice."""
@@ -384,7 +385,7 @@ async def compose_in_character(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     try:
-        result = await personality.compose_as_profile(profile.personality)
+        result = await personality.compose_as_profile(profile.personality, data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return models.PersonalityTextResponse(

--- a/backend/services/personality.py
+++ b/backend/services/personality.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 
 from . import llm as llm_service
 from .refinement import collapse_repetitive_artifacts
+from ..backends import LANGUAGE_CODE_TO_NAME
+from .. import models
 
 
 # Shared rules block embedded in every mode-specific system prompt. Kept
@@ -71,6 +73,7 @@ def _require_personality(personality: str | None) -> str:
 
 async def compose_as_profile(
     personality: str | None,
+    data: models.ComposeRequest | None = models.ComposeRequest(language="en"),
     model_size: str | None = None,
 ) -> PersonalityResult:
     """Produce a fresh utterance in the character's voice.
@@ -84,7 +87,7 @@ async def compose_as_profile(
     backend = llm_service.get_llm_model()
     resolved_size = model_size or backend.model_size
 
-    system_prompt = _build_system_prompt(text, _COMPOSE_TASK)
+    system_prompt = f"{_build_system_prompt(text, _COMPOSE_TASK)}. Output language: {LANGUAGE_CODE_TO_NAME.get(data.language if data.language else 'en')}"
     output = await backend.generate(
         prompt="Speak.",
         system=system_prompt,


### PR DESCRIPTION
The original 'compose' could only generate English. Now, as picture, it can follows the selected language.

<img width="464" height="373" alt="Snipaste_2026-05-22_16-34-23" src="https://github.com/user-attachments/assets/14db1c9b-6998-406e-8d26-d8abec10d73f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added language selection for text generation. Users can now choose their preferred output language when generating content, with English as the default option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->