### PR TITLE
fix: harden mac generation status and MLX threading

### DIFF
--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -269,7 +269,7 @@ export interface HealthResponse {
   gpu_type?: string;
   vram_used_mb?: number;
   backend_type?: string;
-  backend_variant?: string; // "cpu" or "cuda"
+  backend_variant?: string; // "cpu", "cuda", "xpu", or "metal"
 }
 
 export interface CudaDownloadProgress {

--- a/app/src/lib/hooks/useGenerationProgress.ts
+++ b/app/src/lib/hooks/useGenerationProgress.ts
@@ -18,10 +18,14 @@ interface GenerationStatusEvent {
 // main-window AudioPlayer. Skip autoplay here to avoid double-playback.
 const AGENT_SOURCES = new Set(['mcp', 'rest']);
 
+// SSE reconnect — cap at 30 s, give up after this many consecutive errors.
+const MAX_RECONNECT_ATTEMPTS = 8;
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+
 /**
  * Subscribes to SSE for all pending generations. When a generation completes,
- * invalidates the history query, removes it from pending, and auto-plays
- * if the player is idle.
+ * refetches history, removes it from pending, and auto-plays if the player is idle.
  */
 export function useGenerationProgress() {
   const queryClient = useQueryClient();
@@ -34,57 +38,91 @@ export function useGenerationProgress() {
   const { settings: genSettings } = useGenerationSettings();
   const autoplayOnGenerate = genSettings?.autoplay_on_generate ?? true;
 
-  // Keep refs to avoid stale closures in EventSource handlers
+  // Keep refs to avoid stale closures in EventSource handlers.
   const isPlayingRef = useRef(isPlaying);
   const autoplayRef = useRef(autoplayOnGenerate);
   isPlayingRef.current = isPlaying;
   autoplayRef.current = autoplayOnGenerate;
 
-  // Track active EventSource instances
+  // Track active EventSource instances and reconnect state.
   const eventSourcesRef = useRef<Map<string, EventSource>>(new Map());
+  const errorCountRef = useRef<Map<string, number>>(new Map());
+  const reconnectTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
-  // Unmount-only cleanup — close all SSE connections when the hook is torn down
+  // Unmount-only cleanup — close all SSE connections and timers.
   useEffect(() => {
     const sources = eventSourcesRef.current;
+    const timers = reconnectTimersRef.current;
     return () => {
-      for (const source of sources.values()) {
-        source.close();
-      }
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+      for (const source of sources.values()) source.close();
       sources.clear();
+      errorCountRef.current.clear();
     };
   }, []);
 
   useEffect(() => {
     const currentSources = eventSourcesRef.current;
+    const reconnectTimers = reconnectTimersRef.current;
 
-    // Close SSE connections for IDs no longer pending
+    const clearReconnectTimer = (id: string) => {
+      const timer = reconnectTimers.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        reconnectTimers.delete(id);
+      }
+    };
+
+    // Close SSE connections and cancel pending reconnect timers for IDs that
+    // are no longer pending.
     for (const [id, source] of currentSources.entries()) {
       if (!pendingIds.has(id)) {
         source.close();
         currentSources.delete(id);
       }
     }
+    for (const [id, timer] of reconnectTimers.entries()) {
+      if (!pendingIds.has(id)) {
+        clearTimeout(timer);
+        reconnectTimers.delete(id);
+        errorCountRef.current.delete(id);
+      }
+    }
 
-    // Open SSE connections for new pending IDs
-    for (const id of pendingIds) {
-      if (currentSources.has(id)) continue;
+    const openSource = (id: string) => {
+      if (!pendingIds.has(id) || currentSources.has(id)) return;
 
       const url = apiClient.getGenerationStatusUrl(id);
       const source = new EventSource(url);
+      currentSources.set(id, source);
+
+      const cleanup = (removePending = true) => {
+        source.close();
+        if (currentSources.get(id) === source) {
+          currentSources.delete(id);
+        }
+        clearReconnectTimer(id);
+        if (removePending) {
+          removePendingGeneration(id);
+          errorCountRef.current.delete(id);
+        }
+      };
 
       source.onmessage = (event) => {
+        // A successful message resets the consecutive-error counter.
+        errorCountRef.current.set(id, 0);
+
         try {
           const data: GenerationStatusEvent = JSON.parse(event.data);
 
           if (data.status === 'completed') {
-            source.close();
-            currentSources.delete(id);
-            removePendingGeneration(id);
+            cleanup();
 
-            // Refetch history to pick up the completed generation
+            // Refetch history to pick up the completed generation.
             queryClient.refetchQueries({ queryKey: ['history'] });
 
-            // If this generation was queued for a story, add it now
+            // If this generation was queued for a story, add it now.
             const storyId = removePendingStoryAdd(id);
             if (storyId) {
               apiClient
@@ -106,31 +144,19 @@ export function useGenerationProgress() {
                     variant: 'destructive',
                   });
                 });
-            } else {
-              // toast({
-              //   title: 'Generation complete!',
-              //   description: data.duration
-              //     ? `Audio generated (${data.duration.toFixed(2)}s)`
-              //     : 'Audio generated',
-              // });
             }
 
             // Auto-play if enabled and nothing is currently playing.
-            // Skip agent-initiated sources — the floating pill window
-            // plays those itself.
+            // Skip agent-initiated sources — the floating pill window plays those itself.
             const isAgentSpeak = data.source ? AGENT_SOURCES.has(data.source) : false;
             if (autoplayRef.current && !isPlayingRef.current && !isAgentSpeak) {
               const genAudioUrl = apiClient.getAudioUrl(id);
               setAudioWithAutoPlay(genAudioUrl, id, '', '');
             }
           } else if (data.status === 'failed' || data.status === 'not_found') {
-            source.close();
-            currentSources.delete(id);
-            removePendingGeneration(id);
+            cleanup();
             removePendingStoryAdd(id);
-
             queryClient.refetchQueries({ queryKey: ['history'] });
-
             toast({
               title: data.status === 'not_found' ? 'Generation not found' : 'Generation failed',
               description: data.error || 'An error occurred during generation',
@@ -138,20 +164,46 @@ export function useGenerationProgress() {
             });
           }
         } catch {
-          // Ignore parse errors from heartbeats etc
+          // Ignore parse errors from SSE heartbeats or malformed frames.
         }
       };
 
       source.onerror = () => {
-        // SSE connection dropped — clean up and refresh history so any
-        // completed/failed generation still appears in the list
         source.close();
-        currentSources.delete(id);
-        removePendingGeneration(id);
-        queryClient.refetchQueries({ queryKey: ['history'] });
-      };
+        if (currentSources.get(id) === source) {
+          currentSources.delete(id);
+        }
 
-      currentSources.set(id, source);
+        const attempts = (errorCountRef.current.get(id) ?? 0) + 1;
+        errorCountRef.current.set(id, attempts);
+
+        if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+          // Too many consecutive errors — give up and let the user see the
+          // current state in the history list instead of hanging forever.
+          removePendingGeneration(id);
+          errorCountRef.current.delete(id);
+          queryClient.refetchQueries({ queryKey: ['history'] });
+          return;
+        }
+
+        // Exponential back-off reconnect (1 s, 2 s, 4 s … capped at 30 s).
+        const delay = Math.min(RECONNECT_BASE_MS * 2 ** (attempts - 1), RECONNECT_MAX_MS);
+        clearReconnectTimer(id);
+        const timer = setTimeout(() => {
+          reconnectTimers.delete(id);
+          if (useGenerationStore.getState().pendingGenerationIds.has(id)) {
+            openSource(id);
+          }
+        }, delay);
+        reconnectTimers.set(id, timer);
+      };
+    };
+
+    // Open SSE connections for new pending IDs.
+    for (const id of pendingIds) {
+      if (currentSources.has(id) || reconnectTimers.has(id)) continue;
+      errorCountRef.current.set(id, 0);
+      openSource(id);
     }
   }, [
     pendingIds,

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -4,6 +4,7 @@ MLX backend implementation for TTS and STT using mlx-audio.
 
 from typing import Optional, List, Tuple
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import numpy as np
 from pathlib import Path
@@ -29,6 +30,16 @@ class MLXTTSBackend:
         self.model = None
         self.model_size = model_size
         self._current_model_size = None
+        # MLX/Metal streams are thread-local. Loading the model in one
+        # asyncio worker thread and generating in another can produce errors
+        # such as "There is no Stream(gpu) in current thread" or flaky second
+        # generations. Keep all MLX TTS work on a dedicated single thread.
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="voicebox-mlx-tts")
+        self._supports_ref_audio = False
+
+    async def _run_on_worker(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, lambda: func(*args))
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -81,8 +92,8 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size != model_size:
             self.unload_model()
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX worker thread.
+        await self._run_on_worker(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -100,16 +111,24 @@ class MLXTTSBackend:
 
             self.model = load(model_path)
 
+        import inspect
+
+        self._supports_ref_audio = "ref_audio" in inspect.signature(self.model.generate).parameters
         self._current_model_size = model_size
         self.model_size = model_size
         logger.info("MLX TTS model %s loaded successfully", model_size)
 
     def unload_model(self):
+        """Unload the model to free memory on the MLX worker thread."""
+        self._executor.submit(self._unload_model_sync).result()
+
+    def _unload_model_sync(self):
         """Unload the model to free memory."""
         if self.model is not None:
             del self.model
             self.model = None
             self._current_model_size = None
+            self._supports_ref_audio = False
             logger.info("MLX TTS model unloaded")
 
     async def create_voice_prompt(
@@ -223,11 +242,7 @@ class MLXTTSBackend:
             # legitimate metadata calls during generation.
             try:
                 if ref_audio:
-                    # Check if generate accepts ref_audio parameter
-                    import inspect
-
-                    sig = inspect.signature(self.model.generate)
-                    if "ref_audio" in sig.parameters:
+                    if self._supports_ref_audio:
                         # Generate with voice cloning
                         for result in self.model.generate(text, ref_audio=ref_audio, ref_text=ref_text, lang_code=lang):
                             audio_chunks.append(np.array(result.audio))
@@ -243,8 +258,10 @@ class MLXTTSBackend:
                         audio_chunks.append(np.array(result.audio))
                         sample_rate = result.sample_rate
             except Exception as e:
-                # If voice cloning fails, try without it
-                logger.warning("Voice cloning failed, generating without voice prompt: %s", e)
+                # If voice cloning fails, try without it. Include traceback so
+                # MLX/Metal thread errors are visible in logs instead of being
+                # reduced to a generic UI failure.
+                logger.warning("Voice cloning failed, generating without voice prompt: %s", e, exc_info=True)
                 for result in self.model.generate(text, lang_code=lang):
                     audio_chunks.append(np.array(result.audio))
                     sample_rate = result.sample_rate
@@ -258,8 +275,8 @@ class MLXTTSBackend:
 
             return audio, sample_rate
 
-        # Run blocking inference in thread pool
-        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        # Run blocking inference on the dedicated MLX worker thread.
+        audio, sample_rate = await self._run_on_worker(_generate_sync)
 
         return audio, sample_rate
 
@@ -270,6 +287,13 @@ class MLXSTTBackend:
     def __init__(self, model_size: str = "base"):
         self.model = None
         self.model_size = model_size
+        # Keep MLX STT load/inference on one thread for the same thread-local
+        # Metal stream reason as MLXTTSBackend.
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="voicebox-mlx-stt")
+
+    async def _run_on_worker(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, lambda: func(*args))
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -292,8 +316,8 @@ class MLXSTTBackend:
         if self.model is not None and self.model_size == model_size:
             return
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX worker thread.
+        await self._run_on_worker(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -315,6 +339,10 @@ class MLXSTTBackend:
         logger.info("MLX Whisper model %s loaded successfully", model_size)
 
     def unload_model(self):
+        """Unload the model to free memory on the MLX worker thread."""
+        self._executor.submit(self._unload_model_sync).result()
+
+    def _unload_model_sync(self):
         """Unload the model to free memory."""
         if self.model is not None:
             del self.model
@@ -363,5 +391,5 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        # Run blocking transcription on the dedicated MLX worker thread.
+        return await self._run_on_worker(_transcribe_sync)

--- a/backend/models.py
+++ b/backend/models.py
@@ -442,7 +442,7 @@ class HealthResponse(BaseModel):
     gpu_type: Optional[str] = None  # GPU type (CUDA, MPS, or None)
     vram_used_mb: Optional[float] = None
     backend_type: Optional[str] = None  # Backend type (mlx or pytorch)
-    backend_variant: Optional[str] = None  # Binary variant (cpu or cuda)
+    backend_variant: Optional[str] = None  # Runtime/backend variant (cpu, cuda, xpu, or metal)
     gpu_compatibility_warning: Optional[str] = None  # Warning if GPU arch unsupported
 
 

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -274,11 +274,21 @@ async def cancel_generation(generation_id: str, db: Session = Depends(get_db)):
 
 @router.get("/generate/{generation_id}/status")
 async def get_generation_status(generation_id: str, db: Session = Depends(get_db)):
-    """SSE endpoint that streams generation status updates."""
+    """SSE endpoint that streams generation status updates.
+
+    Emits a status frame every second while the generation is in flight, then
+    one final frame when it completes or fails. A heartbeat comment is sent
+    periodically so WebKit/proxies do not treat a quiet model load as a dead
+    connection. This avoids false frontend failures where the generation
+    succeeds but the UI drops the pending item before receiving completion.
+    """
     import json
+
+    heartbeat_cycles = 15
 
     async def event_stream():
         try:
+            cycles_since_data = 0
             while True:
                 db.expire_all()
                 gen = db.query(DBGeneration).filter_by(id=generation_id).first()
@@ -296,11 +306,16 @@ async def get_generation_status(generation_id: str, db: Session = Depends(get_db
                     "source": gen.source,
                 }
                 yield f"data: {json.dumps(payload)}\n\n"
+                cycles_since_data = 0
 
                 if (gen.status or "completed") in ("completed", "failed"):
                     return
 
                 await asyncio.sleep(1)
+                cycles_since_data += 1
+                if cycles_since_data >= heartbeat_cycles:
+                    yield ": heartbeat\n\n"
+                    cycles_since_data = 0
         except (BrokenPipeError, ConnectionResetError, asyncio.CancelledError):
             logger.debug("SSE client disconnected for generation %s", generation_id)
 

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -276,11 +276,12 @@ async def cancel_generation(generation_id: str, db: Session = Depends(get_db)):
 async def get_generation_status(generation_id: str, db: Session = Depends(get_db)):
     """SSE endpoint that streams generation status updates.
 
-    Emits a status frame every second while the generation is in flight, then
-    one final frame when it completes or fails. A heartbeat comment is sent
-    periodically so WebKit/proxies do not treat a quiet model load as a dead
-    connection. This avoids false frontend failures where the generation
-    succeeds but the UI drops the pending item before receiving completion.
+    Emits a status frame when the persisted generation state changes, then one
+    final frame when it completes or fails. A heartbeat comment is sent
+    periodically while the state is unchanged so WebKit/proxies do not treat a
+    quiet model load as a dead connection. This avoids false frontend failures
+    where the generation succeeds but the UI drops the pending item before
+    receiving completion.
     """
     import json
 
@@ -289,6 +290,7 @@ async def get_generation_status(generation_id: str, db: Session = Depends(get_db
     async def event_stream():
         try:
             cycles_since_data = 0
+            last_payload_json = None
             while True:
                 db.expire_all()
                 gen = db.query(DBGeneration).filter_by(id=generation_id).first()
@@ -305,8 +307,11 @@ async def get_generation_status(generation_id: str, db: Session = Depends(get_db
                     # autoplay — the floating pill plays those directly.
                     "source": gen.source,
                 }
-                yield f"data: {json.dumps(payload)}\n\n"
-                cycles_since_data = 0
+                payload_json = json.dumps(payload)
+                if payload_json != last_payload_json:
+                    yield f"data: {payload_json}\n\n"
+                    last_payload_json = payload_json
+                    cycles_since_data = 0
 
                 if (gen.status or "completed") in ("completed", "failed"):
                     return

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -175,7 +175,9 @@ async def health():
         backend_type=backend_type,
         backend_variant=os.environ.get(
             "VOICEBOX_BACKEND_VARIANT",
-            "cuda" if torch.cuda.is_available() else ("xpu" if has_xpu else "cpu"),
+            "cuda"
+            if torch.cuda.is_available()
+            else ("xpu" if has_xpu else ("metal" if backend_type == "mlx" else "cpu")),
         ),
         gpu_compatibility_warning=gpu_compat_warning,
     )

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -17,13 +17,18 @@ Mode differences:
 from __future__ import annotations
 
 import asyncio
+import logging
 import traceback
 from typing import Literal, Optional
+
+import numpy as np
 
 from .. import config
 from . import history, profiles
 from ..database import get_db
 from ..utils.tasks import get_task_manager
+
+logger = logging.getLogger(__name__)
 
 
 async def run_generation(
@@ -85,6 +90,7 @@ async def run_generation(
             gen_kwargs["crossfade_ms"] = crossfade_ms
 
         audio, sample_rate = await generate_chunked(tts_model, text, voice_prompt, **gen_kwargs)
+        _validate_generated_audio(audio, sample_rate)
 
         # --- Normalize (generate and regenerate always; retry skips) -----
         if normalize or mode == "regenerate":
@@ -136,6 +142,7 @@ async def run_generation(
         )
         _notify_speak_end(generation_id, status="cancelled")
     except Exception as e:
+        logger.exception("Generation %s failed", generation_id)
         traceback.print_exc()
         await history.update_generation_status(
             generation_id=generation_id,
@@ -149,6 +156,22 @@ async def run_generation(
     finally:
         task_manager.complete_generation(generation_id)
         bg_db.close()
+
+
+def _validate_generated_audio(audio, sample_rate: int) -> None:
+    """Fail clearly instead of saving an empty/corrupt WAV as a completed item."""
+    if sample_rate is None or sample_rate <= 0:
+        raise RuntimeError(f"TTS returned invalid sample rate: {sample_rate}")
+
+    if audio is None:
+        raise RuntimeError("TTS returned no audio")
+
+    audio_array = np.asarray(audio)
+    if audio_array.size == 0:
+        raise RuntimeError("TTS returned empty audio")
+
+    if not np.isfinite(audio_array).all():
+        raise RuntimeError("TTS returned non-finite audio samples")
 
 
 def _notify_speak_end(generation_id: str, *, status: str) -> None:
@@ -302,6 +325,7 @@ async def generate_audio_sync(
     audio, sample_rate = await generate_chunked(
         tts_model, text, voice_prompt, **gen_kwargs
     )
+    _validate_generated_audio(audio, sample_rate)
 
     if normalize:
         audio = normalize_audio(audio)

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -5,7 +5,6 @@ to avoid GPU contention.
 
 import asyncio
 import logging
-import traceback
 from dataclasses import dataclass
 from typing import Coroutine, Literal
 
@@ -59,7 +58,6 @@ async def _generation_worker():
                     raise
         except Exception:
             logger.exception("Generation worker failed for %s", job.generation_id)
-            traceback.print_exc()
             await _force_fail_if_active(
                 job.generation_id,
                 "Worker exited without writing terminal status",
@@ -95,7 +93,6 @@ async def _force_fail_if_active(generation_id: str, error: str) -> None:
             db.close()
     except Exception:
         logger.exception("Failed to force-fail orphaned generation %s", generation_id)
-        traceback.print_exc()
 
 
 def enqueue_generation(generation_id: str, coro):

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -4,9 +4,12 @@ to avoid GPU contention.
 """
 
 import asyncio
+import logging
 import traceback
 from dataclasses import dataclass
 from typing import Coroutine, Literal
+
+logger = logging.getLogger(__name__)
 
 # Keep references to fire-and-forget background tasks to prevent GC
 _background_tasks: set = set()
@@ -55,6 +58,7 @@ async def _generation_worker():
                 if not task.cancelled():
                     raise
         except Exception:
+            logger.exception("Generation worker failed for %s", job.generation_id)
             traceback.print_exc()
             await _force_fail_if_active(
                 job.generation_id,
@@ -90,6 +94,7 @@ async def _force_fail_if_active(generation_id: str, error: str) -> None:
         finally:
             db.close()
     except Exception:
+        logger.exception("Failed to force-fail orphaned generation %s", generation_id)
         traceback.print_exc()
 
 

--- a/justfile
+++ b/justfile
@@ -52,6 +52,14 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        # mlx-audio / mlx-lm declare transformers>=5.x, which conflicts with the
+        # transformers<=4.57.6 cap in requirements.txt. The runtime APIs Voicebox
+        # uses work on transformers 4.57.x, so install them --no-deps. Mirrors the
+        # install step in .github/workflows/release.yml; without this a fresh
+        # Apple Silicon `just setup` ships a venv with no mlx_audio module and
+        # MLX model loads fail with "ModuleNotFoundError: No module named 'mlx_audio'".
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q


### PR DESCRIPTION
## Summary

This PR hardens macOS generation status tracking and MLX/Metal execution to address the failure pattern reported in #170.

I was hitting the same issue on macOS 26 and macOS 27 with Voicebox 0.5.0: the first generation could succeed, then a later/second generation would show `Generation Failed: load failed` or fail to appear in history until restart, even though generation sometimes completed.

Root cause: transient status-SSE disconnects during long MLX/Metal generation were treated as terminal frontend failures while the backend generation continued, leaving the UI stale and showing `load failed`.

## What changed

- Add SSE reconnect/backoff for pending generations instead of immediately removing them on the first `EventSource.onerror`.
- Add heartbeat comments to `/generate/{id}/status` so WebKit/proxies do not treat quiet model-load/generation periods as dead connections.
- Keep MLX TTS/STT load and inference on dedicated single worker threads because MLX/Metal streams are thread-local; this prevents cross-thread `Stream(gpu)` failures and flaky follow-up generations.
- Cache MLX `ref_audio` capability once at model load instead of introspecting on every generation.
- Report `backend_variant=metal` for MLX in `/health` so Apple Silicon acceleration status is clearer.
- Add backend exception logging and generated-audio validation so empty/corrupt outputs fail with useful errors instead of becoming confusing history entries.
- Fix fresh Apple Silicon dev setup by installing `mlx-lm` and `mlx-audio` with `--no-deps`, matching the release workflow and avoiding the transformers 5.x conflict.

## Testing

- `python3 -m py_compile backend/backends/mlx_backend.py backend/routes/generations.py backend/routes/health.py backend/services/generation.py backend/services/task_queue.py`
- `git diff --check`
- Built a local macOS `.app` and manually verified the #170 reproduction no longer occurs on macOS 26/27 with Voicebox 0.5.0.

Fixes #170.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved generation status streaming with heartbeat support and automatic SSE reconnection (with capped exponential backoff).
* **Bug Fixes**
  * Added validation for generated audio before saving/processing.
  * Enhanced error handling so failures reliably clean up pending generations and notify users.
  * Updated health backend reporting to map MLX to **metal**, and refreshed related documentation.
* **Chores**
  * Improved Apple Silicon setup to explicitly install pinned `mlx-lm` and `mlx-audio` for more reliable fresh installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->