### PR TITLE
fix(linux): avoid abort when hiding the dictate pill

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1273,6 +1273,16 @@ pub fn run() {
                 let handle_for_hide = app.handle().clone();
                 app.handle().listen("dictate:hide", move |_event| {
                     if let Some(window) = handle_for_hide.get_webview_window(DICTATE_WINDOW_LABEL) {
+                        // `set_ignore_cursor_events(true)` aborts on Linux/GTK:
+                        // tao's CursorIgnoreEvents(true) handler calls
+                        // `gtk_window.window().unwrap()`, and a pill that was
+                        // built `.visible(false)` and never shown has no
+                        // realized GdkWindow yet, so the unwrap panics in a
+                        // non-unwinding context. The click-through-while-hidden
+                        // hack is a macOS NSWindow workaround anyway (see the
+                        // comment above), so skip it on Linux — parking the
+                        // window off-screen and `hide()` are enough there.
+                        #[cfg(not(target_os = "linux"))]
                         let _ = window.set_ignore_cursor_events(true);
                         let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
                         let _ = window.hide();


### PR DESCRIPTION
## Problem

On Linux the app aborts at startup. As soon as the hidden dictate pill webview loads and emits `dictate:hide`, the whole process dies with:

```
tao/src/platform_impl/linux/event_loop.rs:449:18:
called `Option::unwrap()` on a `None` value
thread caused non-unwinding panic. aborting.
```

## Root cause

The `dictate:hide` handler in `main.rs` calls `window.set_ignore_cursor_events(true)` on the pill window.

The pill is built with `.visible(false)` and is never shown, so on Linux/GTK it has no realized `GdkWindow` yet. tao's `WindowRequest::CursorIgnoreEvents(true)` branch does `gtk_window.window().unwrap()`, which is `None` for an unrealized window → panic in a non-unwinding context → `abort()`.

Note the asymmetry in tao: the `CursorIgnoreEvents(false)` branch calls `input_shape_combine_region(None)` directly and never unwraps, which is why every `set_ignore_cursor_events(false)` call is fine and only the single `(true)` call site crashes.

## Fix

The click-through-while-hidden trick is a macOS NSWindow workaround (documented in the surrounding comment — the NSWindow lingers as an invisible click target). On Linux, parking the window off-screen plus `hide()` already suffice, so the `set_ignore_cursor_events(true)` call is gated with `#[cfg(not(target_os = "linux"))]`. macOS and Windows behaviour is unchanged.

## Testing

- Before: `target/release/voicebox` aborts within seconds of launch on Wayland (native and XWayland), 100% reproducible.
- After: app launches and stays up; the `voicebox-server` sidecar comes up and listens on `127.0.0.1:17493`; no panic in the logs.

Tested on Arch Linux, Wayland session, `webkit2gtk-4.1` 2.52.4, `tauri-cli` 2.9.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when hiding the window on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->