### PR TITLE
docs: add TTS Hub to known HTTP integrators

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -120,6 +120,14 @@ curl http://localhost:17493/generate/{id}/status
 
 Default location is the OS-specific app data directory. Override with `--data-dir` or the `VOICEBOX_DATA_DIR` environment variable.
 
+## Known HTTP clients
+
+Third-party apps that integrate with this server over the local REST API (`127.0.0.1:17493`):
+
+| Client | Repository | Notes |
+|--------|--------------|-------|
+| **TTS Hub** | https://github.com/xcwajdax/TTS_hub | Desktop TTS hub (Google Gemini, MiniMax, Voicebox). Sends `User-Agent: TTS-Hub/… (Voicebox-client)` and `X-Voicebox-Client-Id: tts-hub`. Upstream heads-up: https://github.com/jamiepine/voicebox/issues/749 |
+
 ## Code quality
 
 Linting and formatting are enforced by [ruff](https://docs.astral.sh/ruff/), configured in `pyproject.toml`. See `STYLE_GUIDE.md` for conventions.


### PR DESCRIPTION
Related to #749 — TTS Hub heads-up on backend-only MIT fork + bundled sidecar.

Documents TTS Hub as a known HTTP client of the Voicebox backend. TTS Hub already integrates on `:17493` with `X-Voicebox-Client-Id: tts-hub` and publishes attribution policy at https://github.com/xcwajdax/TTS_hub/blob/main/docs/VOICEBOX_FORK.md

No API or runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend documentation with a new "Known HTTP clients" section featuring TTS Hub, a third-party local REST API client, including repository information and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->