### PR TITLE
[codex] Add Fun-CosyVoice3 engine option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
           pip install -r backend/requirements.txt
           pip install --no-deps chatterbox-tts
           pip install --no-deps hume-tada
+          pip install --no-build-isolation openai-whisper==20231117
 
       - name: Install MLX dependencies (Apple Silicon only)
         if: matrix.backend == 'mlx'
@@ -290,6 +291,7 @@ jobs:
           pip install -r backend/requirements.txt
           pip install --no-deps chatterbox-tts
           pip install --no-deps hume-tada
+          pip install --no-build-isolation openai-whisper==20231117
 
       - name: Install PyTorch with CUDA 12.8
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # Changelog
 
+## [Unreleased]
+
+Voicebox can now experiment with Fun-CosyVoice3 as an optional cloned-voice engine, focused on Cantonese and other multilingual speech workflows.
+
+### Voice Generation
+
+- **Fun-CosyVoice3 engine option.** Adds a dev-mode `cosyvoice3` backend for `FunAudioLLM/Fun-CosyVoice3-0.5B-2512`, with cloned voice prompts, model management metadata, and frontend engine selection.
+- **Cantonese language path.** Adds `yue` / Cantonese as a language option and routes CosyVoice3 Cantonese generation through its instruction-style prompt format.
+
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY backend/requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 RUN pip install --no-cache-dir --prefix=/install --no-deps chatterbox-tts
 RUN pip install --no-cache-dir --prefix=/install --no-deps hume-tada
+RUN pip install --no-cache-dir --prefix=/install --no-build-isolation openai-whisper==20231117
 RUN pip install --no-cache-dir --prefix=/install \
     git+https://github.com/QwenLM/Qwen3-TTS.git
 

--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -24,6 +24,7 @@ const ENGINE_OPTIONS = [
   { value: 'luxtts', label: 'LuxTTS', engine: 'luxtts' },
   { value: 'chatterbox', label: 'Chatterbox', engine: 'chatterbox' },
   { value: 'chatterbox_turbo', label: 'Chatterbox Turbo', engine: 'chatterbox_turbo' },
+  { value: 'cosyvoice3:0.5B', label: 'Fun-CosyVoice3 0.5B', engine: 'cosyvoice3' },
   { value: 'tada:1B', label: 'TADA 1B', engine: 'tada' },
   { value: 'tada:3B', label: 'TADA 3B Multilingual', engine: 'tada' },
   { value: 'kokoro', label: 'Kokoro 82M', engine: 'kokoro' },
@@ -35,6 +36,7 @@ const ENGINE_DESCRIPTIONS: Record<string, string> = {
   luxtts: 'Fast, English-focused',
   chatterbox: '23 languages, incl. Hebrew',
   chatterbox_turbo: 'English, [laugh] [cough] tags',
+  cosyvoice3: '0.5B, Cantonese via instruction',
   tada: 'HumeAI, 700s+ coherent audio',
   kokoro: '82M params, CPU realtime, 8 langs',
 };
@@ -43,7 +45,7 @@ const ENGINE_DESCRIPTIONS: Record<string, string> = {
 const ENGLISH_ONLY_ENGINES = new Set(['luxtts', 'chatterbox_turbo']);
 
 /** Engines that support cloned (reference audio) profiles. */
-const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'tada']);
+const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'cosyvoice3', 'tada']);
 
 function getAvailableOptions(selectedProfile?: VoiceProfileResponse | null) {
   if (!selectedProfile) return ENGINE_OPTIONS;
@@ -53,6 +55,7 @@ function getAvailableOptions(selectedProfile?: VoiceProfileResponse | null) {
 function getSelectValue(engine: string, modelSize?: string): string {
   if (engine === 'qwen') return `qwen:${modelSize || '1.7B'}`;
   if (engine === 'qwen_custom_voice') return `qwen_custom_voice:${modelSize || '1.7B'}`;
+  if (engine === 'cosyvoice3') return `cosyvoice3:${modelSize || '0.5B'}`;
   if (engine === 'tada') return `tada:${modelSize || '1B'}`;
   return engine;
 }
@@ -74,6 +77,14 @@ export function applyEngineSelection(form: UseFormReturn<GenerationFormValues>, 
     // Validate language is supported by Qwen
     const currentLang = form.getValues('language');
     const available = getLanguageOptionsForEngine('qwen');
+    if (!available.some((l) => l.value === currentLang)) {
+      form.setValue('language', available[0]?.value ?? 'en');
+    }
+  } else if (value.startsWith('cosyvoice3:')) {
+    form.setValue('engine', 'cosyvoice3');
+    form.setValue('modelSize', '0.5B' as GenerationFormValues['modelSize']);
+    const currentLang = form.getValues('language');
+    const available = getLanguageOptionsForEngine('cosyvoice3');
     if (!available.some((l) => l.value === currentLang)) {
       form.setValue('language', available[0]?.value ?? 'en');
     }

--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -63,6 +63,8 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
     'Production-grade open source TTS by Resemble AI. Supports 23 languages with voice cloning and emotion exaggeration control.',
   'chatterbox-turbo':
     'Streamlined 350M parameter TTS by Resemble AI. High-quality English speech with less compute and VRAM than larger models.',
+  'cosyvoice3-0.5B':
+    'Fun-CosyVoice3 0.5B by FunAudioLLM. Zero-shot multilingual TTS with Cantonese support via instruction prompting. Requires a local CosyVoice repo path in dev mode.',
   'tada-1b':
     'HumeAI TADA 1B — English speech-language model built on Llama 3.2 1B. Generates 700s+ of coherent audio with synchronized text-acoustic alignment.',
   'tada-3b-ml':
@@ -413,6 +415,7 @@ export function ModelManagement() {
         m.model_name.startsWith('qwen-custom-voice') ||
         m.model_name.startsWith('luxtts') ||
         m.model_name.startsWith('chatterbox') ||
+        m.model_name.startsWith('cosyvoice3') ||
         m.model_name.startsWith('tada') ||
         m.model_name.startsWith('kokoro'),
     ) ?? [];

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -70,13 +70,14 @@ export interface GenerationRequest {
   text: string;
   language: LanguageCode;
   seed?: number;
-  model_size?: '1.7B' | '0.6B' | '1B' | '3B';
+  model_size?: '1.7B' | '0.6B' | '0.5B' | '1B' | '3B';
   engine?:
     | 'qwen'
     | 'qwen_custom_voice'
     | 'luxtts'
     | 'chatterbox'
     | 'chatterbox_turbo'
+    | 'cosyvoice3'
     | 'tada'
     | 'kokoro';
   instruct?: string;

--- a/app/src/lib/constants/languages.ts
+++ b/app/src/lib/constants/languages.ts
@@ -5,6 +5,7 @@
  * LuxTTS is English-only.
  * Chatterbox Multilingual supports 23 languages.
  * Chatterbox Turbo is English-only.
+ * Fun-CosyVoice3 supports major languages plus Cantonese via instruction.
  * Kokoro supports 8 languages.
  */
 
@@ -32,6 +33,7 @@ export const ALL_LANGUAGES = {
   sv: 'Swedish',
   sw: 'Swahili',
   tr: 'Turkish',
+  yue: 'Cantonese',
   zh: 'Chinese',
 } as const;
 
@@ -67,6 +69,7 @@ export const ENGINE_LANGUAGES: Record<string, readonly LanguageCode[]> = {
     'zh',
   ],
   chatterbox_turbo: ['en'],
+  cosyvoice3: ['zh', 'yue', 'en', 'ja', 'ko'],
   tada: ['en', 'ar', 'zh', 'de', 'es', 'fr', 'it', 'ja', 'pl', 'pt'],
   kokoro: ['en', 'es', 'fr', 'hi', 'it', 'pt', 'ja', 'zh'],
   qwen_custom_voice: ['zh', 'en', 'ja', 'ko', 'de', 'fr', 'ru', 'pt', 'es', 'it'],

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -16,7 +16,7 @@ const generationSchema = z.object({
   text: z.string().min(1, '').max(50000),
   language: z.enum(LANGUAGE_CODES as [LanguageCode, ...LanguageCode[]]),
   seed: z.number().int().optional(),
-  modelSize: z.enum(['1.7B', '0.6B', '1B', '3B']).optional(),
+  modelSize: z.enum(['1.7B', '0.6B', '0.5B', '1B', '3B']).optional(),
   instruct: z.string().max(500).optional(),
   engine: z
     .enum([
@@ -25,6 +25,7 @@ const generationSchema = z.object({
       'luxtts',
       'chatterbox',
       'chatterbox_turbo',
+      'cosyvoice3',
       'tada',
       'kokoro',
     ])
@@ -92,8 +93,10 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
           ? 'luxtts'
           : engine === 'chatterbox'
             ? 'chatterbox-tts'
-            : engine === 'chatterbox_turbo'
-              ? 'chatterbox-turbo'
+          : engine === 'chatterbox_turbo'
+            ? 'chatterbox-turbo'
+            : engine === 'cosyvoice3'
+              ? 'cosyvoice3-0.5B'
               : engine === 'tada'
                 ? data.modelSize === '3B'
                   ? 'tada-3b-ml'
@@ -108,8 +111,10 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
           ? 'LuxTTS'
           : engine === 'chatterbox'
             ? 'Chatterbox TTS'
-            : engine === 'chatterbox_turbo'
-              ? 'Chatterbox Turbo'
+          : engine === 'chatterbox_turbo'
+            ? 'Chatterbox Turbo'
+            : engine === 'cosyvoice3'
+              ? 'Fun-CosyVoice3 0.5B'
               : engine === 'tada'
                 ? data.modelSize === '3B'
                   ? 'TADA 3B Multilingual'
@@ -138,10 +143,10 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
       }
 
       const hasModelSizes =
-        engine === 'qwen' || engine === 'qwen_custom_voice' || engine === 'tada';
+        engine === 'qwen' || engine === 'qwen_custom_voice' || engine === 'tada' || engine === 'cosyvoice3';
       // Only Qwen CustomVoice actually honors the instruct kwarg at model level.
       // Base Qwen3-TTS accepts the kwarg but ignores it.
-      const supportsInstruct = engine === 'qwen_custom_voice';
+      const supportsInstruct = engine === 'qwen_custom_voice' || engine === 'cosyvoice3';
       const effectsChain = options.getEffectsChain?.();
       // This now returns immediately with status="generating"
       const result = await generation.mutateAsync({

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -25,6 +25,7 @@ from ..utils.platform_detect import get_backend_type
 
 LANGUAGE_CODE_TO_NAME = {
     "zh": "chinese",
+    "yue": "cantonese",
     "en": "english",
     "ja": "japanese",
     "ko": "korean",
@@ -213,6 +214,7 @@ TTS_ENGINES = {
     "luxtts": "LuxTTS",
     "chatterbox": "Chatterbox TTS",
     "chatterbox_turbo": "Chatterbox Turbo",
+    "cosyvoice3": "Fun-CosyVoice3",
     "tada": "TADA",
     "kokoro": "Kokoro",
 }
@@ -337,6 +339,17 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             size_mb=1500,
             needs_trim=True,
             languages=["en"],
+        ),
+        ModelConfig(
+            model_name="cosyvoice3-0.5B",
+            display_name="Fun-CosyVoice3 0.5B",
+            engine="cosyvoice3",
+            hf_repo_id="FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
+            model_size="0.5B",
+            size_mb=2500,
+            needs_trim=True,
+            supports_instruct=True,
+            languages=["zh", "yue", "en", "ja", "ko"],
         ),
         ModelConfig(
             model_name="tada-1b",
@@ -505,7 +518,9 @@ def engine_needs_trim(engine: str) -> bool:
 
 
 def engine_has_model_sizes(engine: str) -> bool:
-    """Whether this engine supports multiple model sizes (only Qwen currently)."""
+    """Whether requests should preserve and pass a model_size for this engine."""
+    if engine == "cosyvoice3":
+        return True
     configs = [c for c in get_tts_model_configs() if c.engine == engine]
     return len(configs) > 1
 
@@ -515,7 +530,7 @@ async def load_engine_model(engine: str, model_size: str = "default") -> None:
     backend = get_tts_backend_for_engine(engine)
     if engine in ("qwen", "qwen_custom_voice"):
         await backend.load_model_async(model_size)
-    elif engine == "tada":
+    elif engine in ("tada", "cosyvoice3"):
         await backend.load_model(model_size)
     else:
         await backend.load_model()
@@ -532,7 +547,7 @@ async def ensure_model_cached_or_raise(engine: str, model_size: str = "default")
             cfg = c
             break
 
-    if engine in ("qwen", "qwen_custom_voice", "tada"):
+    if engine in ("qwen", "qwen_custom_voice", "tada", "cosyvoice3"):
         if not backend._is_model_cached(model_size):
             raise HTTPException(
                 status_code=400,
@@ -696,6 +711,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .chatterbox_turbo_backend import ChatterboxTurboTTSBackend
 
             backend = ChatterboxTurboTTSBackend()
+        elif engine == "cosyvoice3":
+            from .cosyvoice3_backend import CosyVoice3Backend
+
+            backend = CosyVoice3Backend()
         elif engine == "tada":
             from .hume_backend import HumeTadaBackend
 

--- a/backend/backends/cosyvoice3_backend.py
+++ b/backend/backends/cosyvoice3_backend.py
@@ -1,0 +1,229 @@
+"""Fun-CosyVoice3 backend.
+
+This backend intentionally treats CosyVoice as an optional development
+dependency. Upstream is not packaged as a normal PyPI library and currently
+expects callers to import from a cloned repository plus the Matcha-TTS
+submodule. Set COSYVOICE_REPO_PATH to that clone before using this engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from .base import combine_voice_prompts as _combine_voice_prompts
+from .base import empty_device_cache, is_model_cached, model_load_progress
+
+logger = logging.getLogger(__name__)
+
+COSYVOICE3_HF_REPO = "FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+COSYVOICE3_MODEL_NAME = "cosyvoice3-0.5B"
+COSYVOICE3_REQUIRED_FILES = [
+    "cosyvoice3.yaml",
+    "llm.pt",
+    "flow.pt",
+    "hift.pt",
+    "campplus.onnx",
+    "speech_tokenizer_v3.onnx",
+    "spk2info.pt",
+    "CosyVoice-BlankEN/*",
+]
+
+
+class CosyVoice3Backend:
+    """Fun-CosyVoice3 0.5B backend for zero-shot voice cloning."""
+
+    def __init__(self):
+        self.model = None
+        self.model_size = "0.5B"
+        self._device = "cpu"
+        self._model_load_lock = asyncio.Lock()
+
+    def is_loaded(self) -> bool:
+        return self.model is not None
+
+    def _get_model_path(self, model_size: str = "0.5B") -> str:
+        return COSYVOICE3_HF_REPO
+
+    def _is_model_cached(self, model_size: str = "0.5B") -> bool:
+        return is_model_cached(
+            COSYVOICE3_HF_REPO,
+            required_files=["cosyvoice3.yaml", "llm.pt", "flow.pt", "hift.pt", "speech_tokenizer_v3.onnx"],
+        )
+
+    async def load_model(self, model_size: str = "0.5B") -> None:
+        if self.model is not None:
+            return
+        async with self._model_load_lock:
+            if self.model is not None:
+                return
+            await asyncio.to_thread(self._load_model_sync)
+
+    def _load_model_sync(self) -> None:
+        cosyvoice_repo = os.environ.get("COSYVOICE_REPO_PATH")
+        if not cosyvoice_repo:
+            raise RuntimeError(
+                "CosyVoice3 requires COSYVOICE_REPO_PATH to point at a cloned "
+                "FunAudioLLM/CosyVoice repository with submodules initialized."
+            )
+
+        repo_path = Path(cosyvoice_repo).expanduser().resolve()
+        matcha_path = repo_path / "third_party" / "Matcha-TTS"
+        if not (repo_path / "cosyvoice").exists() or not matcha_path.exists():
+            raise RuntimeError(
+                f"COSYVOICE_REPO_PATH is invalid: {repo_path}. Expected a "
+                "CosyVoice clone with third_party/Matcha-TTS."
+            )
+
+        for path in (str(repo_path), str(matcha_path)):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+
+        is_cached = self._is_model_cached()
+        with model_load_progress(COSYVOICE3_MODEL_NAME, is_cached):
+            from huggingface_hub import snapshot_download
+            from cosyvoice.cli.cosyvoice import AutoModel
+
+            model_dir = snapshot_download(
+                COSYVOICE3_HF_REPO,
+                token=None,
+                allow_patterns=COSYVOICE3_REQUIRED_FILES,
+            )
+            logger.info("Loading Fun-CosyVoice3 from %s", model_dir)
+            _patch_torchaudio_load()
+            self.model = AutoModel(model_dir=model_dir, load_trt=False, load_vllm=False, fp16=False)
+            self.model_size = "0.5B"
+            self._device = "cuda" if _torch_cuda_available() else "cpu"
+
+    def unload_model(self) -> None:
+        if self.model is not None:
+            del self.model
+            self.model = None
+            empty_device_cache(self._device)
+            logger.info("CosyVoice3 unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> Tuple[dict, bool]:
+        return {"ref_audio": str(audio_path), "ref_text": reference_text}, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: List[str],
+        reference_texts: List[str],
+    ) -> Tuple[np.ndarray, str]:
+        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=16000)
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> Tuple[np.ndarray, int]:
+        await self.load_model()
+
+        ref_audio = voice_prompt.get("ref_audio")
+        if not ref_audio or not Path(ref_audio).exists():
+            raise RuntimeError("CosyVoice3 requires a valid reference audio sample.")
+
+        ref_text = voice_prompt.get("ref_text") or ""
+        prompt_text = _build_prompt_text(ref_text, language, instruct)
+        tts_text, use_instruct = _prepare_text(text, language, instruct)
+
+        def _generate_sync() -> tuple[np.ndarray, int]:
+            import torch
+
+            if seed is not None:
+                torch.manual_seed(seed)
+                if torch.cuda.is_available():
+                    torch.cuda.manual_seed(seed)
+
+            if use_instruct:
+                outputs = self.model.inference_instruct2(
+                    tts_text,
+                    prompt_text,
+                    ref_audio,
+                    stream=False,
+                )
+            else:
+                outputs = self.model.inference_zero_shot(
+                    tts_text,
+                    prompt_text,
+                    ref_audio,
+                    stream=False,
+                )
+
+            chunks: list[np.ndarray] = []
+            for item in outputs:
+                wav = item["tts_speech"]
+                if isinstance(wav, torch.Tensor):
+                    chunks.append(wav.squeeze().detach().cpu().numpy().astype(np.float32))
+                else:
+                    chunks.append(np.asarray(wav, dtype=np.float32).squeeze())
+
+            if not chunks:
+                raise RuntimeError("CosyVoice3 returned no audio.")
+
+            return np.concatenate(chunks), int(getattr(self.model, "sample_rate", 24000))
+
+        return await asyncio.to_thread(_generate_sync)
+
+
+def _torch_cuda_available() -> bool:
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _patch_torchaudio_load() -> None:
+    import soundfile as sf
+    import torch
+    import torchaudio
+
+    if getattr(torchaudio.load, "_voicebox_soundfile_patch", False):
+        return
+
+    def _load_with_soundfile(uri, *args, **kwargs):
+        data, sample_rate = sf.read(uri, dtype="float32", always_2d=True)
+        tensor = torch.from_numpy(data.T)
+        frame_offset = kwargs.get("frame_offset", 0) or 0
+        num_frames = kwargs.get("num_frames", -1)
+        if frame_offset:
+            tensor = tensor[:, frame_offset:]
+        if num_frames is not None and num_frames >= 0:
+            tensor = tensor[:, :num_frames]
+        return tensor, sample_rate
+
+    _load_with_soundfile._voicebox_soundfile_patch = True  # type: ignore[attr-defined]
+    torchaudio.load = _load_with_soundfile
+
+
+def _build_prompt_text(reference_text: str, language: str, instruct: Optional[str]) -> str:
+    prefix = "You are a helpful assistant."
+    if instruct:
+        prefix = f"{prefix} {instruct.strip()}"
+    elif language == "yue":
+        prefix = f"{prefix} 请用广东话表达。"
+    return f"{prefix}<|endofprompt|>{reference_text}".strip()
+
+
+def _prepare_text(text: str, language: str, instruct: Optional[str]) -> tuple[str, bool]:
+    if instruct or language == "yue":
+        return text, True
+    if language in {"zh", "en", "ja", "ko", "yue"}:
+        return text, False
+    return text, True

--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -138,6 +138,8 @@ def build_server(cuda=False):
             "backend.backends.chatterbox_backend",
             "--hidden-import",
             "backend.backends.chatterbox_turbo_backend",
+            "--hidden-import",
+            "backend.backends.cosyvoice3_backend",
             # chatterbox multilingual uses spacy_pkuseg for Chinese word
             # segmentation, which ships pickled dict files (dicts/default.pkl)
             # and native .so extensions that --hidden-import alone won't bundle.

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,15 +11,16 @@ from .utils.capture_chords import (
     default_toggle_to_talk_chord,
 )
 
+VOICE_LANGUAGE_PATTERN = "^(zh|yue|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+STT_LANGUAGE_PATTERN = "^(en|zh|yue|ja|ko|de|fr|ru|pt|es|it)$"
+
 
 class VoiceProfileCreate(BaseModel):
     """Request model for creating a voice profile."""
 
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
-    language: str = Field(
-        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
-    )
+    language: str = Field(default="en", pattern=VOICE_LANGUAGE_PATTERN)
     voice_type: Optional[str] = Field(default="cloned", pattern="^(cloned|preset|designed)$")
     preset_engine: Optional[str] = Field(None, max_length=50)
     preset_voice_id: Optional[str] = Field(None, max_length=100)
@@ -81,11 +82,11 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$")
+    language: str = Field(default="en", pattern=VOICE_LANGUAGE_PATTERN)
     seed: Optional[int] = Field(None, ge=0)
-    model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
+    model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|0\\.5B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|cosyvoice3|tada|kokoro)$")
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -171,7 +172,7 @@ class HistoryListResponse(BaseModel):
 class TranscriptionRequest(BaseModel):
     """Request model for audio transcription."""
 
-    language: Optional[str] = Field(None, pattern="^(en|zh|ja|ko|de|fr|ru|pt|es|it)$")
+    language: Optional[str] = Field(None, pattern=STT_LANGUAGE_PATTERN)
     model: Optional[str] = Field(None, pattern="^(base|small|medium|large|turbo)$")
 
 
@@ -242,7 +243,7 @@ class CaptureRetranscribeRequest(BaseModel):
     """Request to re-run STT on a capture's audio with a different model."""
 
     model: Optional[str] = Field(None, pattern="^(base|small|medium|large|turbo)$")
-    language: Optional[str] = Field(None, pattern="^(en|zh|ja|ko|de|fr|ru|pt|es|it)$")
+    language: Optional[str] = Field(None, pattern=STT_LANGUAGE_PATTERN)
 
 
 class CaptureSettingsResponse(BaseModel):
@@ -317,7 +318,7 @@ class MCPClientBindingResponse(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|cosyvoice3|tada|kokoro)$",
     )
     default_personality: bool = False
     last_seen_at: Optional[datetime] = None
@@ -336,7 +337,7 @@ class MCPClientBindingUpsert(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|cosyvoice3|tada|kokoro)$",
     )
     default_personality: bool = False
 
@@ -355,16 +356,13 @@ class SpeakRequest(BaseModel):
     )
     engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|cosyvoice3|tada|kokoro)$",
     )
     personality: Optional[bool] = Field(
         None,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS. When null, the per-client binding's default_personality flag decides.",
     )
-    language: Optional[str] = Field(
-        None,
-        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
-    )
+    language: Optional[str] = Field(None, pattern=VOICE_LANGUAGE_PATTERN)
 
 
 class LLMGenerateRequest(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,6 +40,29 @@ pyloudnorm
 # provides the only class TADA uses: Snake1d.)
 torchaudio
 
+# Fun-CosyVoice3 dev-mode backend. The upstream CosyVoice repo is not a
+# normal PyPI package; set COSYVOICE_REPO_PATH to a cloned repo with
+# submodules initialized. openai-whisper is installed separately with
+# --no-build-isolation in setup scripts because its 20231117 sdist expects
+# pkg_resources during metadata generation.
+hyperpyyaml==1.2.3
+hydra-core==1.3.2
+gdown==5.1.0
+beautifulsoup4>=4.12.0
+lightning==2.2.4
+pytorch-lightning==2.2.4
+lightning-utilities==0.11.9
+torchmetrics==1.4.0.post0
+matplotlib==3.8.4
+modelscope==1.20.0
+onnxruntime==1.18.0; sys_platform == "darwin" or sys_platform == "win32"
+pyarrow==18.1.0
+pyworld==0.3.4
+wetext==0.0.4
+wget==3.2
+x-transformers==2.11.24
+einx>=0.4.3
+
 # Kokoro TTS (lightweight 82M-param engine)
 kokoro>=0.9.4
 misaki[en,ja,zh]>=0.9.4

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -24,7 +24,7 @@ from ..utils.images import process_avatar, validate_image
 
 logger = logging.getLogger(__name__)
 
-CLONING_ENGINES = {"qwen", "luxtts", "chatterbox", "chatterbox_turbo", "tada"}
+CLONING_ENGINES = {"qwen", "luxtts", "chatterbox", "chatterbox_turbo", "cosyvoice3", "tada"}
 
 
 def _profile_to_response(

--- a/justfile
+++ b/justfile
@@ -48,6 +48,8 @@ setup-python:
     {{ pip }} install --no-deps chatterbox-tts
     # HumeAI TADA pins torch>=2.7,<2.8 which conflicts with our torch>=2.1
     {{ pip }} install --no-deps hume-tada
+    # CosyVoice3's openai-whisper pin needs pkg_resources during metadata generation
+    {{ pip }} install --no-build-isolation openai-whisper==20231117
     # Apple Silicon: install MLX backend
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
@@ -89,6 +91,7 @@ setup-python:
     & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
     & "{{ pip }}" install --no-deps chatterbox-tts
     & "{{ pip }}" install --no-deps hume-tada
+    & "{{ pip }}" install --no-build-isolation openai-whisper==20231117
     & "{{ pip }}" install git+https://github.com/QwenLM/Qwen3-TTS.git
     & "{{ pip }}" install pyinstaller ruff pytest pytest-asyncio -q
     Write-Host "Python environment ready."


### PR DESCRIPTION
## Summary
- add a new `cosyvoice3` TTS engine option for `FunAudioLLM/Fun-CosyVoice3-0.5B-2512`
- wire CosyVoice3 into backend model registry, cloned-profile validation, model management, generation form types, and engine selector UI
- add Cantonese (`yue`) as a language option for CosyVoice3 and route Cantonese generation through CosyVoice3's instruction-style prompt format
- add the CosyVoice3 dependency set and setup-script handling for `openai-whisper==20231117`

## Dev-mode setup note
CosyVoice upstream is not packaged as a normal PyPI package. This backend expects a local clone with submodules initialized and requires:

```bash
git clone --recursive https://github.com/FunAudioLLM/CosyVoice.git /path/to/CosyVoice
export COSYVOICE_REPO_PATH=/path/to/CosyVoice
```

The backend raises a clear runtime error if `COSYVOICE_REPO_PATH` is missing or invalid.

## Validation
- `bun run typecheck`
- `python -m py_compile` for the new backend and touched backend modules
- Pydantic smoke validation for `engine="cosyvoice3"`, `model_size="0.5B"`, and `language="yue"`
- Fun-CosyVoice3 model load succeeded on macOS/Apple Silicon CPU path with sample rate 24 kHz
- Cantonese generation smoke test using an existing cloned `Ceci Wu` profile produced a 1.76s / 24 kHz WAV result at `/tmp/cosyvoice3_cantonese_smoke.wav`

## Limitations
- This is a draft because frozen PyInstaller builds are not fully verified yet. The backend hidden import is registered, but CosyVoice's upstream repo import path, Matcha-TTS dependency chain, and native/data-file packaging still need full release-build testing.
- CPU inference works but is slow in the smoke test: roughly RTF 21.7 on this local run.
- CosyVoice3 is currently dev-mode only because upstream requires a cloned repo path rather than a regular installable package.
