### PR TITLE
docs(i18n): add Spanish translations (README, CONTRIBUTING, SECURITY)

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -1,0 +1,394 @@
+# Contribuir a Voicebox
+
+[English](CONTRIBUTING.md) · **Español**
+
+¡Gracias por tu interés en contribuir a Voicebox! Este documento ofrece pautas e instrucciones para contribuir.
+
+## Código de conducta
+
+- Sé respetuoso e inclusivo
+- Da la bienvenida a los recién llegados y ayúdales a aprender
+- Céntrate en el feedback constructivo
+- Respeta los distintos puntos de vista y experiencias
+
+## Primeros pasos
+
+### Requisitos previos
+
+- **[Bun](https://bun.sh)** - Runtime y gestor de paquetes de JavaScript rápido
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+
+- **[Python 3.11+](https://python.org)** - Para el desarrollo del backend
+  ```bash
+  python --version  # Debe ser 3.11 o superior
+  ```
+
+- **[Rust](https://rustup.rs)** - Para la app de escritorio Tauri (lo instala automáticamente la CLI de Tauri)
+  ```bash
+  rustc --version  # Comprueba si está instalado
+  ```
+- **[Requisitos previos de Tauri](https://v2.tauri.app/start/prerequisites)** - Dependencias del sistema específicas de Tauri (varían según el SO).
+
+- **Git** - Control de versiones
+
+### Configuración del entorno de desarrollo
+
+Instala [just](https://github.com/casey/just) (`brew install just`, `cargo install just` o `winget install Casey.Just`), y luego:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/voicebox.git
+cd voicebox
+
+just setup   # crea el venv, instala dependencias de Python + JS
+just dev     # arranca el backend + la app de escritorio
+```
+
+`just setup` se encarga de todo automáticamente, incluyendo:
+- Crear un entorno virtual de Python
+- Instalar las dependencias de Python (con PyTorch CUDA en Windows si se detecta una GPU NVIDIA)
+- Instalar las dependencias de MLX en Apple Silicon
+- Instalar las dependencias de JavaScript
+
+`just dev` arranca el backend y la app de escritorio juntos. Si ya hay un backend en marcha (p. ej. desde `just dev-backend` en otra terminal), lo detecta y solo arranca el frontend.
+
+Otros comandos útiles:
+
+```bash
+just dev-web       # backend + app web (sin compilación de Tauri/Rust)
+just dev-backend   # solo backend
+just dev-frontend  # solo app Tauri (el backend debe estar en marcha)
+just kill          # detiene todos los procesos de desarrollo
+just clean-all     # borra todo y empieza de cero
+just --list        # ve todos los comandos disponibles
+```
+
+> **Nota:** En modo desarrollo, la app se conecta a un servidor Python iniciado manualmente.
+> El binario del servidor incluido solo se usa en las compilaciones de producción.
+
+#### Notas para Windows
+
+El justfile funciona de forma nativa en Windows vía PowerShell. No hace falta WSL ni Git Bash. En Windows con una GPU NVIDIA, `just setup` instala automáticamente PyTorch con CUDA para la aceleración por GPU.
+
+### Descargas de modelos
+
+Los modelos se descargan automáticamente desde HuggingFace Hub en el primer uso:
+- **Whisper** (transcripción): se descarga solo en la primera transcripción
+- **Qwen3-TTS** (clonación de voz): se descarga solo en la primera generación (~2-4 GB)
+
+El primer uso será más lento por las descargas de modelos, pero las ejecuciones posteriores usarán los modelos en caché.
+
+### Compilación
+
+**Compilar la app de producción:**
+
+```bash
+just build        # Compila el binario del servidor CPU + el instalador de Tauri
+```
+
+En Windows, para compilar con compatibilidad CUDA para pruebas locales:
+
+```bash
+just build-local  # Compila los binarios del servidor CPU + CUDA + el instalador de Tauri
+```
+
+Esto compila el sidecar de CPU (incluido con la app), el binario CUDA (ubicado en `%APPDATA%/com.voicebox.app/backends/` para el cambio de GPU en tiempo de ejecución) y la app Tauri instalable.
+
+Crea instaladores específicos de cada plataforma (`.dmg`, `.msi`, `.AppImage`) en `tauri/src-tauri/target/release/bundle/`.
+
+**Objetivos de compilación individuales:**
+
+```bash
+just build-server       # solo el binario del servidor CPU
+just build-server-cuda  # solo el binario del servidor CUDA (Windows)
+just build-tauri        # solo la app de escritorio Tauri
+just build-web          # solo la app web
+```
+
+**Compilar con una versión de desarrollo local de Qwen3-TTS:**
+
+Si estás desarrollando o modificando activamente la biblioteca Qwen3-TTS, define la variable de entorno `QWEN_TTS_PATH` apuntando a tu clon local:
+
+```bash
+export QWEN_TTS_PATH=~/path/to/your/Qwen3-TTS
+just build-server
+```
+
+Esto hace que PyInstaller use tu versión local de qwen-tts en lugar del paquete instalado con pip.
+
+### Generar el cliente OpenAPI
+
+Tras arrancar el servidor backend:
+```bash
+./scripts/generate-api.sh
+```
+Esto descarga el esquema OpenAPI y genera el cliente TypeScript en `app/src/lib/api/`
+
+### Convertir recursos a formatos web
+
+Para optimizar imágenes y vídeos para la web, ejecuta:
+```bash
+bun run convert:assets
+```
+
+Este script:
+- Convierte PNG → WebP (mejor compresión, misma calidad)
+- Convierte MOV → WebM (códec VP9, menor tamaño de archivo)
+- Procesa los archivos en `landing/public/` y `docs/public/`
+- **Elimina los archivos originales** tras una conversión correcta
+
+**Requisitos:** Instala `webp` y `ffmpeg`:
+```bash
+brew install webp ffmpeg
+```
+
+> **Nota:** Ejecuta esto antes de hacer commit de imágenes o vídeos nuevos para mantener el tamaño del repositorio pequeño.
+
+## Flujo de trabajo de desarrollo
+
+### 1. Crea una rama
+
+```bash
+git checkout -b feature/your-feature-name
+# o
+git checkout -b fix/your-bug-fix
+```
+
+### 2. Haz tus cambios
+
+- Escribe código limpio y legible
+- Sigue el estilo de código existente
+- Añade comentarios para la lógica compleja
+- Actualiza la documentación según haga falta
+
+### 3. Prueba tus cambios
+
+- Pruébalos manualmente en la app
+- Asegúrate de que los endpoints de la API del backend funcionan
+- Comprueba que no hay errores de TypeScript/Python
+- Verifica que los componentes de la UI se renderizan correctamente
+
+### 4. Haz commit de tus cambios
+
+Escribe mensajes de commit claros y descriptivos:
+
+```bash
+git commit -m "Add feature: voice profile export"
+git commit -m "Fix: audio playback stops after 30 seconds"
+```
+
+### 5. Haz push y crea un Pull Request
+
+```bash
+git push origin feature/your-feature-name
+```
+
+Luego crea un pull request en GitHub con:
+- Una descripción clara de los cambios
+- Capturas de pantalla (para cambios de UI)
+- Referencia a los issues relacionados
+
+## Estilo de código
+
+### TypeScript/React
+
+- Usa el modo estricto de TypeScript
+- Sigue las buenas prácticas de React
+- Usa componentes funcionales con hooks
+- Prefiere las exportaciones nombradas
+- Formatea con Biome (se ejecuta automáticamente)
+
+```typescript
+// Bien
+export function ProfileCard({ profile }: { profile: Profile }) {
+  return <div>{profile.name}</div>;
+}
+
+// Evita
+export const ProfileCard = (props) => { ... }
+```
+
+### Python
+
+- Sigue la guía de estilo PEP 8
+- Usa anotaciones de tipo
+- Usa async/await para las operaciones de E/S
+- Formatea con Black (si está configurado)
+
+```python
+# Bien
+async def create_profile(name: str, language: str) -> Profile:
+    """Create a new voice profile."""
+    ...
+
+# Evita
+def create_profile(name, language):
+    ...
+```
+
+### Rust
+
+- Sigue las convenciones de Rust
+- Usa nombres de variable significativos
+- Maneja los errores de forma explícita
+- Formatea con `rustfmt`
+
+## Estructura del proyecto
+
+```
+voicebox/
+├── app/              # Frontend React compartido
+│   └── src/
+│       ├── components/   # Componentes de UI
+│       ├── lib/          # Utilidades y cliente de la API
+│       └── hooks/        # Hooks de React
+├── backend/          # Servidor Python FastAPI
+│   ├── main.py       # Rutas de la API
+│   ├── tts.py        # Síntesis de voz
+│   └── ...
+├── tauri/            # Envoltorio de la app de escritorio
+│   └── src-tauri/    # Backend en Rust
+└── scripts/          # Scripts de compilación
+```
+
+## Áreas para contribuir
+
+### 🐛 Corrección de errores
+
+- Revisa los issues existentes en busca de errores que corregir
+- Prueba tu corrección a fondo
+- Añade tests si es posible
+
+### ✨ Funciones nuevas
+
+- Revisa la hoja de ruta en README.md y el estado de ingeniería en [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) antes de proponer trabajo — enumera tareas priorizadas (Tier 1 → 3), cuellos de botella arquitectónicos conocidos y motores TTS candidatos ya en evaluación (incluido por qué algunos se han aplazado)
+- Discute las funciones grandes primero en un issue
+- Mantén las funciones enfocadas y bien acotadas
+
+### 📚 Documentación
+
+- Mejora la claridad del README
+- Añade comentarios al código
+- Escribe documentación de la API
+- Crea tutoriales o guías
+
+### 🎨 Mejoras de UI/UX
+
+- Mejora la accesibilidad
+- Mejora el diseño visual
+- Optimiza el rendimiento
+- Añade animaciones/transiciones
+
+### 🔧 Infraestructura
+
+- Mejora el proceso de compilación
+- Añade mejoras de CI/CD
+- Optimiza el tamaño del bundle
+- Añade infraestructura de tests
+
+## Desarrollo de la API
+
+Al añadir nuevos endpoints de la API:
+
+1. **Añade la ruta en `backend/main.py`**
+2. **Crea los modelos Pydantic en `backend/models.py`**
+3. **Implementa la lógica de negocio en el módulo apropiado**
+4. **Actualiza el esquema OpenAPI** (automático con FastAPI)
+5. **Regenera el cliente TypeScript:**
+   ```bash
+   bun run generate:api
+   ```
+6. **Actualiza `backend/README.md`** con la documentación del endpoint
+
+## Tests
+
+Actualmente, las pruebas son principalmente manuales. Al añadir tests:
+
+- **Backend**: usa pytest para los tests de Python
+- **Frontend**: usa Vitest para los tests de componentes de React
+- **E2E**: usa Playwright para los tests de extremo a extremo (futuro)
+
+## Proceso de Pull Request
+
+1. **Actualiza la documentación** si hace falta
+2. **Asegúrate de que el código sigue las pautas de estilo**
+3. **Prueba tus cambios a fondo**
+4. **Actualiza CHANGELOG.md** con tus cambios
+5. **Solicita revisión** a los mantenedores
+
+### Checklist del PR
+
+- [ ] El código sigue las pautas de estilo
+- [ ] Documentación actualizada
+- [ ] Cambios probados
+- [ ] Sin cambios disruptivos (o documentados)
+- [ ] CHANGELOG.md actualizado
+
+## Proceso de release
+
+Los releases los gestionan los mantenedores:
+
+1. **Sube la versión con bumpversion:**
+   ```bash
+   # Instala bumpversion (si aún no está instalado)
+   pip install bumpversion
+   
+   # Sube la versión de parche (0.1.0 -> 0.1.1)
+   bumpversion patch
+   
+   # O sube la versión menor (0.1.0 -> 0.2.0)
+   bumpversion minor
+   
+   # O sube la versión mayor (0.1.0 -> 1.0.0)
+   bumpversion major
+   ```
+   
+   Esto automáticamente:
+   - Actualiza los números de versión en todos los archivos (`tauri.conf.json`, `Cargo.toml`, todos los `package.json`, `backend/main.py`)
+   - Crea un commit de git con la subida de versión
+   - Crea una etiqueta de git (p. ej., `v0.1.1`, `v0.2.0`)
+
+2. **Actualiza CHANGELOG.md** con las notas del release
+
+3. **Haz push de los commits y las etiquetas:**
+   ```bash
+   git push
+   git push --tags
+   ```
+
+4. **GitHub Actions compila y publica** automáticamente cuando se suben las etiquetas
+
+## Solución de problemas
+
+Consulta [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/troubleshooting.mdx) para problemas comunes y sus soluciones.
+
+**Arreglos rápidos:**
+
+- **El backend no arranca:** Comprueba la versión de Python (3.11+), asegúrate de que el venv está activado, instala las dependencias
+- **La compilación de Tauri falla:** Asegúrate de que Rust está instalado, limpia la compilación con `cd tauri/src-tauri && cargo clean`
+- **La generación del cliente OpenAPI falla:** Asegúrate de que el backend está en marcha, comprueba `curl http://localhost:17493/openapi.json`
+
+## ¿Preguntas?
+
+- Abre un issue para errores o solicitudes de funciones
+- Revisa los issues y discusiones existentes
+- Revisa el código para entender los patrones
+- Consulta [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/troubleshooting.mdx) para problemas comunes
+
+## Recursos adicionales
+
+- [README.md](README.md) - Visión general del proyecto
+- [backend/README.md](backend/README.md) - Documentación de la API
+- [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md) - Hoja de ruta de ingeniería viva: arquitectura, trabajo publicado vs en curso, issues abiertos priorizados, motores TTS candidatos en evaluación, cuellos de botella arquitectónicos. Mantenlo actualizado cuando publiques funciones importantes, cierres o aplaces una integración de modelo, o identifiques nuevos cuellos de botella.
+- [docs/content/docs/developer/autoupdater.mdx](docs/content/docs/developer/autoupdater.mdx) - Configuración del actualizador automático
+- [SECURITY.md](SECURITY.md) - Política de seguridad
+- [CHANGELOG.md](CHANGELOG.md) - Historial de versiones
+
+## Licencia
+
+Al contribuir, aceptas que tus contribuciones se licencien bajo la Licencia MIT.
+
+---
+
+¡Gracias por contribuir a Voicebox! 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Voicebox
 
+**English** · [Español](CONTRIBUTING.es.md)
+
 Thank you for your interest in contributing to Voicebox! This document provides guidelines and instructions for contributing.
 
 ## Code of Conduct
@@ -379,7 +381,7 @@ See [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/
 - [README.md](README.md) - Project overview
 - [backend/README.md](backend/README.md) - API documentation
 - [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md) - Living engineering roadmap: architecture, shipped vs in-flight work, prioritized open issues, candidate TTS engines under evaluation, architectural bottlenecks. Keep this updated when you ship significant features, close or backlog a model integration, or identify new bottlenecks.
-- [docs/AUTOUPDATER_QUICKSTART.md](docs/AUTOUPDATER_QUICKSTART.md) - Auto-updater setup
+- [docs/content/docs/developer/autoupdater.mdx](docs/content/docs/developer/autoupdater.mdx) - Auto-updater setup
 - [SECURITY.md](SECURITY.md) - Security policy
 - [CHANGELOG.md](CHANGELOG.md) - Version history
 

--- a/README.es.md
+++ b/README.es.md
@@ -315,7 +315,7 @@ Voicebox incluye un servidor **Model Context Protocol** integrado para que cualq
 
 **Comando de una línea para Claude Code:**
 
-```
+```bash
 claude mcp add voicebox \
   --transport http \
   --url http://127.0.0.1:17493/mcp \
@@ -439,7 +439,7 @@ La guía está optimizada para agentes de programación con IA. Una [skill de ag
 
 ### Estructura del proyecto
 
-```
+```text
 voicebox/
 ├── app/              # Frontend React compartido
 ├── tauri/            # App de escritorio (Tauri + Rust)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,477 @@
+<p align="center">
+  <img src=".github/assets/icon-dark.webp" alt="Voicebox" width="120" height="120" />
+</p>
+
+<h1 align="center">Voicebox</h1>
+
+<p align="center">
+  <strong>El estudio de voz con IA de código abierto.</strong><br/>
+  Clona cualquier voz. Genera voz. Dicta en cualquier app. Habla con agentes en voces que son tuyas.<br/>
+  Toda la pila de E/S de voz, ejecutándose localmente en tu equipo.
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · <strong>Español</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/jamiepine/voicebox/releases">
+    <img src="https://img.shields.io/github/downloads/jamiepine/voicebox/total?style=flat&color=blue" alt="Descargas" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/releases/latest">
+    <img src="https://img.shields.io/github/v/release/jamiepine/voicebox?style=flat" alt="Versión" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/stargazers">
+    <img src="https://img.shields.io/github/stars/jamiepine/voicebox?style=flat" alt="Estrellas" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/jamiepine/voicebox?style=flat" alt="Licencia" />
+  </a>
+  <a href="https://deepwiki.com/jamiepine/voicebox">
+    <img src="https://img.shields.io/static/v1?label=Ask&message=DeepWiki&color=5B6EF7" alt="Preguntar a DeepWiki" />
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://trendshift.io/repositories/21213" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21213" alt="jamiepine%2Fvoicebox | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
+<p align="center">
+  <a href="https://voicebox.sh">voicebox.sh</a> •
+  <a href="https://docs.voicebox.sh">Documentación</a> •
+  <a href="#descargar">Descargar</a> •
+  <a href="#funciones">Funciones</a> •
+  <a href="#api">API</a> •
+  <a href="docs/content/docs/overview/troubleshooting.mdx">Solución de problemas</a>
+</p>
+
+<br/>
+
+<p align="center">
+  <a href="https://voicebox.sh">
+    <img src="landing/public/assets/app-screenshot-1.webp" alt="Captura de la app Voicebox" width="800" />
+  </a>
+</p>
+
+<p align="center">
+  <em>Haz clic en la imagen de arriba para ver el vídeo de demostración en <a href="https://voicebox.sh">voicebox.sh</a></em>
+</p>
+
+<br/>
+
+<p align="center">
+  <img src="landing/public/assets/app-screenshot-2.webp" alt="Captura 2 de Voicebox" width="800" />
+</p>
+
+<p align="center">
+  <img src="landing/public/assets/app-screenshot-3.webp" alt="Captura 3 de Voicebox" width="800" />
+</p>
+
+<br/>
+
+## ¿Qué es Voicebox?
+
+Voicebox es un **estudio de voz con IA local-first**: una alternativa gratuita y de código abierto a **ElevenLabs** y **WisprFlow** en una sola app. Clona voces a partir de unos segundos de audio, genera voz en 23 idiomas con 7 motores TTS, dicta en cualquier campo de texto con un atajo global y dale a cualquier agente de IA compatible con MCP una voz de tu elección.
+
+Los dos referentes en la nube ocupan mitades opuestas del bucle de E/S de voz: ElevenLabs en la salida, WisprFlow en la entrada. Voicebox hace ambas, las conecta con un LLM local incluido para el refinamiento y las personalidades por perfil, y ejecuta todo en tu equipo.
+
+- **Privacidad total** — los modelos, los datos de voz y las capturas nunca salen de tu equipo
+- **7 motores TTS** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA y Kokoro
+- **Clonación de voz y voces predefinidas** — clonación zero-shot a partir de una muestra de referencia, o más de 50 voces predefinidas y curadas vía Kokoro y Qwen CustomVoice
+- **23 idiomas** — del inglés al árabe, japonés, hindi, suajili y más
+- **Efectos de posprocesado** — cambio de tono, reverberación, retardo, coro, compresión y filtros
+- **Voz expresiva** — etiquetas paralingüísticas como `[laugh]`, `[sigh]`, `[gasp]` vía Chatterbox Turbo; control de la interpretación en lenguaje natural vía Qwen CustomVoice
+- **Longitud ilimitada** — fragmentación automática con fundido cruzado para guiones, artículos y capítulos
+- **Editor de historias** — línea de tiempo multipista para conversaciones, pódcasts y narraciones
+- **Entrada de voz** — atajo global de dictado con modos pulsar para hablar y alternancia, pegado automático verificado por Accesibilidad en macOS, micrófono in-app en cada campo de texto, STT basado en Whisper
+- **Salida de voz para agentes** — una sola llamada de herramienta (`voicebox.speak`) y cualquier agente compatible con MCP (Claude Code, Cursor, Cline) te habla en una voz que has clonado
+- **Personalidades de voz** — asigna una personalidad libre a cualquier perfil de voz y luego usa Redactar, Reescribir o Responder mediante un LLM local incluido; los agentes pueden invocar los mismos modos por MCP
+- **API-first** — API REST más un servidor MCP integrado para incorporar E/S de voz a tus propias apps y agentes
+- **Rendimiento nativo** — construido con Tauri (Rust), no Electron
+- **Funciona en todas partes** — macOS (MLX/Metal), Windows (CUDA), Linux, AMD ROCm, Intel Arc, Docker
+
+---
+
+## Descargar
+
+| Plataforma            | Descarga                                               |
+| --------------------- | ------------------------------------------------------ |
+| macOS (Apple Silicon) | [Descargar DMG](https://voicebox.sh/download/mac-arm)   |
+| macOS (Intel)         | [Descargar DMG](https://voicebox.sh/download/mac-intel) |
+| Windows               | [Descargar MSI](https://voicebox.sh/download/windows)   |
+| Docker                | `docker compose up`                                    |
+
+> **[Ver todos los binarios →](https://github.com/jamiepine/voicebox/releases/latest)**
+
+> **Linux** — Aún no hay binarios precompilados. Consulta [voicebox.sh/linux-install](https://voicebox.sh/linux-install) para las instrucciones de compilación desde el código fuente.
+
+> **¿Problemas?** Consulta la [guía de solución de problemas](docs/content/docs/overview/troubleshooting.mdx) para incidencias comunes de instalación, generación, descarga de modelos y GPU.
+
+---
+
+## Funciones
+
+### Clonación de voz multimotor
+
+Siete motores TTS con puntos fuertes distintos, intercambiables en cada generación:
+
+| Motor                       | Idiomas   | Puntos fuertes                                                                                                                           |
+| --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Qwen3-TTS** (0.6B / 1.7B) | 10        | Clonación multilingüe de alta calidad, instrucciones de interpretación ("habla despacio", "susurra")                                     |
+| **Qwen CustomVoice**        | 10        | 9 voces predefinidas curadas con control de interpretación en lenguaje natural — sin audio de referencia                                 |
+| **LuxTTS**                  | Inglés    | Ligero (~1 GB de VRAM), salida a 48 kHz, 150x tiempo real en CPU                                                                          |
+| **Chatterbox Multilingual** | 23        | La cobertura de idiomas más amplia — árabe, danés, finés, griego, hebreo, hindi, malayo, noruego, polaco, suajili, sueco, turco y más    |
+| **Chatterbox Turbo**        | Inglés    | Modelo rápido de 350M con etiquetas paralingüísticas de emoción/sonido                                                                    |
+| **TADA** (1B / 3B)          | 10        | Modelo de lenguaje-habla de HumeAI — audio coherente de más de 700 s, alineación dual texto-acústica                                      |
+| **Kokoro**                  | 8         | 50 voces predefinidas curadas, modelo diminuto de 82M, inferencia rápida en CPU                                                          |
+
+### Emociones y etiquetas paralingüísticas
+
+Solo **Chatterbox Turbo** interpreta etiquetas paralingüísticas como `[laugh]` y
+`[sigh]`. Qwen3-TTS, LuxTTS, Chatterbox Multilingual y HumeAI TADA las leen
+literalmente como texto.
+
+Con **Chatterbox Turbo** seleccionado, escribe `/` en el campo de texto para abrir el
+insertador de etiquetas y añadir etiquetas expresivas en línea con el habla:
+
+`[laugh]` `[chuckle]` `[gasp]` `[cough]` `[sigh]` `[groan]` `[sniff]` `[shush]` `[clear throat]`
+
+### Efectos de posprocesado
+
+8 efectos de audio con la biblioteca `pedalboard` de Spotify. Se aplican tras la generación, con vista previa en tiempo real y preajustes reutilizables.
+
+| Efecto            | Descripción                                       |
+| ----------------- | ------------------------------------------------- |
+| Cambio de tono    | Hacia arriba o abajo hasta 12 semitonos           |
+| Reverberación     | Tamaño de sala, amortiguación y mezcla húmedo/seco configurables |
+| Retardo           | Eco con tiempo, realimentación y mezcla ajustables |
+| Coro / Flanger    | Retardo modulado para texturas metálicas o densas |
+| Compresor         | Compresión de rango dinámico                      |
+| Ganancia          | Ajuste de volumen (−40 a +40 dB)                  |
+| Filtro paso alto  | Elimina las frecuencias bajas                     |
+| Filtro paso bajo  | Elimina las frecuencias altas                     |
+
+Incluye 4 preajustes integrados (Robótica, Radio, Cámara de eco, Voz grave) y admite preajustes personalizados. Los efectos pueden asignarse por perfil como predeterminados.
+
+### Longitud de generación ilimitada
+
+El texto se divide automáticamente en los límites de las frases y cada fragmento se genera por separado, para luego unirse con fundido cruzado. Funciona con todos los motores.
+
+- Límite de fragmentación automática configurable (100–5000 caracteres)
+- Control deslizante de fundido cruzado (0–200 ms) para transiciones suaves
+- Longitud máxima de texto: 50 000 caracteres
+- La división inteligente respeta abreviaturas, puntuación CJK y `[etiquetas]`
+
+### Versiones de generación
+
+Cada generación admite varias versiones con seguimiento de procedencia:
+
+- **Original** — salida TTS limpia, siempre conservada
+- **Versiones con efectos** — aplica distintas cadenas de efectos desde cualquier versión de origen
+- **Tomas** — regenera con una nueva semilla para variar
+- **Seguimiento de origen** — cada versión registra su linaje
+- **Favoritos** — marca generaciones con estrella para acceso rápido
+
+### Cola de generación asíncrona
+
+La generación no bloquea. Envía y empieza a escribir la siguiente de inmediato.
+
+- La cola de ejecución en serie evita la contención de la GPU
+- Streaming de estado en tiempo real vía SSE
+- Las generaciones fallidas se pueden reintentar
+- Las generaciones obsoletas por cierres inesperados se recuperan solas al arrancar
+
+### Gestión de perfiles de voz
+
+- Crea perfiles a partir de archivos de audio o grábalos directamente en la app
+- Importa/exporta perfiles para compartirlos o respaldarlos
+- Compatible con varias muestras para una clonación de mayor calidad
+- Cadenas de efectos predeterminadas por perfil
+- Organiza con descripciones y etiquetas de idioma
+
+### Editor de historias
+
+Editor de línea de tiempo multivoz para conversaciones, pódcasts y narraciones.
+
+- Composición multipista con arrastrar y soltar
+- Recorte y división de audio en línea
+- Reproducción automática con cabezal sincronizado
+- Fijación de versión por clip de pista
+
+### Dictado global y entrada de voz
+
+La otra mitad del bucle de E/S de voz. Mantén pulsado un atajo en cualquier parte de tu sistema, habla, suelta — en macOS la transcripción se pega directamente en el campo de texto activo. O pulsa el micrófono en cualquier campo de texto de Voicebox y dicta directamente en la app.
+
+- **Combinaciones de teclas configurables** — combinaciones de mantener-para-hablar y pulsar-para-alternar, cada una reasignable en el selector de combinaciones in-app. Manteniendo pulsar para hablar y tocando `Espacio` a mitad de pulsación se asciende a una sesión de alternancia sin cortes en el audio
+- **Pegado consciente del destino (macOS)** — inyección verificada por Accesibilidad en el campo de texto activo, con guardado/restauración atómica del portapapeles para que no se sobrescriba
+- **UX de permisos en el primer uso** — las puertas in-app te guían por la concesión de Accesibilidad y Monitorización de entrada de macOS con enlaces directos a Ajustes del Sistema
+- **Botón de micrófono in-app** en cada campo de texto de Voicebox — formulario de generación, descripciones de perfil, títulos de historia, donde sea que escribas
+- **Refinamiento por LLM** — limpieza opcional de muletillas, tartamudeos y falsos comienzos antes de pegar
+- **Píldora en pantalla** — superposición flotante que muestra los estados `grabando`, `transcribiendo`, `refinando` y `hablando`. La misma píldora que usan los agentes cuando te hablan, así hay un único modelo mental para ambas direcciones del bucle
+
+### Voz a texto
+
+Voicebox ejecuta OpenAI Whisper para la transcripción — el mismo modelo que sustenta el dictado, la pestaña Capturas y la API `/transcribe`. Se ejecuta en MLX (Apple Silicon) o PyTorch (CUDA / ROCm / DirectML / CPU) según tu plataforma.
+
+| Tamaño                        | Notas                                              |
+| ----------------------------- | -------------------------------------------------- |
+| Base / Small / Medium / Large | Escalera de calidad estándar de Whisper            |
+| Turbo                         | ~8x más rápido que Whisper Large, con pérdida mínima de calidad |
+
+Se planean más motores (Parakeet v3, Qwen3-ASR) — consulta la [hoja de ruta](#hoja-de-ruta).
+
+### Capturas
+
+Cada dictado, grabación in-app y archivo de audio subido aparece en la pestaña Capturas — audio original emparejado con su transcripción, siempre conservado.
+
+- **Reproduce, vuelve a transcribir, refina** — reejecuta STT con cualquier tamaño de Whisper, o reprocesa la transcripción en bruto con el LLM local con distintos ajustes (limpieza de muletillas, eliminación de autocorrecciones, conservación de términos técnicos)
+- **Edita en línea** — ajusta la transcripción y se guarda al perder el foco
+- **Reproducir como perfil de voz** — convierte cualquier captura en voz con una voz clonada, en un clic
+- **Promover a muestra de voz** — usa el audio + transcripción de una captura como muestra de referencia en cualquier perfil de voz
+- **Almacenamiento local de capturas** — el audio original y la transcripción se quedan en tu directorio de datos de Voicebox, con un acceso directo a la carpeta en Ajustes
+
+### Salida de voz para agentes
+
+Cada agente tiene voz. Una sola llamada de herramienta y cualquier agente compatible con MCP puede hablarte en una voz que has clonado — finalizaciones de tareas, preguntas, notificaciones. La misma píldora que aparece durante el dictado aparece durante el habla del agente, así siempre ves lo que sale de tu equipo.
+
+```ts
+// En cualquier agente compatible con MCP:
+await voicebox.speak({
+  text: "Despliegue completado.",
+  profile: "Morgan",
+});
+```
+
+También expuesto como `POST /speak` para todo lo que no hable MCP — ACP, A2A, scripts de shell, arneses personalizados.
+
+- **Píldora bidireccional** — `grabando`, `transcribiendo`, `refinando` y `hablando` son estados de la misma superposición a nivel de SO, así que el dictado y el habla del agente comparten una sola superficie
+- **Vinculación de voz por agente** — en **Ajustes → MCP**, asigna Claude Code a Morgan y Cursor a Scarlett para saber qué agente habla sin mirar. La marca de tiempo `last_seen_at` de cada cliente confirma que la instalación funcionó
+- **Siempre visible** — sin TTS silencioso en segundo plano; cada habla iniciada por un agente muestra la píldora con el nombre del perfil de voz durante toda su duración
+- **Transportes HTTP + stdio** — instálalo como URL en el MCP de Claude Code / Cursor / Windsurf / VS Code, o apunta los clientes solo-stdio al binario `voicebox-mcp` incluido
+
+### Personalidades de voz
+
+Asigna una personalidad libre a cualquier perfil de voz — quién es esta voz, cómo habla, qué le importa. Aparecen dos acciones en el cuadro de generación cuando hay una personalidad definida, impulsadas por un LLM Qwen3 incluido que se ejecuta enteramente en local.
+
+- **Redactar** — un botón de barajar que deja una frase fresca en personaje en el área de texto; edita y habla, o haz clic de nuevo para otra versión
+- **Hablar en personaje** — un interruptor que pasa tu texto de entrada por el LLM de personalidad para reescribirlo en su voz antes del TTS
+
+Los agentes pueden acceder a la misma ruta de reescritura por MCP pasando `personality: true` a `voicebox.speak`, convirtiendo la herramienta en una tubería texto-de-entrada → LLM-de-personalidad → TTS. El mismo LLM sustenta el paso de refinamiento del dictado — un LLM en la app, una caché de modelo, una huella de memoria de GPU.
+
+**Opciones de LLM local:** Qwen3 0.6B / 1.7B / 4B, compartiendo el runtime de TTS (MLX en Apple Silicon, PyTorch en el resto).
+
+Casos de uso: bucles de desarrollo con agentes (dicta una pregunta, escucha la respuesta en una voz clonada), personajes interactivos para juegos y herramientas narrativas, asistencia del habla para personas que no pueden hablar con su voz original.
+
+### Gestión de modelos
+
+- Liberación por modelo para liberar memoria de GPU sin borrar las descargas
+- Directorio de modelos personalizado vía `VOICEBOX_MODELS_DIR`
+- Migración de la carpeta de modelos con seguimiento del progreso
+- Interfaz para cancelar/limpiar descargas
+
+### Compatibilidad con GPU
+
+| Plataforma               | Backend        | Notas                                          |
+| ------------------------ | -------------- | ---------------------------------------------- |
+| macOS (Apple Silicon)    | MLX (Metal)    | 4-5x más rápido vía Neural Engine              |
+| Windows / Linux (NVIDIA) | PyTorch (CUDA) | Descarga el binario CUDA automáticamente desde la app |
+| Linux (AMD)              | PyTorch (ROCm) | Configura HSA_OVERRIDE_GFX_VERSION automáticamente |
+| Windows (cualquier GPU)  | DirectML       | Compatibilidad universal con GPU en Windows    |
+| Intel Arc                | IPEX/XPU       | Aceleración con GPU discreta de Intel          |
+| Cualquiera               | CPU            | Funciona en todas partes, solo que más lento   |
+
+---
+
+## API
+
+Voicebox expone una API REST para integrar E/S de voz en tus propias apps y agentes.
+
+```bash
+# Generar voz
+curl -X POST http://127.0.0.1:17493/generate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello world", "profile_id": "abc123", "language": "en"}'
+
+# Salida de voz para agentes — cualquier app o script puede hablar en una voz clonada
+curl -X POST http://127.0.0.1:17493/speak \
+  -H "Content-Type: application/json" \
+  -H "X-Voicebox-Client-Id: my-script" \
+  -d '{"text": "Deploy complete.", "profile": "Morgan"}'
+
+# Transcribir un archivo de audio
+curl -X POST http://127.0.0.1:17493/transcribe \
+  -F "audio=@recording.wav" \
+  -F "model=whisper-turbo"
+
+# Listar perfiles de voz
+curl http://127.0.0.1:17493/profiles
+```
+
+`POST /speak` acepta `profile` como nombre (sin distinguir mayúsculas) o id, y lo resuelve con la misma precedencia que la herramienta MCP: argumento explícito → vinculación por cliente → `capture_settings.default_playback_voice_id`.
+
+### Servidor MCP
+
+Voicebox incluye un servidor **Model Context Protocol** integrado para que cualquier agente compatible con MCP (Claude Code, Cursor, Windsurf, Cline, extensiones MCP de VS Code) pueda hablar, transcribir y explorar capturas y perfiles.
+
+**Comando de una línea para Claude Code:**
+
+```
+claude mcp add voicebox \
+  --transport http \
+  --url http://127.0.0.1:17493/mcp \
+  --header "X-Voicebox-Client-Id: claude-code"
+```
+
+**Cualquier cliente MCP por HTTP** (Cursor, Windsurf, VS Code, etc.):
+
+```json
+{
+  "mcpServers": {
+    "voicebox": {
+      "url": "http://127.0.0.1:17493/mcp",
+      "headers": { "X-Voicebox-Client-Id": "cursor" }
+    }
+  }
+}
+```
+
+**Alternativa por stdio** para clientes que no hablan MCP por HTTP — apunta al binario `voicebox-mcp` incluido dentro de la app:
+
+```json
+{
+  "mcpServers": {
+    "voicebox": {
+      "command": "/Applications/Voicebox.app/Contents/MacOS/voicebox-mcp",
+      "env": { "VOICEBOX_CLIENT_ID": "claude-desktop" }
+    }
+  }
+}
+```
+
+Se incluyen cuatro herramientas: `voicebox.speak`, `voicebox.transcribe`, `voicebox.list_captures`, `voicebox.list_profiles`. Las vinculaciones de voz por cliente se gestionan en **Voicebox → Ajustes → MCP**. Consulta la [guía completa de MCP](docs/content/docs/overview/mcp-server.mdx) para las firmas de las herramientas, la precedencia de resolución, el contrato de la píldora de habla y las notas de seguridad.
+
+```ts
+// En cualquier agente compatible con MCP:
+await voicebox.speak({
+  text: "Tests passing. Ready to merge.",
+  profile: "Morgan",      // opcional — recurre a la vinculación por cliente
+  personality: true,      // opcional — reescribe el texto con el LLM de personalidad del perfil primero
+});
+```
+
+**Casos de uso:** bucles de desarrollo con agentes (voz de entrada, voz de salida), diálogos de videojuegos, producción de pódcasts, herramientas de accesibilidad, asistentes de voz, automatización de contenido.
+
+Documentación completa de la API disponible en `http://127.0.0.1:17493/docs`.
+
+---
+
+## Pila tecnológica
+
+| Capa          | Tecnología                                                                      |
+| ------------- | ------------------------------------------------------------------------------- |
+| App de escritorio | Tauri (Rust)                                                                |
+| Frontend      | React, TypeScript, Tailwind CSS                                                 |
+| Estado        | Zustand, React Query                                                            |
+| Backend       | FastAPI (Python)                                                                |
+| Motores TTS   | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
+| STT           | Whisper / Whisper Turbo (PyTorch o MLX)                                         |
+| LLM local     | Qwen3 (0.6B / 1.7B / 4B), runtime compartido con TTS / STT                      |
+| Servidor MCP  | FastMCP montado en `/mcp` (HTTP en streaming) + binario adaptador stdio incluido |
+| Adaptador nativo | Rust (dentro de Tauri) para el atajo global, la inyección de pegado y la introspección de foco |
+| Efectos       | Pedalboard (Spotify)                                                            |
+| Inferencia    | MLX (Apple Silicon) / PyTorch (CUDA/ROCm/XPU/CPU)                               |
+| Base de datos | SQLite                                                                          |
+| Audio         | WaveSurfer.js, librosa                                                          |
+
+---
+
+## Hoja de ruta
+
+| Función                            | Descripción                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| **Pegado automático en Windows / Linux** | Paridad del pegado del dictado — `SendInput` en Windows, `uinput` / AT-SPI en Linux |
+| **Ampliación de motores STT**      | Parakeet v3 y Qwen3-ASR sumándose a Whisper — más de 50 idiomas, mejor calidad fuera del inglés |
+| **Enrutamiento de tuberías**       | Cadenas configurables origen → transformación → destino con destinos webhook + MCP y un editor de preajustes |
+| **Transcripción en streaming**     | `/transcribe/stream` por WebSocket para transcripciones parciales mientras hablas |
+| **LLM de habla de extremo a extremo** | Moshi, GLM-4-Voice, Qwen2.5 Omni — voz a voz real, sin texto intermedio |
+| **Diseño de voz**                  | Crea voces nuevas a partir de descripciones de texto                     |
+| **Captura de formato largo**       | Grabador de doble flujo (micrófono + audio del sistema) con transformación por LLM de resumen |
+| **Destinos de plataforma**         | Apple Notes, Obsidian y otras integraciones opcionales                   |
+| **Arquitectura de plugins**        | Amplía con modelos, transformaciones y destinos personalizados           |
+| **App complementaria para móvil**  | Controla Voicebox desde tu teléfono                                      |
+
+Para el **estado de ingeniería completo, el triaje de issues abiertos y la cola de trabajo priorizada**, consulta [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) — un documento vivo que registra lo que se ha publicado, lo que está en curso, los motores TTS candidatos en evaluación y por qué hemos aceptado o aplazado integraciones concretas.
+
+---
+
+## Desarrollo
+
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) ([versión en español](CONTRIBUTING.es.md)) para la configuración detallada y las pautas de contribución.
+
+### Inicio rápido
+
+```bash
+git clone https://github.com/jamiepine/voicebox.git
+cd voicebox
+
+just setup   # crea el venv de Python e instala todas las dependencias
+just dev     # arranca el backend + la app de escritorio
+```
+
+Instala [just](https://github.com/casey/just): `brew install just` o `cargo install just`. Ejecuta `just --list` para ver todos los comandos.
+
+**Requisitos previos:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.11+](https://python.org), [requisitos previos de Tauri](https://v2.tauri.app/start/prerequisites/) y [Xcode](https://developer.apple.com/xcode/) en macOS.
+
+El repo incluye un `.mcp.json` preconfigurado en la raíz — ejecutar Claude Code dentro de este checkout recoge las herramientas MCP de Voicebox automáticamente una vez que la app de desarrollo está en marcha.
+
+### Compilar localmente
+
+```bash
+just build          # Compila el binario del servidor CPU + la app Tauri
+just build-local    # (Windows) Compila los binarios del servidor CPU + CUDA + la app Tauri
+```
+
+### Añadir nuevos modelos de voz
+
+La arquitectura multimotor hace que añadir nuevos motores TTS sea sencillo. Una [guía paso a paso](docs/content/docs/developer/tts-engines.mdx) cubre todo el proceso: investigación de dependencias, implementación del protocolo del backend, cableado del frontend y empaquetado con PyInstaller.
+
+La guía está optimizada para agentes de programación con IA. Una [skill de agente](.agents/skills/add-tts-engine/SKILL.md) puede tomar el nombre de un modelo y encargarse de toda la integración de forma autónoma — tú solo pruebas la compilación localmente.
+
+### Estructura del proyecto
+
+```
+voicebox/
+├── app/              # Frontend React compartido
+├── tauri/            # App de escritorio (Tauri + Rust)
+├── web/              # Despliegue web
+├── backend/          # Servidor Python FastAPI
+├── landing/          # Sitio web de marketing
+└── scripts/          # Scripts de compilación y release
+```
+
+---
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Consulta [CONTRIBUTING.md](CONTRIBUTING.md) ([versión en español](CONTRIBUTING.es.md)) para las pautas.
+
+1. Haz un fork del repo
+2. Crea una rama de función
+3. Haz tus cambios
+4. Envía un PR
+
+## Seguridad
+
+¿Has encontrado una vulnerabilidad de seguridad? Repórtala de forma responsable. Consulta [SECURITY.md](SECURITY.md) ([versión en español](SECURITY.es.md)) para más detalles.
+
+---
+
+## Licencia
+
+Licencia MIT — consulta [LICENSE](LICENSE) para más detalles.
+
+---
+
+<p align="center">
+  <a href="https://voicebox.sh">voicebox.sh</a>
+</p>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 </p>
 
 <p align="center">
+  <strong>English</strong> · <a href="README.es.md">Español</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/jamiepine/voicebox/releases">
     <img src="https://img.shields.io/github/downloads/jamiepine/voicebox/total?style=flat&color=blue" alt="Downloads" />
   </a>

--- a/SECURITY.es.md
+++ b/SECURITY.es.md
@@ -1,0 +1,94 @@
+# Política de seguridad
+
+[English](SECURITY.md) · **Español**
+
+## Versiones compatibles
+
+Publicamos parches para vulnerabilidades de seguridad. Qué versiones son elegibles para recibir dichos parches depende de la clasificación CVSS v3.0:
+
+| Versión | Compatible         |
+| ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
+
+## Reportar una vulnerabilidad
+
+Si descubres una vulnerabilidad de seguridad, repórtala de forma responsable:
+
+1. **No** abras un issue público en GitHub
+2. Envía los detalles de seguridad por correo a: [security@voicebox.sh](mailto:security@voicebox.sh)
+3. Incluye:
+   - Descripción de la vulnerabilidad
+   - Pasos para reproducirla
+   - Impacto potencial
+   - Solución sugerida (si la hay)
+
+Nosotros:
+- Confirmaremos la recepción en un plazo de 48 horas
+- Daremos un calendario para abordar el problema
+- Te mantendremos informado del progreso
+- Te daremos crédito en el aviso de seguridad (si lo deseas)
+
+## Buenas prácticas de seguridad
+
+### Para usuarios
+
+- **Mantén Voicebox actualizado** - Las actualizaciones incluyen parches de seguridad
+- **Verifica las descargas** - Descarga solo de los releases oficiales
+- **Procesamiento local** - Los datos de voz se quedan en tu equipo
+- **Seguridad de red** - Usa HTTPS al conectarte a servidores remotos
+
+### Para desarrolladores
+
+- **Dependencias** - Mantén todas las dependencias al día
+- **Revisión de código** - Todos los PR requieren revisión antes de fusionarse
+- **Secretos** - Nunca hagas commit de claves de API ni de firma
+- **Firma** - Todos los releases están firmados criptográficamente
+
+## Consideraciones de seguridad conocidas
+
+### Procesamiento local
+
+Voicebox procesa todo el audio localmente de forma predeterminada. Tus datos de voz nunca salen de tu equipo a menos que actives explícitamente el modo de servidor remoto.
+
+### Modo de servidor remoto
+
+Al conectarte a un servidor remoto:
+- Asegúrate de que el servidor está en una red de confianza
+- Usa HTTPS para las conexiones remotas
+- Verifica la identidad del servidor antes de conectarte
+
+### Actualizaciones automáticas
+
+- Las actualizaciones están firmadas criptográficamente
+- La verificación de la firma ocurre antes de la instalación
+- Solo se permiten endpoints HTTPS
+
+### Servidor Python
+
+El servidor Python integrado:
+- Se ejecuta localmente de forma predeterminada (solo localhost)
+- Se puede configurar para acceso remoto
+- Usa las prácticas de seguridad estándar de FastAPI
+
+## Calendario de divulgación
+
+- **Día 0**: Vulnerabilidad reportada
+- **Día 1-2**: Evaluación inicial y confirmación
+- **Día 3-7**: Investigación y desarrollo de la corrección
+- **Día 8-14**: Pruebas y preparación del release
+- **Día 15+**: Divulgación pública (si procede)
+
+El calendario puede variar según la gravedad y la complejidad.
+
+## Actualizaciones de seguridad
+
+Las actualizaciones de seguridad se:
+- Publicarán como versiones de parche (p. ej., 0.3.2)
+- Documentarán en CHANGELOG.md
+- Anunciarán vía releases de GitHub
+- Entregarán automáticamente vía el actualizador automático
+
+---
+
+¡Gracias por ayudar a mantener Voicebox seguro! 🔒

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+**English** · [Español](SECURITY.es.md)
+
 ## Supported Versions
 
 We release patches for security vulnerabilities. Which versions are eligible for receiving such patches depends on the CVSS v3.0 Rating:


### PR DESCRIPTION
## What

Adds Spanish (`es`) translations of the top-level documentation as separate `*.es.md` files, with a reciprocal language switcher on each doc.

## Why

Lowers the entry barrier for Spanish-speaking users and contributors. Complements the UI locale work (#798) so both the app and its docs are available in Spanish. Kept as a separate PR from the UI locale so each is small and easy to review.

## Changes

- **`README.es.md`**, **`CONTRIBUTING.es.md`**, **`SECURITY.es.md`** — full translations. Code blocks, commands, paths, CLI flags, brand/model names, badges and table structure are preserved; only prose is translated. The README's internal anchors point to the translated headings.
- **`README.md` / `CONTRIBUTING.md` / `SECURITY.md`** — add an `English · Español` switcher line near the top so each English doc links to its Spanish counterpart (and back).
- **Drive-by fix:** the "Additional Resources" entry in CONTRIBUTING linked to a non-existent `docs/AUTOUPDATER_QUICKSTART.md`; repointed to the actual `docs/content/docs/developer/autoupdater.mdx` (in both EN and ES).

## Verification

- All internal `#anchor` links and local file links resolve across all six files (checked programmatically).
- No code changes; no CI build impact.

## Notes

- `CHANGELOG.md` left untouched — it's auto-compiled during the release workflow per the file header.
- The docs site under `docs/` (Fumadocs) and the landing page are intentionally out of scope here — localizing those needs an i18n-architecture decision and can be follow-up PRs. Happy to open an issue to align on the approach if there's interest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated full Spanish documentation for getting started, contributing, security, and the main project overview.
  * Updated English docs with a language selector linking to the Spanish versions.
  * Expanded README content, including REST API usage examples, MCP server overview, development guidance, and contribution/release details.
  * Added a Spanish-language security policy document and linked it from the English security page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->