### PR TITLE
fix(kokoro): add missing male Mandarin voices

### DIFF
--- a/backend/backends/kokoro_backend.py
+++ b/backend/backends/kokoro_backend.py
@@ -96,11 +96,16 @@ KOKORO_VOICES = [
     ("pf_dora", "Dora", "female", "pt"),
     ("pm_alex", "Alex", "male", "pt"),
     ("pm_santa", "Santa", "male", "pt"),
-    # Chinese
+    # Chinese female
     ("zf_xiaobei", "Xiaobei", "female", "zh"),
     ("zf_xiaoni", "Xiaoni", "female", "zh"),
     ("zf_xiaoxiao", "Xiaoxiao", "female", "zh"),
     ("zf_xiaoyi", "Xiaoyi", "female", "zh"),
+    # Chinese male
+    ("zm_yunjian", "Yunjian", "male", "zh"),
+    ("zm_yunxi", "Yunxi", "male", "zh"),
+    ("zm_yunxia", "Yunxia", "male", "zh"),
+    ("zm_yunyang", "Yunyang", "male", "zh"),
 ]
 
 # Map our ISO language codes to Kokoro lang_code characters


### PR DESCRIPTION
## Problem
On Create Voice → Built-in Voices → Kokoro 82M, only female Chinese voices are listed, so users can't select a male Mandarin voice.

## Root cause
The model (`hexgrad/Kokoro-82M`) already ships 4 male Mandarin voices (`zm_yunjian`, `zm_yunxi`, `zm_yunxia`, `zm_yunyang`) — per the official VOICES.md (Mandarin: 4F 4M). The backend's hardcoded `KOKORO_VOICES` list only included the 4 female Chinese voices, so the UI (which renders `GET /profiles/presets/kokoro`) never showed the male ones.

## Fix
Add the 4 male Mandarin voices to `KOKORO_VOICES` in `backend/backends/kokoro_backend.py`. No model bump, no new dependencies (`misaki[zh]` is already required), no frontend changes — the voice `.pt` files are auto-downloaded by KPipeline from the same HF repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Chinese language voice support by introducing male voice variants alongside existing female voices, providing users with more options when selecting Chinese voices for their applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->