### PR TITLE
Fix MLX backend reference audio leak in voice cloning

### DIFF
--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -228,8 +228,30 @@ class MLXTTSBackend:
 
                     sig = inspect.signature(self.model.generate)
                     if "ref_audio" in sig.parameters:
-                        # Generate with voice cloning
-                        for result in self.model.generate(text, ref_audio=ref_audio, ref_text=ref_text, lang_code=lang):
+                        # Generate with voice cloning.
+                        #
+                        # NOTE: We deliberately do NOT pass ref_text here.
+                        # The mlx_audio Qwen3 TTS model has two code paths for
+                        # ref_audio:
+                        #
+                        #   1. ICL (In-Context Learning) — triggered when BOTH
+                        #      ref_audio AND ref_text are provided AND the
+                        #      speech tokenizer has an encoder.  This path
+                        #      encodes the reference audio into codec tokens,
+                        #      prepends them to the generated codes, and
+                        #      decodes everything together — so the output
+                        #      CONTAINS THE REFERENCE AUDIO (the bug).
+                        #
+                        #   2. Speaker-embedding path — triggered when only
+                        #      ref_audio is provided (or the tokenizer lacks
+                        #      an encoder).  This path extracts a speaker
+                        #      embedding from the reference audio and uses it
+                        #      to condition generation WITHOUT including the
+                        #      reference audio in the output.
+                        #
+                        # By omitting ref_text we force path 2, which is the
+                        # correct zero-shot voice cloning behaviour.
+                        for result in self.model.generate(text, ref_audio=ref_audio, lang_code=lang):
                             audio_chunks.append(np.array(result.audio))
                             sample_rate = result.sample_rate
                     else:


### PR DESCRIPTION
## Description

When using the MLX backend (Apple Silicon) for voice cloning, the reference audio sample is included in the generated output. This happens because the backend passes both `ref_audio` and `ref_text` to mlx_audio's `model.generate()`, which triggers the **ICL (In-Context Learning)** path. The ICL path encodes the reference audio into codec tokens, prepends them to the generated codes, and decodes everything together — so the output contains the reference audio followed by the new speech.

## Root Cause

In mlx_audio's Qwen3 TTS model (`qwen3_tts.py:965-970`):

```python
use_icl = (
    ref_audio is not None
    and ref_text is not None      # both must be set
    and self.speech_tokenizer.has_encoder
)
```

When ICL mode is active, `_generate_icl()` prepends the reference audio codes to the generated output.

## Fix

Omit `ref_text` from the `model.generate()` call. Without `ref_text`, the ICL path is not triggered, and the model falls through to the **speaker-embedding path** which:
1. Extracts a speaker embedding from the reference audio via `extract_speaker_embedding()`
2. Uses that embedding to condition generation
3. Does **not** include the reference audio in the output

## Testing

Generated the same text with a cloned voice profile:

| Test | Duration | Result |
|------|----------|--------|
| `ref_audio` + `ref_text` (before) | 4.96s | Reference audio (~2.3s) prepended to output |
| `ref_audio` only (after fix) | 2.64s | Clean generated speech, no reference audio leak |

The PyTorch backend is not affected — it uses `create_voice_clone_prompt()` / `generate_voice_clone()` which properly processes the voice prompt into an embedding before generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice cloning output quality when using reference audio.
  * Reduced cases where generated speech could unintentionally resemble the reference recording too closely.
  * Better supports zero-shot voice cloning behavior for more natural results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->