### PR TITLE
fix(backends): run MLX load and inference on one thread (fixes #699)

### DIFF
--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -4,11 +4,32 @@ MLX backend implementation for TTS and STT using mlx-audio.
 
 from typing import Optional, List, Tuple
 import asyncio
+import functools
 import logging
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# MLX streams are thread-local and mlx-audio caches one on the model at load
+# time, so model load and inference must run on the same OS thread or inference
+# aborts with "There is no Stream(gpu, N) in current thread" (issues #675, #699).
+_mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
+
+
+async def _run_on_mlx_thread[T](func: Callable[..., T], *args: object) -> T:
+    """Run a blocking MLX call on the single dedicated MLX worker thread.
+
+    Drop-in replacement for ``asyncio.to_thread`` that pins every MLX call --
+    load, generate and transcribe -- to one thread, so a model and the stream
+    mlx-audio caches at load time always share a thread. ``max_workers=1`` also
+    serialises work on the single local GPU.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_mlx_executor, functools.partial(func, *args))
+
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage
 # This prevents mlx_audio from making network requests when models are cached
@@ -82,7 +103,7 @@ class MLXTTSBackend:
             self.unload_model()
 
         # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -259,7 +280,7 @@ class MLXTTSBackend:
             return audio, sample_rate
 
         # Run blocking inference in thread pool
-        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
 
         return audio, sample_rate
 
@@ -293,7 +314,7 @@ class MLXSTTBackend:
             return
 
         # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -364,4 +385,4 @@ class MLXSTTBackend:
                 return str(result).strip()
 
         # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        return await _run_on_mlx_thread(_transcribe_sync)

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -2,7 +2,7 @@
 MLX backend implementation for TTS and STT using mlx-audio.
 """
 
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, TypeVar
 import asyncio
 import functools
 import logging
@@ -13,22 +13,26 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# A TypeVar rather than PEP 695 ``[T]`` generics keeps this module importable on
+# Python 3.11, which the Dockerfile still uses; ruff's UP047 prefers PEP 695 here.
+_T = TypeVar("_T")
+
 # MLX streams are thread-local and mlx-audio caches one on the model at load
 # time, so model load and inference must run on the same OS thread or inference
 # aborts with "There is no Stream(gpu, N) in current thread" (issues #675, #699).
 _mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
 
 
-async def _run_on_mlx_thread[T](func: Callable[..., T], *args: object) -> T:
+async def _run_on_mlx_thread(func: Callable[..., _T], *args: object, **kwargs: object) -> _T:  # noqa: UP047 -- see TypeVar note above (3.11 compat)
     """Run a blocking MLX call on the single dedicated MLX worker thread.
 
-    Drop-in replacement for ``asyncio.to_thread`` that pins every MLX call --
-    load, generate and transcribe -- to one thread, so a model and the stream
-    mlx-audio caches at load time always share a thread. ``max_workers=1`` also
-    serialises work on the single local GPU.
+    Drop-in replacement for ``asyncio.to_thread`` (forwards the same ``*args``
+    and ``**kwargs``) that pins every MLX call -- load, generate and transcribe
+    -- to one thread, so a model and the stream mlx-audio caches at load time
+    always share a thread. ``max_workers=1`` also serialises the single local GPU.
     """
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_mlx_executor, functools.partial(func, *args))
+    return await loop.run_in_executor(_mlx_executor, functools.partial(func, *args, **kwargs))
 
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -4,6 +4,7 @@ MLX backend implementation for TTS and STT using mlx-audio.
 
 from typing import Optional, List, Tuple, TypeVar
 import asyncio
+import contextvars
 import functools
 import logging
 from collections.abc import Callable
@@ -26,13 +27,16 @@ _mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
 async def _run_on_mlx_thread(func: Callable[..., _T], *args: object, **kwargs: object) -> _T:  # noqa: UP047 -- see TypeVar note above (3.11 compat)
     """Run a blocking MLX call on the single dedicated MLX worker thread.
 
-    Drop-in replacement for ``asyncio.to_thread`` (forwards the same ``*args``
-    and ``**kwargs``) that pins every MLX call -- load, generate and transcribe
-    -- to one thread, so a model and the stream mlx-audio caches at load time
-    always share a thread. ``max_workers=1`` also serialises the single local GPU.
+    Drop-in replacement for ``asyncio.to_thread``: forwards the same ``*args``
+    and ``**kwargs`` and copies the caller's ``contextvars`` context into the
+    worker (so client-id / request tracing survive). Pins every MLX call --
+    load, generate and transcribe -- to one thread, so a model and the stream
+    mlx-audio caches at load time always share a thread. ``max_workers=1`` also
+    serialises the single local GPU.
     """
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_mlx_executor, functools.partial(func, *args, **kwargs))
+    ctx = contextvars.copy_context()
+    return await loop.run_in_executor(_mlx_executor, functools.partial(ctx.run, func, *args, **kwargs))
 
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage

--- a/backend/tests/test_mlx_thread_affinity.py
+++ b/backend/tests/test_mlx_thread_affinity.py
@@ -1,14 +1,11 @@
 """Regression tests for MLX worker-thread affinity (issues #675, #699)."""
 
-import sys
+import asyncio
 import threading
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from backends.mlx_backend import _mlx_executor, _run_on_mlx_thread  # noqa: E402 -- needs the sys.path shim above
+from backend.backends.mlx_backend import _run_on_mlx_thread
 
 
 class TestMLXThreadAffinity:
@@ -20,14 +17,15 @@ class TestMLXThreadAffinity:
     single-dedicated-thread guarantee that prevents that.
     """
 
-    def test_executor_is_single_worker(self):
-        """A single worker is what guarantees cross-call thread affinity."""
-        assert _mlx_executor._max_workers == 1
-
     @pytest.mark.asyncio
-    async def test_all_calls_share_one_thread(self):
-        """Load plus many inference calls all run on the same OS thread."""
-        thread_ids = [await _run_on_mlx_thread(threading.get_ident) for _ in range(25)]
+    async def test_all_calls_run_on_one_thread(self):
+        """Concurrently dispatched MLX calls all land on the same OS thread.
+
+        Dispatching concurrently (not sequentially) is what makes this prove a
+        single worker: with more than one worker the gather would fan out across
+        threads and the id set would have more than one entry.
+        """
+        thread_ids = await asyncio.gather(*[_run_on_mlx_thread(threading.get_ident) for _ in range(25)])
 
         assert len(set(thread_ids)) == 1, f"MLX work spread across threads: {set(thread_ids)}"
 

--- a/backend/tests/test_mlx_thread_affinity.py
+++ b/backend/tests/test_mlx_thread_affinity.py
@@ -1,0 +1,56 @@
+"""Regression tests for MLX worker-thread affinity (issues #675, #699)."""
+
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from backends.mlx_backend import _mlx_executor, _run_on_mlx_thread  # noqa: E402 -- needs the sys.path shim above
+
+
+class TestMLXThreadAffinity:
+    """MLX model load and inference must stay pinned to one OS thread.
+
+    MLX streams are thread-local and mlx-audio caches one at load time, so a
+    model loaded on one thread cannot be used from another -- inference aborts
+    with "There is no Stream(gpu, 1) in current thread". These tests lock in the
+    single-dedicated-thread guarantee that prevents that.
+    """
+
+    def test_executor_is_single_worker(self):
+        """A single worker is what guarantees cross-call thread affinity."""
+        assert _mlx_executor._max_workers == 1
+
+    @pytest.mark.asyncio
+    async def test_all_calls_share_one_thread(self):
+        """Load plus many inference calls all run on the same OS thread."""
+        thread_ids = [await _run_on_mlx_thread(threading.get_ident) for _ in range(25)]
+
+        assert len(set(thread_ids)) == 1, f"MLX work spread across threads: {set(thread_ids)}"
+
+    @pytest.mark.asyncio
+    async def test_thread_local_stream_survives_across_calls(self):
+        """A stream cached at load time stays visible to later inference calls.
+
+        Mirrors mlx-audio: the stream is created on the load thread and reused
+        on every generate. On a different thread the second step would raise,
+        reproducing the user-facing error verbatim.
+        """
+        stream_registry = threading.local()
+
+        def _load_model():
+            stream_registry.stream = "Stream(gpu, 1)"
+
+        def _generate():
+            stream = getattr(stream_registry, "stream", None)
+            if stream is None:
+                raise RuntimeError("There is no Stream(gpu, 1) in current thread.")
+            return stream
+
+        await _run_on_mlx_thread(_load_model)
+        results = [await _run_on_mlx_thread(_generate) for _ in range(10)]
+
+        assert results == ["Stream(gpu, 1)"] * 10


### PR DESCRIPTION
## Problem

Every MLX TTS generation (and Whisper transcription / dictation) fails immediately on Apple Silicon with:

```
There is no Stream(gpu, 1) in current thread.
```

Reproduced 100% on macOS 26.5.1 / M4 Pro against `mlx-community/Qwen3-TTS-12Hz-1.7B`:

```bash
curl -s -X POST http://127.0.0.1:17493/generate \
  -H 'Content-Type: application/json' \
  -d '{"profile_id":"<existing>","text":"hello world","language":"en","engine":"qwen","model_size":"1.7B"}'
# /generate/{id}/status →
# {"status":"failed","error":"There is no Stream(gpu, 1) in current thread.", ...}
```

## Root cause

MLX streams are **thread-local** — a stream is only valid on the OS thread that created it. `mlx-audio` creates and caches a generation stream on the model at load time. In `backends/mlx_backend.py`, model load and inference were each dispatched through `asyncio.to_thread(...)`, which runs on Python's **default multi-worker** thread pool. So the model loads on pool thread A, and a later `generate()`/`transcribe()` runs on pool thread B — which has no `Stream(gpu, N)` registered, so MLX aborts.

This affects both `MLXTTSBackend` (#699) and `MLXSTTBackend` / dictation (#675).

## Fix

Route every MLX call — load, generate, and transcribe, for both TTS and STT — through a **single dedicated worker thread** (`ThreadPoolExecutor(max_workers=1)`), so a model and its cached stream always share one thread. `max_workers=1` also serialises work on the single local GPU, which is the intended behaviour (matches the "GPU-bound inference is serialised" note in `STYLE_GUIDE.md`).

```python
_mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")

async def _run_on_mlx_thread[T](func: Callable[..., T], *args: object) -> T:
    loop = asyncio.get_running_loop()
    return await loop.run_in_executor(_mlx_executor, functools.partial(func, *args))
```

Stdlib only — no new dependencies, no version-floor concerns.

## Verification

A faithful standalone replica of the helper (modelling a thread-local stream cached at "load" and reused at "generate"):

```
[old] asyncio.to_thread generate failures: 7/10
[old] sample error: There is no Stream(gpu, 1) in current thread.
[fix] distinct threads across 25 calls: 1   (expect 1)
[fix] generate results: all valid = True
```

Added `backend/tests/test_mlx_thread_affinity.py` (pytest + `pytest-asyncio`) locking in the invariant: all calls share one thread, and a stream cached at load survives every later call.

## Alternatives considered

`mlx.core.new_thread_local_stream` (MLX 0.31) would also work, but the stream is created and cached **inside** `mlx-audio` at load time — voicebox can't inject a per-thread stream there without monkeypatching the dependency. Thread-pinning is the minimal fix that stays agnostic of `mlx-audio` internals and also covers STT.

## Notes for review

- Scope is one file (`mlx_backend.py`) plus the test; `mlx_backend.py` is the only backend that touches MLX.
- `ruff check` shows **no new findings** vs. the pre-change file, and `ruff format --check` is clean.
- `unload_model` already ran on the event-loop thread before this change and is unchanged.

Fixes #699. Also addresses #675.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of MLX-based text-to-speech and speech-to-text by routing blocking model operations (model loading, generation, and transcription) through a consistent dedicated execution thread to avoid concurrency-related issues.

* **Tests**
  * Added regression coverage that validates MLX work runs with single-thread affinity under concurrent calls and confirms thread-local state is preserved across subsequent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->