### PR TITLE
Add capture preview placement setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,6 @@
 
 # Changelog
 
-## [Unreleased]
-
-This draft follows the Capture release with a more configurable dictation overlay and a smoother Apple Silicon dev setup. The capture preview can now live where it is easiest to see while dictating, and the local setup path installs the MLX audio packages needed by the backend on Apple Silicon machines.
-
-### Captures
-
-- **Configurable preview placement.** Settings -> Captures now includes a preview location selector with top-left, top-center, top-right, bottom-left, bottom-center, and bottom-right options. The setting persists with the rest of the capture configuration and applies to the floating dictate preview ([#796](https://github.com/jamiepine/voicebox/pull/796)).
-- **Monitor-aware preview positioning.** The dictate preview now positions itself on the monitor containing the cursor when recording starts, then falls back to the current or primary monitor if needed ([#796](https://github.com/jamiepine/voicebox/pull/796)).
-
-### Development
-
-- **Apple Silicon setup installs MLX audio dependencies.** `just setup` now installs the missing `mlx-lm` and `mlx-audio` packages needed for the local backend on Apple Silicon machines ([#796](https://github.com/jamiepine/voicebox/pull/796)).
-
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ This draft follows the Capture release with a more configurable dictation overla
 
 - **Apple Silicon setup installs MLX audio dependencies.** `just setup` now installs the missing `mlx-lm` and `mlx-audio` packages needed for the local backend on Apple Silicon machines ([#796](https://github.com/jamiepine/voicebox/pull/796)).
 
-### Project
-
-- **Trendshift badge.** The README now includes a Trendshift badge for project visibility.
-
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 # Changelog
 
+## [Unreleased]
+
+This draft follows the Capture release with a more configurable dictation overlay and a smoother Apple Silicon dev setup. The capture preview can now live where it is easiest to see while dictating, and the local setup path installs the MLX audio packages needed by the backend on Apple Silicon machines.
+
+### Captures
+
+- **Configurable preview placement.** Settings -> Captures now includes a preview location selector with top-left, top-center, top-right, bottom-left, bottom-center, and bottom-right options. The setting persists with the rest of the capture configuration and applies to the floating dictate preview ([#796](https://github.com/jamiepine/voicebox/pull/796)).
+- **Monitor-aware preview positioning.** The dictate preview now positions itself on the monitor containing the cursor when recording starts, then falls back to the current or primary monitor if needed ([#796](https://github.com/jamiepine/voicebox/pull/796)).
+
+### Development
+
+- **Apple Silicon setup installs MLX audio dependencies.** `just setup` now installs the missing `mlx-lm` and `mlx-audio` packages needed for the local backend on Apple Silicon machines ([#796](https://github.com/jamiepine/voicebox/pull/796)).
+
+### Project
+
+- **Trendshift badge.** The README now includes a Trendshift badge for project visibility.
+
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -31,8 +31,22 @@ import { usePlatform } from '@/platform/PlatformContext';
 import { useServerStore } from '@/stores/serverStore';
 import { cn } from '@/lib/utils/cn';
 import { defaultChordKeys, displayLabelForKey, modifierSideHint } from '@/lib/utils/keyCodes';
-import type { Qwen3ModelSize, VoiceProfileResponse, WhisperModelSize } from '@/lib/api/types';
+import type {
+  CapturePreviewLocation,
+  Qwen3ModelSize,
+  VoiceProfileResponse,
+  WhisperModelSize,
+} from '@/lib/api/types';
 import { SettingRow, SettingSection } from './SettingRow';
+
+const PREVIEW_LOCATION_OPTIONS: CapturePreviewLocation[] = [
+  'top_left',
+  'top_center',
+  'top_right',
+  'bottom_left',
+  'bottom_center',
+  'bottom_right',
+];
 
 function ChordPreview({ keys }: { keys: string[] }) {
   const { t } = useTranslation();
@@ -140,6 +154,7 @@ export function CapturesPage() {
   const hotkeyEnabled = settings?.hotkey_enabled ?? false;
   const pushToTalkKeys = settings?.chord_push_to_talk_keys ?? defaultChordKeys('push');
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
+  const previewLocation = settings?.preview_location ?? 'top_left';
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
   const [opening, setOpening] = useState(false);
@@ -281,6 +296,28 @@ export function CapturesPage() {
             update({ chord_toggle_to_talk_keys: keys });
             setChordEditor(null);
           }}
+        />
+
+        <SettingRow
+          title={t('settings.captures.dictation.previewLocation.title')}
+          description={t('settings.captures.dictation.previewLocation.description')}
+          action={
+            <Select
+              value={previewLocation}
+              onValueChange={(v) => update({ preview_location: v as CapturePreviewLocation })}
+            >
+              <SelectTrigger className="w-[220px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PREVIEW_LOCATION_OPTIONS.map((location) => (
+                  <SelectItem key={location} value={location}>
+                    {t(`settings.captures.dictation.previewLocation.options.${location}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
         />
 
         <SettingRow

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -902,6 +902,18 @@
           "title": "Preview",
           "description": "What appears on screen while you're holding the shortcut."
         },
+        "previewLocation": {
+          "title": "Preview location",
+          "description": "Choose where the floating capture preview appears.",
+          "options": {
+            "top_left": "Top left",
+            "top_center": "Top center",
+            "top_right": "Top right",
+            "bottom_left": "Bottom left",
+            "bottom_center": "Bottom center",
+            "bottom_right": "Bottom right"
+          }
+        },
         "copyToClipboard": {
           "title": "Copy transcript to clipboard",
           "description": "The cleaned transcript lands on your clipboard when the capture finishes."

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -902,6 +902,18 @@
           "title": "プレビュー",
           "description": "ショートカットを押している間、画面に表示される内容です。"
         },
+        "previewLocation": {
+          "title": "プレビュー位置",
+          "description": "フローティングのキャプチャプレビューを表示する場所を選びます。",
+          "options": {
+            "top_left": "左上",
+            "top_center": "上中央",
+            "top_right": "右上",
+            "bottom_left": "左下",
+            "bottom_center": "下中央",
+            "bottom_right": "右下"
+          }
+        },
         "copyToClipboard": {
           "title": "文字起こしをクリップボードにコピー",
           "description": "キャプチャが終わると、整形済みの文字起こしがクリップボードに保存されます。"

--- a/app/src/i18n/locales/zh-CN/translation.json
+++ b/app/src/i18n/locales/zh-CN/translation.json
@@ -902,6 +902,18 @@
           "title": "预览",
           "description": "按住快捷键时屏幕上显示的内容。"
         },
+        "previewLocation": {
+          "title": "预览位置",
+          "description": "选择浮动捕获预览的显示位置。",
+          "options": {
+            "top_left": "左上",
+            "top_center": "顶部居中",
+            "top_right": "右上",
+            "bottom_left": "左下",
+            "bottom_center": "底部居中",
+            "bottom_right": "右下"
+          }
+        },
         "copyToClipboard": {
           "title": "将转录复制到剪贴板",
           "description": "捕获完成后,清理过的转录会出现在剪贴板上。"

--- a/app/src/i18n/locales/zh-TW/translation.json
+++ b/app/src/i18n/locales/zh-TW/translation.json
@@ -902,6 +902,18 @@
           "title": "預覽",
           "description": "按住快捷鍵時螢幕上顯示的內容。"
         },
+        "previewLocation": {
+          "title": "預覽位置",
+          "description": "選擇浮動擷取預覽的顯示位置。",
+          "options": {
+            "top_left": "左上",
+            "top_center": "頂部置中",
+            "top_right": "右上",
+            "bottom_left": "左下",
+            "bottom_center": "底部置中",
+            "bottom_right": "右下"
+          }
+        },
         "copyToClipboard": {
           "title": "將轉錄文字複製到剪貼簿",
           "description": "擷取完成時,清理過的轉錄文字會出現在您的剪貼簿。"

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -217,7 +217,17 @@ export interface CaptureSettings {
   chord_push_to_talk_keys: string[];
   /** keytap key names. Toggle adds Space to the platform-specific PTT chord. */
   chord_toggle_to_talk_keys: string[];
+  /** Where the floating capture preview appears on the target display. */
+  preview_location: CapturePreviewLocation;
 }
+
+export type CapturePreviewLocation =
+  | 'top_left'
+  | 'top_center'
+  | 'top_right'
+  | 'bottom_left'
+  | 'bottom_center'
+  | 'bottom_right';
 
 export type CaptureSettingsUpdate = Partial<CaptureSettings>;
 

--- a/app/src/lib/hooks/useChordSync.ts
+++ b/app/src/lib/hooks/useChordSync.ts
@@ -32,13 +32,23 @@ export function useChordSync() {
   const enabled = settings?.hotkey_enabled;
   const pushKeys = settings?.chord_push_to_talk_keys;
   const toggleKeys = settings?.chord_toggle_to_talk_keys;
+  const previewLocation = settings?.preview_location ?? 'top_left';
+
+  useEffect(() => {
+    if (!platform.metadata.isTauri) return;
+    invoke('set_dictate_preview_location', { location: previewLocation }).catch((err) => {
+      console.warn('[chord-sync] set_dictate_preview_location failed:', err);
+    });
+  }, [platform.metadata.isTauri, previewLocation]);
 
   useEffect(() => {
     if (!platform.metadata.isTauri) return;
     if (enabled === undefined || !pushKeys || !toggleKeys) return;
     const shouldArm = enabled && canRecord;
     const command = shouldArm ? 'enable_hotkey' : 'disable_hotkey';
-    const args = shouldArm ? { pushToTalk: pushKeys, toggleToTalk: toggleKeys } : {};
+    const args = shouldArm
+      ? { pushToTalk: pushKeys, toggleToTalk: toggleKeys, previewLocation }
+      : {};
     invoke(command, args).catch((err) => {
       console.warn(`[chord-sync] ${command} failed:`, err);
     });
@@ -50,5 +60,6 @@ export function useChordSync() {
     // doesn't fire a redundant invoke on every settings refetch.
     pushKeys?.join(','),
     toggleKeys?.join(','),
+    previewLocation,
   ]);
 }

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -243,6 +243,13 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "hotkey_enabled BOOLEAN NOT NULL DEFAULT 0",
             "hotkey_enabled",
         )
+    if "preview_location" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "preview_location VARCHAR NOT NULL DEFAULT 'top_left'",
+            "preview_location",
+        )
 
 
 def _migrate_mcp_bindings(engine, inspector, tables: set[str]) -> None:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -218,6 +218,7 @@ class CaptureSettings(Base):
     chord_toggle_to_talk_keys = Column(
         JSON, nullable=False, default=default_toggle_to_talk_chord
     )
+    preview_location = Column(String, nullable=False, default="top_left")
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,7 @@ Pydantic models for request/response validation.
 """
 
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Literal, Optional, List
 from datetime import datetime
 
 from .utils.capture_chords import (
@@ -264,6 +264,14 @@ class CaptureSettingsResponse(BaseModel):
     chord_toggle_to_talk_keys: List[str] = Field(
         default_factory=default_toggle_to_talk_chord
     )
+    preview_location: Literal[
+        "top_left",
+        "top_center",
+        "top_right",
+        "bottom_left",
+        "bottom_center",
+        "bottom_right",
+    ] = "top_left"
 
     class Config:
         from_attributes = True
@@ -284,6 +292,16 @@ class CaptureSettingsUpdate(BaseModel):
     hotkey_enabled: Optional[bool] = None
     chord_push_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
     chord_toggle_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
+    preview_location: Optional[
+        Literal[
+            "top_left",
+            "top_center",
+            "top_right",
+            "bottom_left",
+            "bottom_center",
+            "bottom_right",
+        ]
+    ] = None
 
 
 class GenerationSettingsResponse(BaseModel):

--- a/justfile
+++ b/justfile
@@ -52,6 +52,8 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q

--- a/tauri/src-tauri/src/hotkey_monitor.rs
+++ b/tauri/src-tauri/src/hotkey_monitor.rs
@@ -35,7 +35,7 @@ use keytap::{Key, RecvTimeoutError};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::focus_capture;
-use crate::DICTATE_WINDOW_LABEL;
+use crate::{dictate_preview_location, position_dictate_window, DICTATE_WINDOW_LABEL};
 
 // ========================================================================
 // Public types
@@ -242,28 +242,9 @@ fn apply_effect(app: &AppHandle, effect: Effect) {
             if let Some(window) = app.get_webview_window(DICTATE_WINDOW_LABEL) {
                 // The previous hide-cycle parked the window off-screen and
                 // made it click-through — undo both before showing, so the
-                // pill lands at top-center and the user can actually click
-                // the error pill / stop button.
-                //
-                // `current_monitor()` returns None when the window is off
-                // any display (our hide handler parks it at -10_000, -10_000
-                // precisely so it never intercepts clicks), so fall back to
-                // the primary monitor for the reposition.
-                let monitor = window
-                    .current_monitor()
-                    .ok()
-                    .flatten()
-                    .or_else(|| window.primary_monitor().ok().flatten());
-                if let Some(monitor) = monitor {
-                    let monitor_pos = monitor.position();
-                    let monitor_size = monitor.size();
-                    if let Ok(win_size) = window.outer_size() {
-                        let x = monitor_pos.x
-                            + (monitor_size.width as i32 - win_size.width as i32) / 2;
-                        let y = monitor_pos.y + (monitor_size.height as f64 * 0.04) as i32;
-                        let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
-                    }
-                }
+                // pill lands where the user configured it and the user can
+                // actually click the error pill / stop button.
+                let _ = position_dictate_window(&window, dictate_preview_location(app));
                 let _ = window.set_ignore_cursor_events(false);
                 // Deliberately no set_focus() — taking key focus would yank
                 // it out of whatever app the user was typing in, which is

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -24,6 +24,85 @@ pub const DICTATE_WINDOW_LABEL: &str = "dictate";
 const DICTATE_WINDOW_WIDTH: f64 = 420.0;
 const DICTATE_WINDOW_HEIGHT: f64 = 64.0;
 
+#[cfg(desktop)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DictatePreviewLocation {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+}
+
+#[cfg(desktop)]
+impl Default for DictatePreviewLocation {
+    fn default() -> Self {
+        Self::TopLeft
+    }
+}
+
+#[cfg(desktop)]
+#[derive(Default)]
+pub struct DictatePreviewState {
+    location: Mutex<DictatePreviewLocation>,
+}
+
+#[cfg(desktop)]
+pub fn dictate_preview_location(app: &tauri::AppHandle) -> DictatePreviewLocation {
+    app.try_state::<DictatePreviewState>()
+        .and_then(|state| state.location.lock().ok().map(|location| *location))
+        .unwrap_or_default()
+}
+
+#[cfg(desktop)]
+fn monitor_containing_cursor(window: &tauri::WebviewWindow) -> Option<tauri::Monitor> {
+    let cursor = window.cursor_position().ok()?;
+    window.monitor_from_point(cursor.x, cursor.y).ok().flatten()
+}
+
+#[cfg(desktop)]
+pub fn position_dictate_window(
+    window: &tauri::WebviewWindow,
+    location: DictatePreviewLocation,
+) -> tauri::Result<()> {
+    let monitor = monitor_containing_cursor(window)
+        .or_else(|| window.current_monitor().ok().flatten())
+        .or_else(|| window.primary_monitor().ok().flatten());
+
+    let Some(monitor) = monitor else {
+        return Ok(());
+    };
+
+    let monitor_pos = monitor.position();
+    let monitor_size = monitor.size();
+    let win_size = window.outer_size()?;
+    let monitor_width = monitor_size.width as i32;
+    let monitor_height = monitor_size.height as i32;
+    let win_width = win_size.width as i32;
+    let win_height = win_size.height as i32;
+    let vertical_margin = (monitor_size.height as f64 * 0.04) as i32;
+    let horizontal_margin = (monitor_size.width as f64 * 0.04) as i32;
+
+    let centered_x = monitor_pos.x + (monitor_width - win_width) / 2;
+    let left_x = monitor_pos.x + horizontal_margin;
+    let right_x = monitor_pos.x + monitor_width - win_width - horizontal_margin;
+    let top_y = monitor_pos.y + vertical_margin;
+    let bottom_y = monitor_pos.y + monitor_height - win_height - vertical_margin;
+
+    let (x, y) = match location {
+        DictatePreviewLocation::TopLeft => (left_x, top_y),
+        DictatePreviewLocation::TopCenter => (centered_x, top_y),
+        DictatePreviewLocation::TopRight => (right_x, top_y),
+        DictatePreviewLocation::BottomLeft => (left_x, bottom_y),
+        DictatePreviewLocation::BottomCenter => (centered_x, bottom_y),
+        DictatePreviewLocation::BottomRight => (right_x, bottom_y),
+    };
+
+    window.set_position(PhysicalPosition::new(x, y))
+}
+
 /// Create the floating dictate webview hidden. The HotkeyMonitor shows it on
 /// chord-start; the frontend hides it when the capture pipeline finishes.
 /// Building it at setup avoids a race where the first chord or agent-speech
@@ -49,13 +128,7 @@ fn build_dictate_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewW
     .visible(false)
     .build()?;
 
-    if let Some(monitor) = window.current_monitor()? {
-        let monitor_size = monitor.size();
-        let win_size = window.outer_size()?;
-        let x = (monitor_size.width as i32 - win_size.width as i32) / 2;
-        let y = (monitor_size.height as f64 * 0.04) as i32;
-        window.set_position(PhysicalPosition::new(x, y))?;
-    }
+    position_dictate_window(&window, DictatePreviewLocation::default())?;
 
     Ok(window)
 }
@@ -95,23 +168,7 @@ pub fn show_dictate_window(app: &tauri::AppHandle) {
             }
         },
     };
-    // current_monitor() returns None when the window has been parked
-    // off any display by the hide path; fall back to the primary.
-    let monitor = window
-        .current_monitor()
-        .ok()
-        .flatten()
-        .or_else(|| window.primary_monitor().ok().flatten());
-    if let Some(monitor) = monitor {
-        let monitor_pos = monitor.position();
-        let monitor_size = monitor.size();
-        if let Ok(win_size) = window.outer_size() {
-            let x = monitor_pos.x
-                + (monitor_size.width as i32 - win_size.width as i32) / 2;
-            let y = monitor_pos.y + (monitor_size.height as f64 * 0.04) as i32;
-            let _ = window.set_position(PhysicalPosition::new(x, y));
-        }
-    }
+    let _ = position_dictate_window(&window, dictate_preview_location(app));
     let _ = window.set_ignore_cursor_events(false);
     let _ = window.show();
 }
@@ -874,6 +931,20 @@ pub struct HotkeyState {
 }
 
 #[cfg(desktop)]
+#[command]
+fn set_dictate_preview_location(
+    app: tauri::AppHandle,
+    state: State<'_, DictatePreviewState>,
+    location: DictatePreviewLocation,
+) -> Result<(), String> {
+    *state.location.lock().map_err(|e| e.to_string())? = location;
+    if let Some(window) = app.get_webview_window(DICTATE_WINDOW_LABEL) {
+        let _ = position_dictate_window(&window, location);
+    }
+    Ok(())
+}
+
+#[cfg(desktop)]
 fn build_chord_bindings(
     push_to_talk: &[String],
     toggle_to_talk: &[String],
@@ -917,9 +988,15 @@ fn build_chord_bindings(
 fn enable_hotkey(
     app: tauri::AppHandle,
     state: State<'_, HotkeyState>,
+    preview_state: State<'_, DictatePreviewState>,
     push_to_talk: Vec<String>,
     toggle_to_talk: Vec<String>,
+    preview_location: Option<DictatePreviewLocation>,
 ) -> Result<(), String> {
+    if let Some(location) = preview_location {
+        *preview_state.location.lock().map_err(|e| e.to_string())? = location;
+    }
+
     let bindings = build_chord_bindings(&push_to_talk, &toggle_to_talk)?;
 
     // Fire the Input Monitoring TCC prompt explicitly from the user's
@@ -1260,6 +1337,7 @@ pub fn run() {
                 // command — see HotkeyState. The hidden dictate webview is
                 // safe to build up front because it does not create the global
                 // keyboard tap or trigger the macOS Input Monitoring prompt.
+                app.manage(DictatePreviewState::default());
                 app.manage(HotkeyState::default());
 
                 // The frontend emits `dictate:hide` whenever the pill cycle
@@ -1372,6 +1450,7 @@ pub fn run() {
             open_accessibility_settings,
             open_input_monitoring_settings,
             paste_final_text,
+            set_dictate_preview_location,
             enable_hotkey,
             disable_hotkey,
             update_chord_bindings


### PR DESCRIPTION
## Summary

- Adds a persisted capture preview location setting with six placement options.
- Repositions the dictate preview from Rust using the selected location and the monitor containing the cursor when recording starts.
- Fixes Apple Silicon setup to install missing MLX audio packages used by the local backend.

Closes #698

I recorded a small little video showing the feature, also fixed the recording showing on your active monitor and not always on primary
Audio dropped a bit as I started recording with the app... but you can still sort of hear after that point... visually it's probably more helpful anyway to see the change

https://youtu.be/bRrf6uEr2aA

## Test plan

- [x] `git diff --check`
- [x] `bun run typecheck`
- [x] `cargo check --manifest-path tauri/src-tauri/Cargo.toml`
- [x] Manually verified in dev on macOS that the preview location setting renders and the preview follows the active monitor.
- [ ] `cargo fmt --check` passes repo-wide; currently blocked by existing unrelated Rust formatting drift across the crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose where the floating dictation/capture preview appears (top/bottom and left/center/right).
  * The selected preview position is saved and applied automatically when starting dictation.

* **Bug Fixes**
  * Improved, monitor-aware window placement so the preview opens reliably in the chosen location.

* **Documentation**
  * Updated app translations for the new preview location setting in multiple languages.

* **Chores**
  * Updated Apple Silicon Python setup to include MLX audio dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->