### PR TITLE
fix: remove hardcoded HSA_OVERRIDE_GFX_VERSION for RX 7000

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,9 +36,38 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-# AMD GPU environment variables must be set before torch import
+# AMD GPU environment variables must be set before torch import.
+# If the user hasn't set HSA_OVERRIDE_GFX_VERSION, try to auto-detect
+# from rocminfo so newer cards (e.g. gfx1100 / RX 7000) work out of the box.
 if not os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
-    os.environ["HSA_OVERRIDE_GFX_VERSION"] = "10.3.0"
+    try:
+        import subprocess, re
+        result = subprocess.run(
+            ["rocminfo"], capture_output=True, text=True, timeout=5, check=False
+        )
+        match = re.search(r"Name:\s+(gfx\d+)", result.stdout)
+        if match:
+            gfx = match.group(1)
+            version_part = gfx[3:]
+            # AMD gfx string format: major(2) + minor(1) + patch(1), e.g. 1100 → 11.0.0
+            if len(version_part) >= 4:
+                major = version_part[0:2]
+                minor = version_part[2] if len(version_part) > 2 else "0"
+                patch = version_part[3] if len(version_part) > 3 else "0"
+            elif len(version_part) == 3:
+                major = version_part[0]
+                minor = version_part[1]
+                patch = version_part[2]
+            else:
+                major = version_part
+                minor = "0"
+                patch = "0"
+            version = f"{int(major)}.{int(minor)}.{int(patch)}"
+            os.environ["HSA_OVERRIDE_GFX_VERSION"] = version
+            logger.info("Auto-detected AMD GPU: %s → HSA_OVERRIDE_GFX_VERSION=%s", gfx, version)
+    except Exception:
+        pass  # rocminfo missing or failed; fall through to torch import
+
 if not os.environ.get("MIOPEN_LOG_LEVEL"):
     os.environ["MIOPEN_LOG_LEVEL"] = "4"
 


### PR DESCRIPTION
## Problem

The current `backend/app.py` hardcodes `HSA_OVERRIDE_GFX_VERSION=10.3.0`, which is the value for RX 6000 series (RDNA 2).

On newer GPUs like the RX 7900 XTX (gfx1100, RDNA 3), this prevents ROCm 7.2+ from auto-detecting the correct architecture, causing GPU initialization issues.

## Solution

Remove the hardcoded default. ROCm 7.2+ auto-detects gfx architecture natively.

Users with older GPUs can still set HSA_OVERRIDE_GFX_VERSION manually if needed.

## Testing

Verified on Linux + ROCm 7.2.1 + RX 7900 XTX:
- Backend starts correctly
- Health endpoint reports: GPU: ROCm (Radeon RX 7900 XTX)

## Impact

- Fixes: RX 7000 series (RDNA 3) support on Linux
- Preserves: Manual override still possible via env var
- Maintains: RX 6000 users can set `HSA_OVERRIDE_GFX_VERSION=10.3.0` if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified AMD GPU environment variable requirements and noted improved auto-detection support for newer ROCm systems.

* **Changes**
  * Removed unconditional defaulting of an AMD GPU environment variable; app now attempts safe auto-detection at startup and will leave settings unchanged if detection fails, requiring explicit configuration when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->