### PR TITLE
fix: personality LLM now respects the selected refinement model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **Personality LLM now respects the selected refinement model.** The "Speak in character" rewrite (`POST /generate` with `personality=true`) and Compose (`POST /profiles/{id}/compose`) both bypassed the user's `llm_model` selection from capture settings, always loading Qwen3 0.6B instead of the chosen 1.7B/4B model. Both now read `saved.llm_model` from capture settings and pass it through to the LLM backend.
+
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -10,7 +10,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import config, models
-from ..services import history, personality, profiles, tts
+from ..services import history, personality, profiles, settings as settings_service, tts
 from ..database import Generation as DBGeneration, VoiceProfile as DBVoiceProfile, get_db
 from ..services.generation import run_generation
 from ..services.task_queue import cancel_generation as cancel_generation_job, enqueue_generation
@@ -80,7 +80,11 @@ async def generate_speech(
     source = "manual"
     if data.personality and getattr(profile, "personality", None):
         try:
-            llm_result = await personality.rewrite_as_profile(profile.personality, data.text)
+            saved = settings_service.get_capture_settings(db)
+            llm_result = await personality.rewrite_as_profile(
+                profile.personality, data.text,
+                model_size=saved.llm_model,
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         text = llm_result.text.strip()

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from .. import config, models
 from ..app import safe_content_disposition
 from ..database import VoiceProfile as DBVoiceProfile, get_db
-from ..services import channels, export_import, personality, profiles
+from ..services import channels, export_import, personality, profiles, settings as settings_service
 from ..services.profiles import _profile_to_response
 
 logger = logging.getLogger(__name__)
@@ -384,7 +384,11 @@ async def compose_in_character(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     try:
-        result = await personality.compose_as_profile(profile.personality)
+        saved = settings_service.get_capture_settings(db)
+        result = await personality.compose_as_profile(
+            profile.personality,
+            model_size=saved.llm_model,
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return models.PersonalityTextResponse(


### PR DESCRIPTION
 **Bug:** Personality LLM (Speak in character / Compose) always loaded Qwen3 0.6B regardless of the user's refinement model selection
- **Root cause**: rewrite_as_profile and compose_as_profile were called without model_size, so they fell back to backend.model_size (default "0.6B")
- **Fix**: Both call sites now read saved.llm_model from capture_settings via settings_service.get_capture_settings(db) and pass it as model_size
- Reference the issue [Bug] Refinement model selection ignores user choice, always loads Qwen3 0.6B instead of selected 1.7B/4B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed personality-based features to respect your selected LLM model configuration. The "Speak in character" rewrite and Compose action now use your chosen model instead of defaulting to a fixed option, ensuring consistent refinement model usage across all features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamiepine/voicebox/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->