### PR TITLE
fix(build): build voicebox-mcp shim sidecar on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -206,12 +206,16 @@ build-server: _ensure-venv
 build-server: _ensure-venv
     $ErrorActionPreference = "Stop"; \
     $env:PATH = "{{ venv_bin }};$env:PATH"; \
-    & "{{ python }}" backend/build_binary.py; \
-    if ($LASTEXITCODE -ne 0) { throw "build_binary.py failed with exit code $LASTEXITCODE" }; \
     $triple = (rustc --print host-tuple); \
     New-Item -ItemType Directory -Path "{{ tauri_dir }}/src-tauri/binaries" -Force | Out-Null; \
+    & "{{ python }}" backend/build_binary.py; \
+    if ($LASTEXITCODE -ne 0) { throw "build_binary.py failed with exit code $LASTEXITCODE" }; \
     Copy-Item "backend/dist/voicebox-server.exe" "{{ tauri_dir }}/src-tauri/binaries/voicebox-server-$triple.exe" -Force; \
-    Write-Host "Copied sidecar: voicebox-server-$triple.exe"
+    Write-Host "Copied sidecar: voicebox-server-$triple.exe"; \
+    & "{{ python }}" backend/build_binary.py --shim; \
+    if ($LASTEXITCODE -ne 0) { throw "build_binary.py --shim failed with exit code $LASTEXITCODE" }; \
+    Copy-Item "backend/dist/voicebox-mcp.exe" "{{ tauri_dir }}/src-tauri/binaries/voicebox-mcp-$triple.exe" -Force; \
+    Write-Host "Copied sidecar: voicebox-mcp-$triple.exe"
 
 # Build CUDA server binary and place in app data dir for local testing
 [windows]


### PR DESCRIPTION
## Problem

On Windows, `just build` fails at the Tauri bundling step with:

```
resource path `binaries\voicebox-mcp-<triple>.exe` doesn't exist
```

`tauri.conf.json` declares two external binaries — `binaries/voicebox-server` **and** `binaries/voicebox-mcp` — but the Windows `build-server` recipe in the `justfile` only builds and copies the **server** sidecar. The `voicebox-mcp` stdio shim is never built, so the bundle step aborts.

The Unix path is unaffected: `scripts/build-server.sh` builds **both** sidecars (`build_binary.py` then `build_binary.py --shim`). Only the Windows recipe was missing the shim.

## Fix

Mirror `build-server.sh` in the Windows `build-server` recipe: after building/copying `voicebox-server`, build the shim via `build_binary.py --shim` and copy it to `voicebox-mcp-<triple>.exe`. The `$triple` and `binaries/` directory setup is hoisted ahead of both builds so the shim step reuses them.

## Testing

- `just build` on Windows (x86_64-pc-windows-msvc, Python 3.12, CPU) now produces both sidecars and completes the Tauri bundle, yielding `Voicebox_0.5.0_x64_en-US.msi` and `Voicebox_0.5.0_x64-setup.exe`.
- `just --dry-run build-server` expands to: build server → copy → build shim → copy, with `$LASTEXITCODE` checks on each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows builds now include an additional bundled executable alongside the server binary.
  * The build process now prepares required output folders earlier, helping ensure both packaged artifacts are copied into the app’s binaries directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->