### PR TITLE
feat(i18n): Spanish docs site (Fumadocs i18n + overview guides)

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -1,0 +1,394 @@
+# Contribuir a Voicebox
+
+[English](CONTRIBUTING.md) · **Español**
+
+¡Gracias por tu interés en contribuir a Voicebox! Este documento ofrece pautas e instrucciones para contribuir.
+
+## Código de conducta
+
+- Sé respetuoso e inclusivo
+- Da la bienvenida a los recién llegados y ayúdales a aprender
+- Céntrate en el feedback constructivo
+- Respeta los distintos puntos de vista y experiencias
+
+## Primeros pasos
+
+### Requisitos previos
+
+- **[Bun](https://bun.sh)** - Runtime y gestor de paquetes de JavaScript rápido
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+
+- **[Python 3.11+](https://python.org)** - Para el desarrollo del backend
+  ```bash
+  python --version  # Debe ser 3.11 o superior
+  ```
+
+- **[Rust](https://rustup.rs)** - Para la app de escritorio Tauri (lo instala automáticamente la CLI de Tauri)
+  ```bash
+  rustc --version  # Comprueba si está instalado
+  ```
+- **[Requisitos previos de Tauri](https://v2.tauri.app/start/prerequisites)** - Dependencias del sistema específicas de Tauri (varían según el SO).
+
+- **Git** - Control de versiones
+
+### Configuración del entorno de desarrollo
+
+Instala [just](https://github.com/casey/just) (`brew install just`, `cargo install just` o `winget install Casey.Just`), y luego:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/voicebox.git
+cd voicebox
+
+just setup   # crea el venv, instala dependencias de Python + JS
+just dev     # arranca el backend + la app de escritorio
+```
+
+`just setup` se encarga de todo automáticamente, incluyendo:
+- Crear un entorno virtual de Python
+- Instalar las dependencias de Python (con PyTorch CUDA en Windows si se detecta una GPU NVIDIA)
+- Instalar las dependencias de MLX en Apple Silicon
+- Instalar las dependencias de JavaScript
+
+`just dev` arranca el backend y la app de escritorio juntos. Si ya hay un backend en marcha (p. ej. desde `just dev-backend` en otra terminal), lo detecta y solo arranca el frontend.
+
+Otros comandos útiles:
+
+```bash
+just dev-web       # backend + app web (sin compilación de Tauri/Rust)
+just dev-backend   # solo backend
+just dev-frontend  # solo app Tauri (el backend debe estar en marcha)
+just kill          # detiene todos los procesos de desarrollo
+just clean-all     # borra todo y empieza de cero
+just --list        # ve todos los comandos disponibles
+```
+
+> **Nota:** En modo desarrollo, la app se conecta a un servidor Python iniciado manualmente.
+> El binario del servidor incluido solo se usa en las compilaciones de producción.
+
+#### Notas para Windows
+
+El justfile funciona de forma nativa en Windows vía PowerShell. No hace falta WSL ni Git Bash. En Windows con una GPU NVIDIA, `just setup` instala automáticamente PyTorch con CUDA para la aceleración por GPU.
+
+### Descargas de modelos
+
+Los modelos se descargan automáticamente desde HuggingFace Hub en el primer uso:
+- **Whisper** (transcripción): se descarga solo en la primera transcripción
+- **Qwen3-TTS** (clonación de voz): se descarga solo en la primera generación (~2-4 GB)
+
+El primer uso será más lento por las descargas de modelos, pero las ejecuciones posteriores usarán los modelos en caché.
+
+### Compilación
+
+**Compilar la app de producción:**
+
+```bash
+just build        # Compila el binario del servidor CPU + el instalador de Tauri
+```
+
+En Windows, para compilar con compatibilidad CUDA para pruebas locales:
+
+```bash
+just build-local  # Compila los binarios del servidor CPU + CUDA + el instalador de Tauri
+```
+
+Esto compila el sidecar de CPU (incluido con la app), el binario CUDA (ubicado en `%APPDATA%/com.voicebox.app/backends/` para el cambio de GPU en tiempo de ejecución) y la app Tauri instalable.
+
+Crea instaladores específicos de cada plataforma (`.dmg`, `.msi`, `.AppImage`) en `tauri/src-tauri/target/release/bundle/`.
+
+**Objetivos de compilación individuales:**
+
+```bash
+just build-server       # solo el binario del servidor CPU
+just build-server-cuda  # solo el binario del servidor CUDA (Windows)
+just build-tauri        # solo la app de escritorio Tauri
+just build-web          # solo la app web
+```
+
+**Compilar con una versión de desarrollo local de Qwen3-TTS:**
+
+Si estás desarrollando o modificando activamente la biblioteca Qwen3-TTS, define la variable de entorno `QWEN_TTS_PATH` apuntando a tu clon local:
+
+```bash
+export QWEN_TTS_PATH=~/path/to/your/Qwen3-TTS
+just build-server
+```
+
+Esto hace que PyInstaller use tu versión local de qwen-tts en lugar del paquete instalado con pip.
+
+### Generar el cliente OpenAPI
+
+Tras arrancar el servidor backend:
+```bash
+./scripts/generate-api.sh
+```
+Esto descarga el esquema OpenAPI y genera el cliente TypeScript en `app/src/lib/api/`
+
+### Convertir recursos a formatos web
+
+Para optimizar imágenes y vídeos para la web, ejecuta:
+```bash
+bun run convert:assets
+```
+
+Este script:
+- Convierte PNG → WebP (mejor compresión, misma calidad)
+- Convierte MOV → WebM (códec VP9, menor tamaño de archivo)
+- Procesa los archivos en `landing/public/` y `docs/public/`
+- **Elimina los archivos originales** tras una conversión correcta
+
+**Requisitos:** Instala `webp` y `ffmpeg`:
+```bash
+brew install webp ffmpeg
+```
+
+> **Nota:** Ejecuta esto antes de hacer commit de imágenes o vídeos nuevos para mantener el tamaño del repositorio pequeño.
+
+## Flujo de trabajo de desarrollo
+
+### 1. Crea una rama
+
+```bash
+git checkout -b feature/your-feature-name
+# o
+git checkout -b fix/your-bug-fix
+```
+
+### 2. Haz tus cambios
+
+- Escribe código limpio y legible
+- Sigue el estilo de código existente
+- Añade comentarios para la lógica compleja
+- Actualiza la documentación según haga falta
+
+### 3. Prueba tus cambios
+
+- Pruébalos manualmente en la app
+- Asegúrate de que los endpoints de la API del backend funcionan
+- Comprueba que no hay errores de TypeScript/Python
+- Verifica que los componentes de la UI se renderizan correctamente
+
+### 4. Haz commit de tus cambios
+
+Escribe mensajes de commit claros y descriptivos:
+
+```bash
+git commit -m "Add feature: voice profile export"
+git commit -m "Fix: audio playback stops after 30 seconds"
+```
+
+### 5. Haz push y crea un Pull Request
+
+```bash
+git push origin feature/your-feature-name
+```
+
+Luego crea un pull request en GitHub con:
+- Una descripción clara de los cambios
+- Capturas de pantalla (para cambios de UI)
+- Referencia a los issues relacionados
+
+## Estilo de código
+
+### TypeScript/React
+
+- Usa el modo estricto de TypeScript
+- Sigue las buenas prácticas de React
+- Usa componentes funcionales con hooks
+- Prefiere las exportaciones nombradas
+- Formatea con Biome (se ejecuta automáticamente)
+
+```typescript
+// Bien
+export function ProfileCard({ profile }: { profile: Profile }) {
+  return <div>{profile.name}</div>;
+}
+
+// Evita
+export const ProfileCard = (props) => { ... }
+```
+
+### Python
+
+- Sigue la guía de estilo PEP 8
+- Usa anotaciones de tipo
+- Usa async/await para las operaciones de E/S
+- Formatea con Black (si está configurado)
+
+```python
+# Bien
+async def create_profile(name: str, language: str) -> Profile:
+    """Create a new voice profile."""
+    ...
+
+# Evita
+def create_profile(name, language):
+    ...
+```
+
+### Rust
+
+- Sigue las convenciones de Rust
+- Usa nombres de variable significativos
+- Maneja los errores de forma explícita
+- Formatea con `rustfmt`
+
+## Estructura del proyecto
+
+```
+voicebox/
+├── app/              # Frontend React compartido
+│   └── src/
+│       ├── components/   # Componentes de UI
+│       ├── lib/          # Utilidades y cliente de la API
+│       └── hooks/        # Hooks de React
+├── backend/          # Servidor Python FastAPI
+│   ├── main.py       # Rutas de la API
+│   ├── tts.py        # Síntesis de voz
+│   └── ...
+├── tauri/            # Envoltorio de la app de escritorio
+│   └── src-tauri/    # Backend en Rust
+└── scripts/          # Scripts de compilación
+```
+
+## Áreas para contribuir
+
+### 🐛 Corrección de errores
+
+- Revisa los issues existentes en busca de errores que corregir
+- Prueba tu corrección a fondo
+- Añade tests si es posible
+
+### ✨ Funciones nuevas
+
+- Revisa la hoja de ruta en README.md y el estado de ingeniería en [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) antes de proponer trabajo — enumera tareas priorizadas (Tier 1 → 3), cuellos de botella arquitectónicos conocidos y motores TTS candidatos ya en evaluación (incluido por qué algunos se han aplazado)
+- Discute las funciones grandes primero en un issue
+- Mantén las funciones enfocadas y bien acotadas
+
+### 📚 Documentación
+
+- Mejora la claridad del README
+- Añade comentarios al código
+- Escribe documentación de la API
+- Crea tutoriales o guías
+
+### 🎨 Mejoras de UI/UX
+
+- Mejora la accesibilidad
+- Mejora el diseño visual
+- Optimiza el rendimiento
+- Añade animaciones/transiciones
+
+### 🔧 Infraestructura
+
+- Mejora el proceso de compilación
+- Añade mejoras de CI/CD
+- Optimiza el tamaño del bundle
+- Añade infraestructura de tests
+
+## Desarrollo de la API
+
+Al añadir nuevos endpoints de la API:
+
+1. **Añade la ruta en `backend/main.py`**
+2. **Crea los modelos Pydantic en `backend/models.py`**
+3. **Implementa la lógica de negocio en el módulo apropiado**
+4. **Actualiza el esquema OpenAPI** (automático con FastAPI)
+5. **Regenera el cliente TypeScript:**
+   ```bash
+   bun run generate:api
+   ```
+6. **Actualiza `backend/README.md`** con la documentación del endpoint
+
+## Tests
+
+Actualmente, las pruebas son principalmente manuales. Al añadir tests:
+
+- **Backend**: usa pytest para los tests de Python
+- **Frontend**: usa Vitest para los tests de componentes de React
+- **E2E**: usa Playwright para los tests de extremo a extremo (futuro)
+
+## Proceso de Pull Request
+
+1. **Actualiza la documentación** si hace falta
+2. **Asegúrate de que el código sigue las pautas de estilo**
+3. **Prueba tus cambios a fondo**
+4. **Actualiza CHANGELOG.md** con tus cambios
+5. **Solicita revisión** a los mantenedores
+
+### Checklist del PR
+
+- [ ] El código sigue las pautas de estilo
+- [ ] Documentación actualizada
+- [ ] Cambios probados
+- [ ] Sin cambios disruptivos (o documentados)
+- [ ] CHANGELOG.md actualizado
+
+## Proceso de release
+
+Los releases los gestionan los mantenedores:
+
+1. **Sube la versión con bumpversion:**
+   ```bash
+   # Instala bumpversion (si aún no está instalado)
+   pip install bumpversion
+   
+   # Sube la versión de parche (0.1.0 -> 0.1.1)
+   bumpversion patch
+   
+   # O sube la versión menor (0.1.0 -> 0.2.0)
+   bumpversion minor
+   
+   # O sube la versión mayor (0.1.0 -> 1.0.0)
+   bumpversion major
+   ```
+   
+   Esto automáticamente:
+   - Actualiza los números de versión en todos los archivos (`tauri.conf.json`, `Cargo.toml`, todos los `package.json`, `backend/main.py`)
+   - Crea un commit de git con la subida de versión
+   - Crea una etiqueta de git (p. ej., `v0.1.1`, `v0.2.0`)
+
+2. **Actualiza CHANGELOG.md** con las notas del release
+
+3. **Haz push de los commits y las etiquetas:**
+   ```bash
+   git push
+   git push --tags
+   ```
+
+4. **GitHub Actions compila y publica** automáticamente cuando se suben las etiquetas
+
+## Solución de problemas
+
+Consulta [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/troubleshooting.mdx) para problemas comunes y sus soluciones.
+
+**Arreglos rápidos:**
+
+- **El backend no arranca:** Comprueba la versión de Python (3.11+), asegúrate de que el venv está activado, instala las dependencias
+- **La compilación de Tauri falla:** Asegúrate de que Rust está instalado, limpia la compilación con `cd tauri/src-tauri && cargo clean`
+- **La generación del cliente OpenAPI falla:** Asegúrate de que el backend está en marcha, comprueba `curl http://localhost:17493/openapi.json`
+
+## ¿Preguntas?
+
+- Abre un issue para errores o solicitudes de funciones
+- Revisa los issues y discusiones existentes
+- Revisa el código para entender los patrones
+- Consulta [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/troubleshooting.mdx) para problemas comunes
+
+## Recursos adicionales
+
+- [README.md](README.md) - Visión general del proyecto
+- [backend/README.md](backend/README.md) - Documentación de la API
+- [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md) - Hoja de ruta de ingeniería viva: arquitectura, trabajo publicado vs en curso, issues abiertos priorizados, motores TTS candidatos en evaluación, cuellos de botella arquitectónicos. Mantenlo actualizado cuando publiques funciones importantes, cierres o aplaces una integración de modelo, o identifiques nuevos cuellos de botella.
+- [docs/content/docs/developer/autoupdater.mdx](docs/content/docs/developer/autoupdater.mdx) - Configuración del actualizador automático
+- [SECURITY.md](SECURITY.md) - Política de seguridad
+- [CHANGELOG.md](CHANGELOG.md) - Historial de versiones
+
+## Licencia
+
+Al contribuir, aceptas que tus contribuciones se licencien bajo la Licencia MIT.
+
+---
+
+¡Gracias por contribuir a Voicebox! 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Voicebox
 
+**English** · [Español](CONTRIBUTING.es.md)
+
 Thank you for your interest in contributing to Voicebox! This document provides guidelines and instructions for contributing.
 
 ## Code of Conduct
@@ -379,7 +381,7 @@ See [docs/content/docs/overview/troubleshooting.mdx](docs/content/docs/overview/
 - [README.md](README.md) - Project overview
 - [backend/README.md](backend/README.md) - API documentation
 - [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md) - Living engineering roadmap: architecture, shipped vs in-flight work, prioritized open issues, candidate TTS engines under evaluation, architectural bottlenecks. Keep this updated when you ship significant features, close or backlog a model integration, or identify new bottlenecks.
-- [docs/AUTOUPDATER_QUICKSTART.md](docs/AUTOUPDATER_QUICKSTART.md) - Auto-updater setup
+- [docs/content/docs/developer/autoupdater.mdx](docs/content/docs/developer/autoupdater.mdx) - Auto-updater setup
 - [SECURITY.md](SECURITY.md) - Security policy
 - [CHANGELOG.md](CHANGELOG.md) - Version history
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,477 @@
+<p align="center">
+  <img src=".github/assets/icon-dark.webp" alt="Voicebox" width="120" height="120" />
+</p>
+
+<h1 align="center">Voicebox</h1>
+
+<p align="center">
+  <strong>El estudio de voz con IA de código abierto.</strong><br/>
+  Clona cualquier voz. Genera voz. Dicta en cualquier app. Habla con agentes en voces que son tuyas.<br/>
+  Toda la pila de E/S de voz, ejecutándose localmente en tu equipo.
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · <strong>Español</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/jamiepine/voicebox/releases">
+    <img src="https://img.shields.io/github/downloads/jamiepine/voicebox/total?style=flat&color=blue" alt="Descargas" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/releases/latest">
+    <img src="https://img.shields.io/github/v/release/jamiepine/voicebox?style=flat" alt="Versión" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/stargazers">
+    <img src="https://img.shields.io/github/stars/jamiepine/voicebox?style=flat" alt="Estrellas" />
+  </a>
+  <a href="https://github.com/jamiepine/voicebox/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/jamiepine/voicebox?style=flat" alt="Licencia" />
+  </a>
+  <a href="https://deepwiki.com/jamiepine/voicebox">
+    <img src="https://img.shields.io/static/v1?label=Ask&message=DeepWiki&color=5B6EF7" alt="Preguntar a DeepWiki" />
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://trendshift.io/repositories/21213" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21213" alt="jamiepine%2Fvoicebox | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
+<p align="center">
+  <a href="https://voicebox.sh">voicebox.sh</a> •
+  <a href="https://docs.voicebox.sh">Documentación</a> •
+  <a href="#descargar">Descargar</a> •
+  <a href="#funciones">Funciones</a> •
+  <a href="#api">API</a> •
+  <a href="docs/content/docs/overview/troubleshooting.mdx">Solución de problemas</a>
+</p>
+
+<br/>
+
+<p align="center">
+  <a href="https://voicebox.sh">
+    <img src="landing/public/assets/app-screenshot-1.webp" alt="Captura de la app Voicebox" width="800" />
+  </a>
+</p>
+
+<p align="center">
+  <em>Haz clic en la imagen de arriba para ver el vídeo de demostración en <a href="https://voicebox.sh">voicebox.sh</a></em>
+</p>
+
+<br/>
+
+<p align="center">
+  <img src="landing/public/assets/app-screenshot-2.webp" alt="Captura 2 de Voicebox" width="800" />
+</p>
+
+<p align="center">
+  <img src="landing/public/assets/app-screenshot-3.webp" alt="Captura 3 de Voicebox" width="800" />
+</p>
+
+<br/>
+
+## ¿Qué es Voicebox?
+
+Voicebox es un **estudio de voz con IA local-first**: una alternativa gratuita y de código abierto a **ElevenLabs** y **WisprFlow** en una sola app. Clona voces a partir de unos segundos de audio, genera voz en 23 idiomas con 7 motores TTS, dicta en cualquier campo de texto con un atajo global y dale a cualquier agente de IA compatible con MCP una voz de tu elección.
+
+Los dos referentes en la nube ocupan mitades opuestas del bucle de E/S de voz: ElevenLabs en la salida, WisprFlow en la entrada. Voicebox hace ambas, las conecta con un LLM local incluido para el refinamiento y las personalidades por perfil, y ejecuta todo en tu equipo.
+
+- **Privacidad total** — los modelos, los datos de voz y las capturas nunca salen de tu equipo
+- **7 motores TTS** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA y Kokoro
+- **Clonación de voz y voces predefinidas** — clonación zero-shot a partir de una muestra de referencia, o más de 50 voces predefinidas y curadas vía Kokoro y Qwen CustomVoice
+- **23 idiomas** — del inglés al árabe, japonés, hindi, suajili y más
+- **Efectos de posprocesado** — cambio de tono, reverberación, retardo, coro, compresión y filtros
+- **Voz expresiva** — etiquetas paralingüísticas como `[laugh]`, `[sigh]`, `[gasp]` vía Chatterbox Turbo; control de la interpretación en lenguaje natural vía Qwen CustomVoice
+- **Longitud ilimitada** — fragmentación automática con fundido cruzado para guiones, artículos y capítulos
+- **Editor de historias** — línea de tiempo multipista para conversaciones, pódcasts y narraciones
+- **Entrada de voz** — atajo global de dictado con modos pulsar para hablar y alternancia, pegado automático verificado por Accesibilidad en macOS, micrófono in-app en cada campo de texto, STT basado en Whisper
+- **Salida de voz para agentes** — una sola llamada de herramienta (`voicebox.speak`) y cualquier agente compatible con MCP (Claude Code, Cursor, Cline) te habla en una voz que has clonado
+- **Personalidades de voz** — asigna una personalidad libre a cualquier perfil de voz y luego usa Redactar, Reescribir o Responder mediante un LLM local incluido; los agentes pueden invocar los mismos modos por MCP
+- **API-first** — API REST más un servidor MCP integrado para incorporar E/S de voz a tus propias apps y agentes
+- **Rendimiento nativo** — construido con Tauri (Rust), no Electron
+- **Funciona en todas partes** — macOS (MLX/Metal), Windows (CUDA), Linux, AMD ROCm, Intel Arc, Docker
+
+---
+
+## Descargar
+
+| Plataforma            | Descarga                                               |
+| --------------------- | ------------------------------------------------------ |
+| macOS (Apple Silicon) | [Descargar DMG](https://voicebox.sh/download/mac-arm)   |
+| macOS (Intel)         | [Descargar DMG](https://voicebox.sh/download/mac-intel) |
+| Windows               | [Descargar MSI](https://voicebox.sh/download/windows)   |
+| Docker                | `docker compose up`                                    |
+
+> **[Ver todos los binarios →](https://github.com/jamiepine/voicebox/releases/latest)**
+
+> **Linux** — Aún no hay binarios precompilados. Consulta [voicebox.sh/linux-install](https://voicebox.sh/linux-install) para las instrucciones de compilación desde el código fuente.
+
+> **¿Problemas?** Consulta la [guía de solución de problemas](docs/content/docs/overview/troubleshooting.mdx) para incidencias comunes de instalación, generación, descarga de modelos y GPU.
+
+---
+
+## Funciones
+
+### Clonación de voz multimotor
+
+Siete motores TTS con puntos fuertes distintos, intercambiables en cada generación:
+
+| Motor                       | Idiomas   | Puntos fuertes                                                                                                                           |
+| --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Qwen3-TTS** (0.6B / 1.7B) | 10        | Clonación multilingüe de alta calidad, instrucciones de interpretación ("habla despacio", "susurra")                                     |
+| **Qwen CustomVoice**        | 10        | 9 voces predefinidas curadas con control de interpretación en lenguaje natural — sin audio de referencia                                 |
+| **LuxTTS**                  | Inglés    | Ligero (~1 GB de VRAM), salida a 48 kHz, 150x tiempo real en CPU                                                                          |
+| **Chatterbox Multilingual** | 23        | La cobertura de idiomas más amplia — árabe, danés, finés, griego, hebreo, hindi, malayo, noruego, polaco, suajili, sueco, turco y más    |
+| **Chatterbox Turbo**        | Inglés    | Modelo rápido de 350M con etiquetas paralingüísticas de emoción/sonido                                                                    |
+| **TADA** (1B / 3B)          | 10        | Modelo de lenguaje-habla de HumeAI — audio coherente de más de 700 s, alineación dual texto-acústica                                      |
+| **Kokoro**                  | 8         | 50 voces predefinidas curadas, modelo diminuto de 82M, inferencia rápida en CPU                                                          |
+
+### Emociones y etiquetas paralingüísticas
+
+Solo **Chatterbox Turbo** interpreta etiquetas paralingüísticas como `[laugh]` y
+`[sigh]`. Qwen3-TTS, LuxTTS, Chatterbox Multilingual y HumeAI TADA las leen
+literalmente como texto.
+
+Con **Chatterbox Turbo** seleccionado, escribe `/` en el campo de texto para abrir el
+insertador de etiquetas y añadir etiquetas expresivas en línea con el habla:
+
+`[laugh]` `[chuckle]` `[gasp]` `[cough]` `[sigh]` `[groan]` `[sniff]` `[shush]` `[clear throat]`
+
+### Efectos de posprocesado
+
+8 efectos de audio con la biblioteca `pedalboard` de Spotify. Se aplican tras la generación, con vista previa en tiempo real y preajustes reutilizables.
+
+| Efecto            | Descripción                                       |
+| ----------------- | ------------------------------------------------- |
+| Cambio de tono    | Hacia arriba o abajo hasta 12 semitonos           |
+| Reverberación     | Tamaño de sala, amortiguación y mezcla húmedo/seco configurables |
+| Retardo           | Eco con tiempo, realimentación y mezcla ajustables |
+| Coro / Flanger    | Retardo modulado para texturas metálicas o densas |
+| Compresor         | Compresión de rango dinámico                      |
+| Ganancia          | Ajuste de volumen (−40 a +40 dB)                  |
+| Filtro paso alto  | Elimina las frecuencias bajas                     |
+| Filtro paso bajo  | Elimina las frecuencias altas                     |
+
+Incluye 4 preajustes integrados (Robótica, Radio, Cámara de eco, Voz grave) y admite preajustes personalizados. Los efectos pueden asignarse por perfil como predeterminados.
+
+### Longitud de generación ilimitada
+
+El texto se divide automáticamente en los límites de las frases y cada fragmento se genera por separado, para luego unirse con fundido cruzado. Funciona con todos los motores.
+
+- Límite de fragmentación automática configurable (100–5000 caracteres)
+- Control deslizante de fundido cruzado (0–200 ms) para transiciones suaves
+- Longitud máxima de texto: 50 000 caracteres
+- La división inteligente respeta abreviaturas, puntuación CJK y `[etiquetas]`
+
+### Versiones de generación
+
+Cada generación admite varias versiones con seguimiento de procedencia:
+
+- **Original** — salida TTS limpia, siempre conservada
+- **Versiones con efectos** — aplica distintas cadenas de efectos desde cualquier versión de origen
+- **Tomas** — regenera con una nueva semilla para variar
+- **Seguimiento de origen** — cada versión registra su linaje
+- **Favoritos** — marca generaciones con estrella para acceso rápido
+
+### Cola de generación asíncrona
+
+La generación no bloquea. Envía y empieza a escribir la siguiente de inmediato.
+
+- La cola de ejecución en serie evita la contención de la GPU
+- Streaming de estado en tiempo real vía SSE
+- Las generaciones fallidas se pueden reintentar
+- Las generaciones obsoletas por cierres inesperados se recuperan solas al arrancar
+
+### Gestión de perfiles de voz
+
+- Crea perfiles a partir de archivos de audio o grábalos directamente en la app
+- Importa/exporta perfiles para compartirlos o respaldarlos
+- Compatible con varias muestras para una clonación de mayor calidad
+- Cadenas de efectos predeterminadas por perfil
+- Organiza con descripciones y etiquetas de idioma
+
+### Editor de historias
+
+Editor de línea de tiempo multivoz para conversaciones, pódcasts y narraciones.
+
+- Composición multipista con arrastrar y soltar
+- Recorte y división de audio en línea
+- Reproducción automática con cabezal sincronizado
+- Fijación de versión por clip de pista
+
+### Dictado global y entrada de voz
+
+La otra mitad del bucle de E/S de voz. Mantén pulsado un atajo en cualquier parte de tu sistema, habla, suelta — en macOS la transcripción se pega directamente en el campo de texto activo. O pulsa el micrófono en cualquier campo de texto de Voicebox y dicta directamente en la app.
+
+- **Combinaciones de teclas configurables** — combinaciones de mantener-para-hablar y pulsar-para-alternar, cada una reasignable en el selector de combinaciones in-app. Manteniendo pulsar para hablar y tocando `Espacio` a mitad de pulsación se asciende a una sesión de alternancia sin cortes en el audio
+- **Pegado consciente del destino (macOS)** — inyección verificada por Accesibilidad en el campo de texto activo, con guardado/restauración atómica del portapapeles para que no se sobrescriba
+- **UX de permisos en el primer uso** — las puertas in-app te guían por la concesión de Accesibilidad y Monitorización de entrada de macOS con enlaces directos a Ajustes del Sistema
+- **Botón de micrófono in-app** en cada campo de texto de Voicebox — formulario de generación, descripciones de perfil, títulos de historia, donde sea que escribas
+- **Refinamiento por LLM** — limpieza opcional de muletillas, tartamudeos y falsos comienzos antes de pegar
+- **Píldora en pantalla** — superposición flotante que muestra los estados `grabando`, `transcribiendo`, `refinando` y `hablando`. La misma píldora que usan los agentes cuando te hablan, así hay un único modelo mental para ambas direcciones del bucle
+
+### Voz a texto
+
+Voicebox ejecuta OpenAI Whisper para la transcripción — el mismo modelo que sustenta el dictado, la pestaña Capturas y la API `/transcribe`. Se ejecuta en MLX (Apple Silicon) o PyTorch (CUDA / ROCm / DirectML / CPU) según tu plataforma.
+
+| Tamaño                        | Notas                                              |
+| ----------------------------- | -------------------------------------------------- |
+| Base / Small / Medium / Large | Escalera de calidad estándar de Whisper            |
+| Turbo                         | ~8x más rápido que Whisper Large, con pérdida mínima de calidad |
+
+Se planean más motores (Parakeet v3, Qwen3-ASR) — consulta la [hoja de ruta](#hoja-de-ruta).
+
+### Capturas
+
+Cada dictado, grabación in-app y archivo de audio subido aparece en la pestaña Capturas — audio original emparejado con su transcripción, siempre conservado.
+
+- **Reproduce, vuelve a transcribir, refina** — reejecuta STT con cualquier tamaño de Whisper, o reprocesa la transcripción en bruto con el LLM local con distintos ajustes (limpieza de muletillas, eliminación de autocorrecciones, conservación de términos técnicos)
+- **Edita en línea** — ajusta la transcripción y se guarda al perder el foco
+- **Reproducir como perfil de voz** — convierte cualquier captura en voz con una voz clonada, en un clic
+- **Promover a muestra de voz** — usa el audio + transcripción de una captura como muestra de referencia en cualquier perfil de voz
+- **Almacenamiento local de capturas** — el audio original y la transcripción se quedan en tu directorio de datos de Voicebox, con un acceso directo a la carpeta en Ajustes
+
+### Salida de voz para agentes
+
+Cada agente tiene voz. Una sola llamada de herramienta y cualquier agente compatible con MCP puede hablarte en una voz que has clonado — finalizaciones de tareas, preguntas, notificaciones. La misma píldora que aparece durante el dictado aparece durante el habla del agente, así siempre ves lo que sale de tu equipo.
+
+```ts
+// En cualquier agente compatible con MCP:
+await voicebox.speak({
+  text: "Despliegue completado.",
+  profile: "Morgan",
+});
+```
+
+También expuesto como `POST /speak` para todo lo que no hable MCP — ACP, A2A, scripts de shell, arneses personalizados.
+
+- **Píldora bidireccional** — `grabando`, `transcribiendo`, `refinando` y `hablando` son estados de la misma superposición a nivel de SO, así que el dictado y el habla del agente comparten una sola superficie
+- **Vinculación de voz por agente** — en **Ajustes → MCP**, asigna Claude Code a Morgan y Cursor a Scarlett para saber qué agente habla sin mirar. La marca de tiempo `last_seen_at` de cada cliente confirma que la instalación funcionó
+- **Siempre visible** — sin TTS silencioso en segundo plano; cada habla iniciada por un agente muestra la píldora con el nombre del perfil de voz durante toda su duración
+- **Transportes HTTP + stdio** — instálalo como URL en el MCP de Claude Code / Cursor / Windsurf / VS Code, o apunta los clientes solo-stdio al binario `voicebox-mcp` incluido
+
+### Personalidades de voz
+
+Asigna una personalidad libre a cualquier perfil de voz — quién es esta voz, cómo habla, qué le importa. Aparecen dos acciones en el cuadro de generación cuando hay una personalidad definida, impulsadas por un LLM Qwen3 incluido que se ejecuta enteramente en local.
+
+- **Redactar** — un botón de barajar que deja una frase fresca en personaje en el área de texto; edita y habla, o haz clic de nuevo para otra versión
+- **Hablar en personaje** — un interruptor que pasa tu texto de entrada por el LLM de personalidad para reescribirlo en su voz antes del TTS
+
+Los agentes pueden acceder a la misma ruta de reescritura por MCP pasando `personality: true` a `voicebox.speak`, convirtiendo la herramienta en una tubería texto-de-entrada → LLM-de-personalidad → TTS. El mismo LLM sustenta el paso de refinamiento del dictado — un LLM en la app, una caché de modelo, una huella de memoria de GPU.
+
+**Opciones de LLM local:** Qwen3 0.6B / 1.7B / 4B, compartiendo el runtime de TTS (MLX en Apple Silicon, PyTorch en el resto).
+
+Casos de uso: bucles de desarrollo con agentes (dicta una pregunta, escucha la respuesta en una voz clonada), personajes interactivos para juegos y herramientas narrativas, asistencia del habla para personas que no pueden hablar con su voz original.
+
+### Gestión de modelos
+
+- Liberación por modelo para liberar memoria de GPU sin borrar las descargas
+- Directorio de modelos personalizado vía `VOICEBOX_MODELS_DIR`
+- Migración de la carpeta de modelos con seguimiento del progreso
+- Interfaz para cancelar/limpiar descargas
+
+### Compatibilidad con GPU
+
+| Plataforma               | Backend        | Notas                                          |
+| ------------------------ | -------------- | ---------------------------------------------- |
+| macOS (Apple Silicon)    | MLX (Metal)    | 4-5x más rápido vía Neural Engine              |
+| Windows / Linux (NVIDIA) | PyTorch (CUDA) | Descarga el binario CUDA automáticamente desde la app |
+| Linux (AMD)              | PyTorch (ROCm) | Configura HSA_OVERRIDE_GFX_VERSION automáticamente |
+| Windows (cualquier GPU)  | DirectML       | Compatibilidad universal con GPU en Windows    |
+| Intel Arc                | IPEX/XPU       | Aceleración con GPU discreta de Intel          |
+| Cualquiera               | CPU            | Funciona en todas partes, solo que más lento   |
+
+---
+
+## API
+
+Voicebox expone una API REST para integrar E/S de voz en tus propias apps y agentes.
+
+```bash
+# Generar voz
+curl -X POST http://127.0.0.1:17493/generate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello world", "profile_id": "abc123", "language": "en"}'
+
+# Salida de voz para agentes — cualquier app o script puede hablar en una voz clonada
+curl -X POST http://127.0.0.1:17493/speak \
+  -H "Content-Type: application/json" \
+  -H "X-Voicebox-Client-Id: my-script" \
+  -d '{"text": "Deploy complete.", "profile": "Morgan"}'
+
+# Transcribir un archivo de audio
+curl -X POST http://127.0.0.1:17493/transcribe \
+  -F "audio=@recording.wav" \
+  -F "model=whisper-turbo"
+
+# Listar perfiles de voz
+curl http://127.0.0.1:17493/profiles
+```
+
+`POST /speak` acepta `profile` como nombre (sin distinguir mayúsculas) o id, y lo resuelve con la misma precedencia que la herramienta MCP: argumento explícito → vinculación por cliente → `capture_settings.default_playback_voice_id`.
+
+### Servidor MCP
+
+Voicebox incluye un servidor **Model Context Protocol** integrado para que cualquier agente compatible con MCP (Claude Code, Cursor, Windsurf, Cline, extensiones MCP de VS Code) pueda hablar, transcribir y explorar capturas y perfiles.
+
+**Comando de una línea para Claude Code:**
+
+```
+claude mcp add voicebox \
+  --transport http \
+  --url http://127.0.0.1:17493/mcp \
+  --header "X-Voicebox-Client-Id: claude-code"
+```
+
+**Cualquier cliente MCP por HTTP** (Cursor, Windsurf, VS Code, etc.):
+
+```json
+{
+  "mcpServers": {
+    "voicebox": {
+      "url": "http://127.0.0.1:17493/mcp",
+      "headers": { "X-Voicebox-Client-Id": "cursor" }
+    }
+  }
+}
+```
+
+**Alternativa por stdio** para clientes que no hablan MCP por HTTP — apunta al binario `voicebox-mcp` incluido dentro de la app:
+
+```json
+{
+  "mcpServers": {
+    "voicebox": {
+      "command": "/Applications/Voicebox.app/Contents/MacOS/voicebox-mcp",
+      "env": { "VOICEBOX_CLIENT_ID": "claude-desktop" }
+    }
+  }
+}
+```
+
+Se incluyen cuatro herramientas: `voicebox.speak`, `voicebox.transcribe`, `voicebox.list_captures`, `voicebox.list_profiles`. Las vinculaciones de voz por cliente se gestionan en **Voicebox → Ajustes → MCP**. Consulta la [guía completa de MCP](docs/content/docs/overview/mcp-server.mdx) para las firmas de las herramientas, la precedencia de resolución, el contrato de la píldora de habla y las notas de seguridad.
+
+```ts
+// En cualquier agente compatible con MCP:
+await voicebox.speak({
+  text: "Tests passing. Ready to merge.",
+  profile: "Morgan",      // opcional — recurre a la vinculación por cliente
+  personality: true,      // opcional — reescribe el texto con el LLM de personalidad del perfil primero
+});
+```
+
+**Casos de uso:** bucles de desarrollo con agentes (voz de entrada, voz de salida), diálogos de videojuegos, producción de pódcasts, herramientas de accesibilidad, asistentes de voz, automatización de contenido.
+
+Documentación completa de la API disponible en `http://127.0.0.1:17493/docs`.
+
+---
+
+## Pila tecnológica
+
+| Capa          | Tecnología                                                                      |
+| ------------- | ------------------------------------------------------------------------------- |
+| App de escritorio | Tauri (Rust)                                                                |
+| Frontend      | React, TypeScript, Tailwind CSS                                                 |
+| Estado        | Zustand, React Query                                                            |
+| Backend       | FastAPI (Python)                                                                |
+| Motores TTS   | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
+| STT           | Whisper / Whisper Turbo (PyTorch o MLX)                                         |
+| LLM local     | Qwen3 (0.6B / 1.7B / 4B), runtime compartido con TTS / STT                      |
+| Servidor MCP  | FastMCP montado en `/mcp` (HTTP en streaming) + binario adaptador stdio incluido |
+| Adaptador nativo | Rust (dentro de Tauri) para el atajo global, la inyección de pegado y la introspección de foco |
+| Efectos       | Pedalboard (Spotify)                                                            |
+| Inferencia    | MLX (Apple Silicon) / PyTorch (CUDA/ROCm/XPU/CPU)                               |
+| Base de datos | SQLite                                                                          |
+| Audio         | WaveSurfer.js, librosa                                                          |
+
+---
+
+## Hoja de ruta
+
+| Función                            | Descripción                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| **Pegado automático en Windows / Linux** | Paridad del pegado del dictado — `SendInput` en Windows, `uinput` / AT-SPI en Linux |
+| **Ampliación de motores STT**      | Parakeet v3 y Qwen3-ASR sumándose a Whisper — más de 50 idiomas, mejor calidad fuera del inglés |
+| **Enrutamiento de tuberías**       | Cadenas configurables origen → transformación → destino con destinos webhook + MCP y un editor de preajustes |
+| **Transcripción en streaming**     | `/transcribe/stream` por WebSocket para transcripciones parciales mientras hablas |
+| **LLM de habla de extremo a extremo** | Moshi, GLM-4-Voice, Qwen2.5 Omni — voz a voz real, sin texto intermedio |
+| **Diseño de voz**                  | Crea voces nuevas a partir de descripciones de texto                     |
+| **Captura de formato largo**       | Grabador de doble flujo (micrófono + audio del sistema) con transformación por LLM de resumen |
+| **Destinos de plataforma**         | Apple Notes, Obsidian y otras integraciones opcionales                   |
+| **Arquitectura de plugins**        | Amplía con modelos, transformaciones y destinos personalizados           |
+| **App complementaria para móvil**  | Controla Voicebox desde tu teléfono                                      |
+
+Para el **estado de ingeniería completo, el triaje de issues abiertos y la cola de trabajo priorizada**, consulta [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) — un documento vivo que registra lo que se ha publicado, lo que está en curso, los motores TTS candidatos en evaluación y por qué hemos aceptado o aplazado integraciones concretas.
+
+---
+
+## Desarrollo
+
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) ([versión en español](CONTRIBUTING.es.md)) para la configuración detallada y las pautas de contribución.
+
+### Inicio rápido
+
+```bash
+git clone https://github.com/jamiepine/voicebox.git
+cd voicebox
+
+just setup   # crea el venv de Python e instala todas las dependencias
+just dev     # arranca el backend + la app de escritorio
+```
+
+Instala [just](https://github.com/casey/just): `brew install just` o `cargo install just`. Ejecuta `just --list` para ver todos los comandos.
+
+**Requisitos previos:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.11+](https://python.org), [requisitos previos de Tauri](https://v2.tauri.app/start/prerequisites/) y [Xcode](https://developer.apple.com/xcode/) en macOS.
+
+El repo incluye un `.mcp.json` preconfigurado en la raíz — ejecutar Claude Code dentro de este checkout recoge las herramientas MCP de Voicebox automáticamente una vez que la app de desarrollo está en marcha.
+
+### Compilar localmente
+
+```bash
+just build          # Compila el binario del servidor CPU + la app Tauri
+just build-local    # (Windows) Compila los binarios del servidor CPU + CUDA + la app Tauri
+```
+
+### Añadir nuevos modelos de voz
+
+La arquitectura multimotor hace que añadir nuevos motores TTS sea sencillo. Una [guía paso a paso](docs/content/docs/developer/tts-engines.mdx) cubre todo el proceso: investigación de dependencias, implementación del protocolo del backend, cableado del frontend y empaquetado con PyInstaller.
+
+La guía está optimizada para agentes de programación con IA. Una [skill de agente](.agents/skills/add-tts-engine/SKILL.md) puede tomar el nombre de un modelo y encargarse de toda la integración de forma autónoma — tú solo pruebas la compilación localmente.
+
+### Estructura del proyecto
+
+```
+voicebox/
+├── app/              # Frontend React compartido
+├── tauri/            # App de escritorio (Tauri + Rust)
+├── web/              # Despliegue web
+├── backend/          # Servidor Python FastAPI
+├── landing/          # Sitio web de marketing
+└── scripts/          # Scripts de compilación y release
+```
+
+---
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Consulta [CONTRIBUTING.md](CONTRIBUTING.md) ([versión en español](CONTRIBUTING.es.md)) para las pautas.
+
+1. Haz un fork del repo
+2. Crea una rama de función
+3. Haz tus cambios
+4. Envía un PR
+
+## Seguridad
+
+¿Has encontrado una vulnerabilidad de seguridad? Repórtala de forma responsable. Consulta [SECURITY.md](SECURITY.md) ([versión en español](SECURITY.es.md)) para más detalles.
+
+---
+
+## Licencia
+
+Licencia MIT — consulta [LICENSE](LICENSE) para más detalles.
+
+---
+
+<p align="center">
+  <a href="https://voicebox.sh">voicebox.sh</a>
+</p>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 </p>
 
 <p align="center">
+  <strong>English</strong> · <a href="README.es.md">Español</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/jamiepine/voicebox/releases">
     <img src="https://img.shields.io/github/downloads/jamiepine/voicebox/total?style=flat&color=blue" alt="Downloads" />
   </a>

--- a/SECURITY.es.md
+++ b/SECURITY.es.md
@@ -1,0 +1,94 @@
+# Política de seguridad
+
+[English](SECURITY.md) · **Español**
+
+## Versiones compatibles
+
+Publicamos parches para vulnerabilidades de seguridad. Qué versiones son elegibles para recibir dichos parches depende de la clasificación CVSS v3.0:
+
+| Versión | Compatible         |
+| ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
+
+## Reportar una vulnerabilidad
+
+Si descubres una vulnerabilidad de seguridad, repórtala de forma responsable:
+
+1. **No** abras un issue público en GitHub
+2. Envía los detalles de seguridad por correo a: [security@voicebox.sh](mailto:security@voicebox.sh)
+3. Incluye:
+   - Descripción de la vulnerabilidad
+   - Pasos para reproducirla
+   - Impacto potencial
+   - Solución sugerida (si la hay)
+
+Nosotros:
+- Confirmaremos la recepción en un plazo de 48 horas
+- Daremos un calendario para abordar el problema
+- Te mantendremos informado del progreso
+- Te daremos crédito en el aviso de seguridad (si lo deseas)
+
+## Buenas prácticas de seguridad
+
+### Para usuarios
+
+- **Mantén Voicebox actualizado** - Las actualizaciones incluyen parches de seguridad
+- **Verifica las descargas** - Descarga solo de los releases oficiales
+- **Procesamiento local** - Los datos de voz se quedan en tu equipo
+- **Seguridad de red** - Usa HTTPS al conectarte a servidores remotos
+
+### Para desarrolladores
+
+- **Dependencias** - Mantén todas las dependencias al día
+- **Revisión de código** - Todos los PR requieren revisión antes de fusionarse
+- **Secretos** - Nunca hagas commit de claves de API ni de firma
+- **Firma** - Todos los releases están firmados criptográficamente
+
+## Consideraciones de seguridad conocidas
+
+### Procesamiento local
+
+Voicebox procesa todo el audio localmente de forma predeterminada. Tus datos de voz nunca salen de tu equipo a menos que actives explícitamente el modo de servidor remoto.
+
+### Modo de servidor remoto
+
+Al conectarte a un servidor remoto:
+- Asegúrate de que el servidor está en una red de confianza
+- Usa HTTPS para las conexiones remotas
+- Verifica la identidad del servidor antes de conectarte
+
+### Actualizaciones automáticas
+
+- Las actualizaciones están firmadas criptográficamente
+- La verificación de la firma ocurre antes de la instalación
+- Solo se permiten endpoints HTTPS
+
+### Servidor Python
+
+El servidor Python integrado:
+- Se ejecuta localmente de forma predeterminada (solo localhost)
+- Se puede configurar para acceso remoto
+- Usa las prácticas de seguridad estándar de FastAPI
+
+## Calendario de divulgación
+
+- **Día 0**: Vulnerabilidad reportada
+- **Día 1-2**: Evaluación inicial y confirmación
+- **Día 3-7**: Investigación y desarrollo de la corrección
+- **Día 8-14**: Pruebas y preparación del release
+- **Día 15+**: Divulgación pública (si procede)
+
+El calendario puede variar según la gravedad y la complejidad.
+
+## Actualizaciones de seguridad
+
+Las actualizaciones de seguridad se:
+- Publicarán como versiones de parche (p. ej., 0.3.2)
+- Documentarán en CHANGELOG.md
+- Anunciarán vía releases de GitHub
+- Entregarán automáticamente vía el actualizador automático
+
+---
+
+¡Gracias por ayudar a mantener Voicebox seguro! 🔒

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+**English** · [Español](SECURITY.es.md)
+
 ## Supported Versions
 
 We release patches for security vulnerabilities. Which versions are eligible for receiving such patches depends on the CVSS v3.0 Rating:

--- a/docs/app/[lang]/[[...slug]]/layout.tsx
+++ b/docs/app/[lang]/[[...slug]]/layout.tsx
@@ -2,9 +2,10 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { baseOptions } from '@/lib/layout.shared';
 import { source } from '@/lib/source';
 
-export default function Layout({ children }: LayoutProps<'/[[...slug]]'>) {
+export default async function Layout({ params, children }: LayoutProps<'/[lang]/[[...slug]]'>) {
+  const { lang } = await params;
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions()}>
+    <DocsLayout tree={source.pageTree[lang]} {...baseOptions()}>
       {children}
     </DocsLayout>
   );

--- a/docs/app/[lang]/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/[[...slug]]/page.tsx
@@ -7,9 +7,9 @@ import { APIPage } from '@/components/api-page';
 import { getPageImage, source } from '@/lib/source';
 import { getMDXComponents } from '@/mdx-components';
 
-export default async function Page(props: PageProps<'/[[...slug]]'>) {
+export default async function Page(props: PageProps<'/[lang]/[[...slug]]'>) {
   const params = await props.params;
-  const page = source.getPage(params.slug);
+  const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 
   const MDX = page.data.body;
@@ -59,9 +59,9 @@ export async function generateStaticParams() {
   return source.generateParams();
 }
 
-export async function generateMetadata(props: PageProps<'/[[...slug]]'>): Promise<Metadata> {
+export async function generateMetadata(props: PageProps<'/[lang]/[[...slug]]'>): Promise<Metadata> {
   const params = await props.params;
-  const page = source.getPage(params.slug);
+  const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 
   return {

--- a/docs/app/[lang]/layout.tsx
+++ b/docs/app/[lang]/layout.tsx
@@ -1,0 +1,39 @@
+import { defineI18nUI } from 'fumadocs-ui/i18n';
+import { RootProvider } from 'fumadocs-ui/provider/next';
+import { Inter } from 'next/font/google';
+import '../global.css';
+import { i18n } from '@/lib/i18n';
+
+const inter = Inter({
+  subsets: ['latin'],
+});
+
+const { provider } = defineI18nUI(i18n, {
+  translations: {
+    en: { displayName: 'English' },
+    es: {
+      displayName: 'Español',
+      search: 'Buscar',
+      searchNoResult: 'Sin resultados',
+      toc: 'En esta página',
+      lastUpdate: 'Última actualización',
+      chooseLanguage: 'Elegir idioma',
+      nextPage: 'Siguiente',
+      previousPage: 'Anterior',
+      chooseTheme: 'Tema',
+      editOnGithub: 'Editar en GitHub',
+    },
+  },
+});
+
+export default async function Layout({ params, children }: LayoutProps<'/[lang]'>) {
+  const { lang } = await params;
+
+  return (
+    <html lang={lang} className={inter.className} suppressHydrationWarning>
+      <body className="flex flex-col min-h-screen">
+        <RootProvider i18n={provider(lang)}>{children}</RootProvider>
+      </body>
+    </html>
+  );
+}

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,7 +1,10 @@
-import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
 
+// https://docs.orama.com/docs/orama-js/supported-languages
 export const { GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: 'english',
+  localeMap: {
+    en: { language: 'english' },
+    es: { language: 'spanish' },
+  },
 });

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,17 +1,6 @@
-import { RootProvider } from 'fumadocs-ui/provider/next';
-import './global.css';
-import { Inter } from 'next/font/google';
+import type { ReactNode } from 'react';
 
-const inter = Inter({
-  subsets: ['latin'],
-});
-
-export default function Layout({ children }: LayoutProps<'/'>) {
-  return (
-    <html lang="en" className={inter.className} suppressHydrationWarning>
-      <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
-      </body>
-    </html>
-  );
+// Root layout is a pass-through; the real <html>/<body> live in app/[lang]/layout.tsx.
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return children;
 }

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -1,9 +1,10 @@
+import { i18n } from '@/lib/i18n';
 import { getLLMText, source } from '@/lib/source';
 
 export const revalidate = false;
 
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source.getPages(i18n.defaultLanguage).map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join('\n\n'));

--- a/docs/content/docs/index.es.mdx
+++ b/docs/content/docs/index.es.mdx
@@ -39,8 +39,8 @@ que es tuya. Todo se ejecuta en tu hardware.
 
 ## Empezar
 
-- [Instalación](/overview/installation) — descarga e instala Voicebox
-- [Inicio rápido](/overview/quick-start) — ponte en marcha en 5 minutos
-- [Dictado](/overview/dictation) — empieza a hablarle a tu ordenador
-- [Personalidades de voz](/overview/voice-personalities) — redacta y reescribe en cualquier perfil
+- [Instalación](./overview/installation.mdx) — descarga e instala Voicebox
+- [Inicio rápido](./overview/quick-start.mdx) — ponte en marcha en 5 minutos
+- [Dictado](./overview/dictation.mdx) — empieza a hablarle a tu ordenador
+- [Personalidades de voz](./overview/voice-personalities.mdx) — redacta y reescribe en cualquier perfil
 - [Referencia de la API](/api-reference) — integra la síntesis de voz en tus apps

--- a/docs/content/docs/index.es.mdx
+++ b/docs/content/docs/index.es.mdx
@@ -1,0 +1,46 @@
+---
+title: "Documentación de Voicebox"
+description: "Voicebox es el estudio de voz con IA de código abierto y local-first — una alternativa gratuita a ElevenLabs y WisprFlow que se ejecuta enteramente en tu equipo."
+---
+
+Voicebox es el **estudio de voz con IA de código abierto y local-first** — una
+alternativa gratuita a ElevenLabs y WisprFlow en una sola app. Clona voces, genera
+voz con 7 motores TTS, dicta en cualquier app con un atajo global,
+compón proyectos multivoz y deja que cualquier agente compatible con MCP hable en una voz
+que es tuya. Todo se ejecuta en tu hardware.
+
+![Captura de la app Voicebox](/images/app-screenshot-1.webp)
+
+- **Dictado** — mantén pulsada una combinación en cualquier parte de tu equipo, habla, suelta; la transcripción se pega en el campo activo
+- **Pestaña Capturas** — archivo emparejado de audio + transcripción, vuelve a transcribir / refina / reproduce como voz
+- **Personalidades de voz** — botón de redactar por perfil + interruptor de reescritura en personaje, impulsados por un LLM local
+- **Los agentes responden hablando** — cualquier agente compatible con MCP puede llamar a Voicebox para hablar con una de tus voces clonadas
+- **7 motores TTS** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, Kokoro
+- **Clonación y voces predefinidas** — clonación zero-shot o más de 50 voces predefinidas curadas
+- **23 idiomas** — del inglés al árabe, japonés, hindi y suajili
+- **Efectos de posprocesado** — cambio de tono, reverberación, retardo, coro, compresión, filtros
+- **Voz expresiva** — etiquetas paralingüísticas (`[laugh]`, `[sigh]`) y control de la interpretación en lenguaje natural
+- **Longitud ilimitada** — fragmentación automática con fundido cruzado para guiones largos
+- **Editor de historias** — línea de tiempo multipista para conversaciones, pódcasts y narraciones
+- **API-first** — API REST + WebSocket, servidor MCP para integraciones con agentes
+- **Privacidad total** — los modelos, el audio, las transcripciones y la salida del LLM nunca salen de tu equipo
+- **Funciona en todas partes** — macOS (MLX/Metal), Windows (CUDA / DirectML), Linux (ROCm / CPU), Intel Arc, Docker
+
+## Descargar
+
+| Plataforma | Descarga |
+|----------|----------|
+| macOS (Apple Silicon) | [Descargar DMG](https://voicebox.sh/download/mac-arm) |
+| macOS (Intel) | [Descargar DMG](https://voicebox.sh/download/mac-intel) |
+| Windows | [Descargar MSI](https://voicebox.sh/download/windows) |
+| Docker | `docker compose up` |
+
+[Ver todos los releases](https://github.com/jamiepine/voicebox/releases/latest)
+
+## Empezar
+
+- [Instalación](/overview/installation) — descarga e instala Voicebox
+- [Inicio rápido](/overview/quick-start) — ponte en marcha en 5 minutos
+- [Dictado](/overview/dictation) — empieza a hablarle a tu ordenador
+- [Personalidades de voz](/overview/voice-personalities) — redacta y reescribe en cualquier perfil
+- [Referencia de la API](/api-reference) — integra la síntesis de voz en tus apps

--- a/docs/content/docs/meta.es.json
+++ b/docs/content/docs/meta.es.json
@@ -1,0 +1,4 @@
+{
+  "title": "Documentación de Voicebox",
+  "pages": ["overview", "api-reference", "developer"]
+}

--- a/docs/content/docs/overview/building-stories.es.mdx
+++ b/docs/content/docs/overview/building-stories.es.mdx
@@ -1,0 +1,37 @@
+---
+title: "Crear historias"
+description: "Crea narrativas con varias voces usando el Editor de historias"
+---
+
+## Primeros pasos
+
+El Editor de historias es perfecto para crear pódcasts, audiolibros y contenido con varios narradores.
+
+<Steps>
+  <Step title="Crear historia">
+    **Stories** → **+ New Story**
+  </Step>
+  <Step title="Añadir pistas">
+    Crea una pista para cada narrador
+  </Step>
+  <Step title="Añadir clips">
+    Genera o arrastra audio a las pistas
+  </Step>
+  <Step title="Organizar">
+    Coloca y recorta los clips en la línea de tiempo
+  </Step>
+  <Step title="Exportar">
+    Renderiza el audio final
+  </Step>
+</Steps>
+
+## Casos de uso
+
+- Pódcasts con varios presentadores
+- Narración de audiolibros con voces de personajes
+- Escenas de diálogo de videojuegos
+- Contenido educativo con varios narradores
+
+## Próximamente
+
+Se añadirá la documentación completa del editor de la línea de tiempo a medida que se finalicen las funciones.

--- a/docs/content/docs/overview/captures.es.mdx
+++ b/docs/content/docs/overview/captures.es.mdx
@@ -1,0 +1,189 @@
+---
+title: "Capturas"
+description: "El archivo emparejado de audio + transcripción — cada dictado, grabación y archivo de audio subido aparece aquí, reproducible y retranscribible."
+---
+
+## Resumen
+
+Una **captura** es un clip de audio emparejado con su transcripción. La pestaña Capturas
+es donde aterrizan todos los dictados, grabaciones manuales y archivos de audio subidos,
+con el audio original guardado junto al texto para que puedas reproducir, volver a ejecutar
+la transcripción con un modelo distinto, refinar la transcripción o enviar el
+contenido a otro sitio — incluso volver a generarlo como voz en cualquiera de
+tus perfiles de voz.
+
+<Callout type="info">
+  La pestaña Capturas llegó en la **0.5.0**, junto con el dictado global y los
+  modos de personalidad por perfil. Si has usado versiones anteriores, ten en cuenta que
+  la pestaña Audio se trasladó a **Ajustes → Canales de Audio** para hacer sitio a
+  esta.
+</Callout>
+
+## De dónde vienen las capturas
+
+| Origen | Cómo aparece | Insignia |
+|---|---|---|
+| **Dictado** | Activado por el atajo global (ver [Dictado](/overview/dictation)). Refinado automáticamente por defecto. | `dictation` |
+| **Grabación en la app** | Grabada directamente en la pestaña Capturas usando el micrófono integrado. | `recording` |
+| **Subida de archivo** | Cualquier archivo de audio arrastrado a la pestaña Capturas — `.wav`, `.mp3`, `.m4a`, `.webm`, `.opus`, `.flac`. | `file` |
+
+Las tres vías comparten la misma tubería de backend, el mismo selector de modelo y
+los mismos indicadores de refinamiento. La insignia de origen está ahí para que puedas
+recorrer visualmente una lista larga.
+
+## Vista de lista
+
+La vista principal de Capturas es una lista cronológica. Cada fila muestra:
+
+- La transcripción (en bruto o refinada — la versión refinada gana si existe)
+- Duración + marca de tiempo
+- Insignia de origen
+- Un botón de reproducción para el audio original
+- Un menú de tres puntos con acciones por fila
+
+El filtrado y la búsqueda son una petición de Nivel 2 — avísanos si los necesitas.
+
+## Vista de detalle
+
+Al hacer clic en una captura se abre la vista de detalle:
+
+- **Reproductor con forma de onda** para el audio original
+- **Editor de transcripción** — haz clic dentro y edita. Los cambios se guardan al perder el foco.
+- **Alternancia entre refinada y en bruto** si se ejecutó el refinamiento en esta captura
+- **Barra de acciones por captura** — retranscribir, refinar, reproducir como voz, eliminar
+- **Instantánea de ajustes** — modelo STT usado, indicadores de refinamiento en el momento
+  en que se procesó esta captura, y el modelo de voz si se reprodujo alguno
+
+## Retranscribir
+
+Pasa el audio original de la captura por un modelo de Whisper distinto sin
+volver a subir ni refinar nada. Útil cuando:
+
+- El modelo por defecto malinterpretó algo y quieres probar un modelo más grande
+- Usaste Base para un clip con ruido y quieres reejecutarlo con Turbo
+- Un clip que no está en inglés necesita una pista de idioma explícita
+
+**Ajustes → Capturas → Transcripción** controla el modelo por defecto y
+el bloqueo de idioma para las capturas nuevas. Retranscribir usa esos valores por defecto a menos que los
+sobrescribas por captura.
+
+## Refinar
+
+Pasa la transcripción en bruto por el LLM local para producir una versión
+limpia. Los indicadores de la captura se capturan en una instantánea cuando el refinamiento se
+ejecuta por primera vez, de modo que puedes volver a refinar más tarde con indicadores distintos sin perder la transcripción
+en bruto:
+
+| Indicador | Efecto |
+|---|---|
+| **Limpieza inteligente** | Elimina muletillas (`um`, `uh`, `like`), ordena la puntuación y las mayúsculas. |
+| **Eliminar autocorrecciones** | Conserva la versión final cuando el hablante se desdice ("en realidad, no, el martes"). |
+| **Preservar términos técnicos** | Deja los identificadores (`handleSubmit`, `npm install`) intactos. |
+
+Consulta la sección de Refinamiento de [Dictado](/overview/dictation#refinement) para saber
+cómo Voicebox elimina las alucinaciones de bucle de Whisper *antes* de que el LLM vea la
+transcripción — una captura se puede volver a refinar cualquier número de veces sin
+reintroducir ecos de "thanks for watching thanks for watching".
+
+El selector del modelo de refinamiento (tres tamaños de Qwen3 incluidos) vive en
+**Ajustes → Capturas → Refinamiento**.
+
+## Reproducir como voz
+
+Esta es la capacidad que nadie más en la categoría de dictado ofrece: toma cualquier
+captura y reprodúcela como voz en cualquiera de tus perfiles de voz. Un
+desplegable sobre cada perfil, un clic, y el texto de la captura pasa por
+`/generate` con la voz seleccionada.
+
+Casos de uso:
+
+- Escuchar tu propio dictado en una voz clonada de alguien que te gusta
+- Enviar un mensaje que dictaste como respuesta de audio en un personaje concreto
+- Prototipar rápidamente una frase para una historia sin reescribir
+
+La reproducción usa el motor al que esté vinculado el perfil seleccionado — las mismas
+reglas que la pestaña Generar. No hay LLM en esta vía; la transcripción pasa
+sin cambios. Si quieres el flujo estilo agente de "transforma el contenido antes
+de hablar", eso es lo que hacen los
+[modos de personalidad](/overview/voice-personalities) — y la misma
+primitiva se expone a los agentes compatibles con MCP a través del
+[Servidor MCP](/overview/mcp-server) para que Claude Code, Cursor o Cline puedan hablar
+con una de tus voces por su cuenta.
+
+<Callout type="info">
+  La voz por defecto para la acción Reproducir como de la pestaña Capturas se configura en
+  **Ajustes → Capturas → Reproducción → Voz por defecto**. Aún puedes sobrescribirla
+  por captura.
+</Callout>
+
+## Menú Enviar a
+
+Cada captura tiene un menú Enviar a para mover su contenido a otras partes de
+Voicebox:
+
+- **Copiar transcripción** — al portapapeles
+- **Usar como muestra de voz…** — promueve esta captura a una muestra en un perfil de voz
+  de tu elección. Abre un selector de perfiles (con "+ Nueva voz" para
+  empezar desde cero) y un diálogo de confirmación de texto de referencia, porque clonar necesita
+  que el `reference_text` coincida con el audio palabra por palabra. Edítalo según sea necesario y
+  guarda — la captura permanece intacta en la pestaña Capturas; la muestra es una
+  copia, no un movimiento.
+
+## Almacenamiento
+
+El audio original se guarda junto a la transcripción en tu directorio de datos
+de Voicebox. **Ajustes → Capturas → Almacenamiento** muestra la carpeta de capturas y puede
+abrirla directamente en tu gestor de archivos.
+
+El archivo de audio y la fila de metadatos de cada captura se pueden reprocesar (retranscribir,
+refinar, Reproducir como) mientras el archivo de audio siga existiendo.
+
+## Protección de grabaciones cortas
+
+Los clips de audio de menos de **300 ms** se cortocircuitan en el lado del cliente y nunca
+se suben. Esto evita que un toque torpe del acorde acabe en una captura vacía.
+El umbral está ajustado para filtrar accidentes sin recortar dictados cortos
+intencionados.
+
+## Atajos de teclado
+
+Dentro de la pestaña Capturas:
+
+| Teclas | Acción |
+|---|---|
+| `Space` | Reproducir / pausar la captura seleccionada |
+| `↑` / `↓` | Captura anterior / siguiente en la lista |
+| `Enter` | Abrir la captura seleccionada en la vista de detalle |
+| `⌘ / Ctrl` + `C` (en la vista de detalle) | Copiar la transcripción |
+
+## Superficie de API
+
+La pestaña Capturas está respaldada por un pequeño conjunto de endpoints REST:
+
+| Método | Endpoint | Uso |
+|---|---|---|
+| `POST` | `/captures` | Sube audio + inicia la tubería (STT, refinamiento opcional, archivado). |
+| `GET` | `/captures` | Lista las capturas. |
+| `GET` | `/captures/{id}` | Obtiene una captura. |
+| `POST` | `/captures/{id}/retranscribe` | Reejecuta STT con un modelo elegido. |
+| `POST` | `/captures/{id}/refine` | Reejecuta el refinamiento con los indicadores elegidos. |
+| `POST` | `/profiles/{id}/samples/from-capture/{capture_id}` | Promueve una captura a una muestra de perfil de voz. |
+
+Estos endpoints son estables y utilizables desde tus propios scripts — consulta
+[Modo Remoto](/overview/remote-mode) para ejecutar Voicebox como un servidor con el que pueda hablar el resto
+de tu máquina.
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Dictado" href="/overview/dictation">
+    El flujo del atajo global que alimenta la mayoría de las capturas.
+  </Card>
+  <Card title="Personalidades de Voz" href="/overview/voice-personalities">
+    Botón de redactar por perfil y alternancia de reescritura de persona para las capturas que
+    quieras transformar, no solo transcribir.
+  </Card>
+  <Card title="Crear Perfiles de Voz" href="/overview/creating-voice-profiles">
+    Promueve una captura a una muestra de voz en un perfil.
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/captures.es.mdx
+++ b/docs/content/docs/overview/captures.es.mdx
@@ -23,7 +23,7 @@ tus perfiles de voz.
 
 | Origen | Cómo aparece | Insignia |
 |---|---|---|
-| **Dictado** | Activado por el atajo global (ver [Dictado](/overview/dictation)). Refinado automáticamente por defecto. | `dictation` |
+| **Dictado** | Activado por el atajo global (ver [Dictado](./dictation.mdx)). Refinado automáticamente por defecto. | `dictation` |
 | **Grabación en la app** | Grabada directamente en la pestaña Capturas usando el micrófono integrado. | `recording` |
 | **Subida de archivo** | Cualquier archivo de audio arrastrado a la pestaña Capturas — `.wav`, `.mp3`, `.m4a`, `.webm`, `.opus`, `.flac`. | `file` |
 
@@ -80,7 +80,7 @@ en bruto:
 | **Eliminar autocorrecciones** | Conserva la versión final cuando el hablante se desdice ("en realidad, no, el martes"). |
 | **Preservar términos técnicos** | Deja los identificadores (`handleSubmit`, `npm install`) intactos. |
 
-Consulta la sección de Refinamiento de [Dictado](/overview/dictation#refinement) para saber
+Consulta la sección de Refinamiento de [Dictado](./dictation.mdx#refinement) para saber
 cómo Voicebox elimina las alucinaciones de bucle de Whisper *antes* de que el LLM vea la
 transcripción — una captura se puede volver a refinar cualquier número de veces sin
 reintroducir ecos de "thanks for watching thanks for watching".
@@ -105,9 +105,9 @@ La reproducción usa el motor al que esté vinculado el perfil seleccionado — 
 reglas que la pestaña Generar. No hay LLM en esta vía; la transcripción pasa
 sin cambios. Si quieres el flujo estilo agente de "transforma el contenido antes
 de hablar", eso es lo que hacen los
-[modos de personalidad](/overview/voice-personalities) — y la misma
+[modos de personalidad](./voice-personalities.mdx) — y la misma
 primitiva se expone a los agentes compatibles con MCP a través del
-[Servidor MCP](/overview/mcp-server) para que Claude Code, Cursor o Cline puedan hablar
+[Servidor MCP](./mcp-server.mdx) para que Claude Code, Cursor o Cline puedan hablar
 con una de tus voces por su cuenta.
 
 <Callout type="info">
@@ -170,7 +170,7 @@ La pestaña Capturas está respaldada por un pequeño conjunto de endpoints REST
 | `POST` | `/profiles/{id}/samples/from-capture/{capture_id}` | Promueve una captura a una muestra de perfil de voz. |
 
 Estos endpoints son estables y utilizables desde tus propios scripts — consulta
-[Modo Remoto](/overview/remote-mode) para ejecutar Voicebox como un servidor con el que pueda hablar el resto
+[Modo Remoto](./remote-mode.mdx) para ejecutar Voicebox como un servidor con el que pueda hablar el resto
 de tu máquina.
 
 ## Próximos pasos

--- a/docs/content/docs/overview/creating-voice-profiles.es.mdx
+++ b/docs/content/docs/overview/creating-voice-profiles.es.mdx
@@ -24,7 +24,7 @@ Ambos tipos viven en la misma pestaña Perfiles y se comportan igual a la hora d
 
 <Steps>
   <Step title="Prepara el audio">
-    De 10 a 30 segundos de habla clara, con un mínimo de ruido de fondo. Consulta [Clonación de voz](/overview/voice-cloning) para ver el catálogo de motores.
+    De 10 a 30 segundos de habla clara, con un mínimo de ruido de fondo. Consulta [Clonación de voz](./voice-cloning.mdx) para ver el catálogo de motores.
   </Step>
   <Step title="Crea el perfil">
     **Perfiles** → **+ Nuevo perfil** → elige un motor de clonación (Qwen3-TTS, Chatterbox Multilingual, Chatterbox Turbo, LuxTTS o TADA)
@@ -198,7 +198,7 @@ Tras crear un perfil clonado:
 
 ## Flujo B — Perfiles de preajuste
 
-Úsalo cuando quieras una voz prefabricada sin grabar nada. Motores disponibles: **Kokoro 82M** (50 voces) y **Qwen CustomVoice** (9 voces). Consulta [Voces de preajuste](/overview/preset-voices) para ver el catálogo completo.
+Úsalo cuando quieras una voz prefabricada sin grabar nada. Motores disponibles: **Kokoro 82M** (50 voces) y **Qwen CustomVoice** (9 voces). Consulta [Voces de preajuste](./preset-voices.mdx) para ver el catálogo completo.
 
 <Steps>
   <Step title="Crea el perfil">
@@ -223,7 +223,7 @@ Tras crear un perfil clonado:
 
 Las voces de preajuste de Qwen CustomVoice admiten **instrucciones de interpretación**: control del estilo en lenguaje natural sobre el tono, el ritmo y la emoción. El cuadro de generación flotante muestra un icono de control deslizante junto al botón de generar cuando hay un perfil de Qwen CustomVoice seleccionado; haz clic en él para mostrar el área de texto de instrucciones.
 
-Consulta [Voces de preajuste → Usar el modo Instruct](/overview/preset-voices#using-instruct-mode) para ver ejemplos.
+Consulta [Voces de preajuste → Usar el modo Instruct](./preset-voices.mdx#using-instruct-mode) para ver ejemplos.
 
 ## Consejos avanzados
 

--- a/docs/content/docs/overview/creating-voice-profiles.es.mdx
+++ b/docs/content/docs/overview/creating-voice-profiles.es.mdx
@@ -1,0 +1,288 @@
+---
+title: "Crear perfiles de voz"
+description: "Cómo crear perfiles de voz, tanto basados en clonación como en preajustes"
+---
+
+## Visión general
+
+Un **perfil de voz** es una voz guardada que puedes reutilizar en generaciones, historias y la API. Desde la versión 0.4, los perfiles de Voicebox vienen en dos variantes que se corresponden con dos formas distintas de obtener una voz:
+
+| Tipo de perfil | Qué almacena                                          | Úsalo cuando…                                            |
+| -------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| **Clonado**    | Una o más muestras de audio de referencia + un embedding de voz | Quieres replicar la voz de una persona concreta          |
+| **Preajuste**  | Una referencia a una voz prefabricada en un motor concreto | Quieres una voz curada y lista para producción sin preparar audio |
+
+Ambos tipos viven en la misma pestaña Perfiles y se comportan igual a la hora de generar: elige el tipo que se ajuste a tu objetivo y sigue el flujo de trabajo de abajo.
+
+<Callout type="info">
+  ¿No sabes cuál usar? La clonación te da una voz *específica* pero necesita audio limpio. El preajuste te da *buenas* voces al instante, pero no eliges a quién se parecen.
+</Callout>
+
+## Flujo A — Perfiles clonados
+
+Úsalo cuando quieras replicar la voz de una persona concreta a partir de una grabación.
+
+<Steps>
+  <Step title="Prepara el audio">
+    De 10 a 30 segundos de habla clara, con un mínimo de ruido de fondo. Consulta [Clonación de voz](/overview/voice-cloning) para ver el catálogo de motores.
+  </Step>
+  <Step title="Crea el perfil">
+    **Perfiles** → **+ Nuevo perfil** → elige un motor de clonación (Qwen3-TTS, Chatterbox Multilingual, Chatterbox Turbo, LuxTTS o TADA)
+  </Step>
+  <Step title="Sube o graba una muestra">
+    Arrastra un archivo de audio o graba directamente con el grabador integrado en la app
+  </Step>
+  <Step title="Genera para probar">
+    Usa el perfil para generar una frase de prueba. Si la calidad es pobre, añade más muestras
+  </Step>
+</Steps>
+
+### Requisitos de audio (solo clonación)
+
+<Cards>
+  <Card title="Duración">
+    **10-30 segundos**
+
+    Demasiado corto: calidad pobre
+    Demasiado largo: innecesario
+  </Card>
+  <Card title="Claridad">
+    **Habla clara**
+
+    Sin ruido de fondo
+    Sin música ni voces superpuestas
+  </Card>
+  <Card title="Calidad">
+    **Alta fidelidad**
+
+    Frecuencia de muestreo de 44,1 kHz o 48 kHz
+    Compresión mínima
+  </Card>
+  <Card title="Contenido">
+    **Habla natural**
+
+    Tono conversacional
+    Frases completas
+  </Card>
+</Cards>
+
+### Formatos de archivo
+
+Formatos admitidos:
+- **WAV** (recomendado) — Calidad sin pérdidas
+- **MP3** — Aceptable, compresión mínima
+- **M4A** — Aceptable
+- **FLAC** — Alternativa sin pérdidas
+
+<Callout type="info">
+  Usa WAV para obtener los mejores resultados. Evita los formatos muy comprimidos.
+</Callout>
+
+### Consejos de grabación
+
+<AccordionGroup>
+  <Accordion title="Espacio silencioso">
+    - Graba en una habitación silenciosa
+    - Apaga ventiladores, aire acondicionado y electrodomésticos
+    - Cierra las ventanas para reducir el ruido exterior
+    - Usa elementos blandos para reducir el eco
+  </Accordion>
+
+  <Accordion title="Colocación del micrófono">
+    - A 15-30 cm de la boca
+    - Con un ligero ángulo para reducir las plosivas (p, b, t)
+    - Usa un filtro antipop si tienes uno
+    - Mantén una distancia constante
+  </Accordion>
+
+  <Accordion title="Ajustes de grabación">
+    - Frecuencia de muestreo de 44,1 kHz o 48 kHz
+    - Profundidad de 16 o 24 bits
+    - Mono está bien (el estéreo se convertirá)
+    - Evita el control automático de ganancia
+  </Accordion>
+</AccordionGroup>
+
+### Estilo de habla
+
+- **Ritmo natural** — No te apresures ni hables demasiado despacio
+- **Articulación clara** — Pronuncia las palabras con claridad
+- **Volumen constante** — Mantén una intensidad estable
+- **Tono normal** — Habla como lo harías normalmente
+- **Frases completas** — Evita fragmentos o muletillas como "eh"
+
+### Varias muestras
+
+Añadir varias muestras puede mejorar la calidad de forma significativa:
+
+<Cards>
+  <Card title="Robustez">
+    El modelo aprende una representación más completa
+  </Card>
+  <Card title="Versatilidad">
+    Maneja mejor distintos estilos de habla
+  </Card>
+  <Card title="Calidad">
+    Reduce los artefactos y mejora la naturalidad
+  </Card>
+  <Card title="Consistencia">
+    Más fiable con distintos textos
+  </Card>
+</Cards>
+
+Considera añadir muestras con:
+
+1. **Distintos tonos** — informal, formal, entusiasta, tranquilo
+2. **Distintos contenidos** — narraciones, preguntas, afirmaciones
+3. **Distintas condiciones de grabación** — calidad de estudio, acústica de la sala
+
+<Callout type="warn">
+  Todas las muestras deben ser del **mismo hablante**. Mezclar voces producirá resultados pobres.
+</Callout>
+
+### Procesar audio existente
+
+Si ya tienes audio (pódcast, vídeos, etc.):
+
+<Steps>
+  <Step title="Encuentra habla limpia">
+    Busca segmentos en los que solo esté el hablante objetivo, sin música de fondo y con un mínimo de ruido
+  </Step>
+  <Step title="Usa un editor de audio">
+    Herramientas como Audacity o Adobe Audition: corta segmentos limpios de 10-30 s, elimina el silencio al principio y al final, normaliza el volumen
+  </Step>
+  <Step title="Exporta como WAV">
+    Guárdalo como un archivo WAV de alta calidad
+  </Step>
+</Steps>
+
+Para ruido de fondo leve, usa la reducción de ruido de Audacity (con ajustes suaves: procesar en exceso introduce artefactos).
+
+### Pruebas e iteración
+
+Tras crear un perfil clonado:
+
+<Steps>
+  <Step title="Genera una prueba">
+    Prueba con una frase sencilla: `"Hola, esto es una prueba de mi perfil de voz."`
+  </Step>
+  <Step title="Evalúa la calidad">
+    Escucha si el tono es natural, la pronunciación es clara, la prosodia es adecuada y no hay artefactos
+  </Step>
+  <Step title="Itera">
+    Si la calidad es pobre: añade más muestras, prueba con otro audio de origen, revisa la calidad de las muestras
+  </Step>
+</Steps>
+
+#### Problemas comunes
+
+<AccordionGroup>
+  <Accordion title="Voz robótica">
+    **Causa**: muestras de baja calidad o demasiado cortas
+
+    **Solución**: usa muestras más largas y de mayor calidad
+  </Accordion>
+
+  <Accordion title="Tono incorrecto">
+    **Causa**: el tono de la muestra no coincide con el resultado deseado
+
+    **Solución**: graba muestras en el estilo que quieras generar
+  </Accordion>
+
+  <Accordion title="Artefactos/fallos">
+    **Causa**: ruido de fondo o problemas de audio en las muestras
+
+    **Solución**: limpia las muestras o vuelve a grabar en un entorno más silencioso
+  </Accordion>
+</AccordionGroup>
+
+## Flujo B — Perfiles de preajuste
+
+Úsalo cuando quieras una voz prefabricada sin grabar nada. Motores disponibles: **Kokoro 82M** (50 voces) y **Qwen CustomVoice** (9 voces). Consulta [Voces de preajuste](/overview/preset-voices) para ver el catálogo completo.
+
+<Steps>
+  <Step title="Crea el perfil">
+    **Perfiles** → **+ Nuevo perfil** → elige **Kokoro** o **Qwen CustomVoice** como motor
+  </Step>
+  <Step title="Elige una voz">
+    Aparece el catálogo de voces del motor. Haz clic en cualquier voz para escucharla
+  </Step>
+  <Step title="Ponle nombre y guárdalo">
+    Dale un nombre al perfil. No se requiere ninguna muestra de audio
+  </Step>
+  <Step title="Genera">
+    El perfil está listo de inmediato: úsalo en el cuadro de generación flotante o en la página Generar
+  </Step>
+</Steps>
+
+<Callout type="info">
+  Los perfiles de preajuste están **vinculados a su motor de origen**. Si cambias a un motor distinto en el cuadro de generación flotante, el perfil se atenúa, ya que la voz solo existe en ese motor. Al hacer clic en un perfil atenuado se vuelve a cambiar automáticamente el motor.
+</Callout>
+
+### Qwen CustomVoice + Instruct
+
+Las voces de preajuste de Qwen CustomVoice admiten **instrucciones de interpretación**: control del estilo en lenguaje natural sobre el tono, el ritmo y la emoción. El cuadro de generación flotante muestra un icono de control deslizante junto al botón de generar cuando hay un perfil de Qwen CustomVoice seleccionado; haz clic en él para mostrar el área de texto de instrucciones.
+
+Consulta [Voces de preajuste → Usar el modo Instruct](/overview/preset-voices#using-instruct-mode) para ver ejemplos.
+
+## Consejos avanzados
+
+### Voces de famosos o personajes (clonación)
+
+Para clonar figuras públicas o personajes:
+
+1. **Consideraciones legales** — Asegúrate de tener los derechos o de que sea claramente uso legítimo
+2. **Calidad de la fuente** — Encuentra audio de entrevistas de alta calidad o clips limpios
+3. **Consistencia** — Usa clips en los que hablen de forma similar
+4. **Varias muestras** — Muy importante para voces reconocibles
+
+### Acento y dialecto (clonación)
+
+Los modelos de clonación conservan el acento y el dialecto:
+
+- Las muestras de inglés británico generan un resultado en inglés británico
+- Las muestras con acento sureño producen un resultado con acento sureño
+- Se mantienen las pronunciaciones regionales
+
+### Transferencia de emoción (clonación)
+
+El tono emocional de las muestras afecta a la generación:
+
+- Muestras enérgicas → resultado enérgico
+- Muestras tranquilas → resultado tranquilo
+- Mezcla muestras para un perfil más versátil
+
+Para los preajustes de Qwen CustomVoice, usa el campo **instruct** en lugar de depender de la emoción de la muestra: es exactamente lo que controla.
+
+## Gestionar perfiles
+
+### Organización
+
+- **Nombres descriptivos** — "Juan Pérez - Narrador profesional"
+- **Añade descripciones** — Anota las condiciones de grabación, los casos de uso o qué voz de preajuste
+- **Etiquetas de idioma** — Marca el idioma principal
+- **Archiva los que no uses** — Mantén manejable la lista de perfiles
+
+### Exportar / Importar
+
+- **Exporta** perfiles para compartirlos o hacer copia de seguridad
+- **Importa** de compañeros o colegas de equipo
+- **Los perfiles clonados** se exportan con sus embeddings de voz (no con el audio original)
+- **Los perfiles de preajuste** se exportan solo como metadatos de motor + ID de voz: quien los importe debe tener instalado el modelo de ese motor
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Clonación de voz" href="/overview/voice-cloning">
+    Catálogo de motores y buenas prácticas para clonar
+  </Card>
+  <Card title="Voces de preajuste" href="/overview/preset-voices">
+    Catálogo completo de voces de Kokoro y Qwen CustomVoice
+  </Card>
+  <Card title="Generar voz" href="/overview/generating-speech">
+    Usa tu perfil para generar voz
+  </Card>
+  <Card title="Crear historias" href="/overview/building-stories">
+    Crea narraciones con varias voces
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/dictation.es.mdx
+++ b/docs/content/docs/overview/dictation.es.mdx
@@ -1,0 +1,218 @@
+---
+title: "Dictado"
+description: "Mantén pulsada una tecla en cualquier parte de tu equipo, habla, suéltala — la transcripción aparece en el campo de texto que tuvieras enfocado."
+---
+
+## Resumen
+
+El dictado te permite convertir voz en texto limpio en cualquier parte de tu
+ordenador. Mantén pulsado un atajo, habla, suelta — Voicebox transcribe lo que
+dijiste con Whisper, opcionalmente lo limpia con un LLM local, y pega el
+resultado en el campo de texto que tuvieras enfocado al empezar.
+
+Todo ocurre en tu hardware. Sin nube, sin cuentas, sin que el audio salga de
+la máquina.
+
+<Callout type="info">
+  El dictado se introdujo en **0.5.0** junto con la pestaña Capturas y los
+  modos de personalidad por perfil. Es la mitad de "entrada" del bucle de E/S
+  de voz de Voicebox — la clonación y el TTS siguen siendo la mitad de "salida".
+</Callout>
+
+## El flujo
+
+<Steps>
+  <Step title="Mantén pulsado el atajo">
+    Mantén pulsado el atajo de pulsar para hablar en cualquier parte de tu
+    equipo. Una pequeña píldora aparece con un fundido sobre tu app actual.
+  </Step>
+  <Step title="Habla">
+    La píldora muestra `Recording` con una forma de onda en vivo y un contador
+    de tiempo transcurrido. Habla con naturalidad — no tienes que esperar a
+    nada.
+  </Step>
+  <Step title="Suelta">
+    Al soltar, la píldora cambia a `Transcribing`, luego a `Refining` si el
+    refinamiento automático está activado, y después desaparece.
+  </Step>
+  <Step title="El texto aparece en tu app">
+    Si el pegado automático está habilitado y Voicebox tiene permiso de
+    Accesibilidad, la transcripción se pega en el campo de texto que tuvieras
+    enfocado al empezar a hablar — no donde se haya desplazado el foco
+    mientras hablabas.
+  </Step>
+</Steps>
+
+En cualquier caso, cada captura aparece también en la **pestaña Capturas** con
+el audio original y la transcripción emparejados. Consulta
+[Capturas](/overview/captures) para ver qué puedes hacer con ellas después.
+
+## Modos de pulsar para hablar y de alternancia
+
+Voicebox incluye dos comportamientos de atajo de fábrica:
+
+| Modo | Por defecto (macOS) | Por defecto (Windows) | Comportamiento |
+|---|---|---|---|
+| **Pulsar para hablar** | `⌘` derecha + `⌥` derecha | `Ctrl` derecha + `Shift` derecha | La grabación se detiene cuando sueltas el atajo. |
+| **Alternancia para hablar** | Pulsar para hablar + `Space` | Pulsar para hablar + `Space` | La grabación continúa hasta que vuelves a pulsar el atajo. |
+
+**Mantener pulsado PTT y tocar `Space` a mitad de la pulsación convierte una
+pulsación mantenida en una sesión de alternancia** sin un hueco en el audio.
+Este es el detalle más útil del sistema de atajos — las ráfagas cortas se
+sienten rápidas, la narración larga se siente manos libres, y no hay que
+decidir de antemano qué modo querías.
+
+## La píldora en pantalla
+
+Mientras dictas, aparece una píldora flotante sobre la app actual. Recorre los
+estados del ciclo de captura y muestra señales en vivo para cada uno:
+
+| Estado | Qué muestra |
+|---|---|
+| `Recording` | Forma de onda en vivo + tiempo transcurrido. |
+| `Transcribing` | Forma de onda "pensando" mientras se ejecuta Whisper. |
+| `Refining` | La misma forma de onda "pensando" mientras el LLM limpia la transcripción (solo si el refinamiento automático está activado). |
+| Error | Tinte rojo. Haz clic en la píldora para copiar el error al portapapeles. Se descarta automáticamente. |
+
+La píldora es transparente, siempre encima, y se precrea oculta al iniciar la
+app — así aparece al instante cuando pulsas el atajo, sin parpadeo de ventana.
+
+## Personalizar el atajo
+
+Abre **Ajustes → Capturas → Dictado** para cambiar cualquiera de los dos atajos.
+
+- **Distintivos de modificador izquierdo vs derecho.** Cuando mantienes teclas
+  pulsadas en el selector de atajos, Voicebox registra si cada modificador es
+  la variante izquierda o derecha. Eso significa que puedes asignar solo el
+  `⌥` derecho dejando libre el `⌥` izquierdo — útil si quieres el dictado en
+  una mano y mantener intactos tus atajos de la otra mano.
+- **Los atajos por defecto se eligen para no estorbarte.** En macOS, los
+  valores por defecto evitan deliberadamente los atajos `Cmd+Option` de la
+  mano izquierda para que `Cmd+Option+I` (herramientas de desarrollo),
+  `Cmd+Option+Esc` (forzar salida) y `Cmd+Option+Space` (Spotlight) sigan
+  siendo tuyos. En Windows, los valores por defecto rodean las colisiones de
+  AltGr en las distribuciones alemana / francesa / española donde `Ctrl+Alt`
+  sintetiza AltGr.
+- **Recarga en vivo.** Cambiar un atajo en Ajustes surte efecto de inmediato —
+  sin reinicio, sin recargar la pestaña.
+
+## Pegado automático en la app enfocada
+
+Una vez que termina la transcripción, Voicebox puede sintetizar un pegado
+nativo en el campo de texto que tuviera el foco cuando iniciaste el atajo. Tu
+portapapeles se guarda antes y se restaura después, así que no se pierde nada
+de lo que hubieras copiado.
+
+| Plataforma | Mecanismo |
+|---|---|
+| macOS | `CGEventPost` en el tap HID con una secuencia completa de teclas `⌘V`, precedida por la reactivación de la app original mediante `NSRunningApplication`. |
+| Windows | `SendInput` con los scan codes correctos, más un handshake `SetForegroundWindow` + `AttachThreadInput` para vencer el bloqueo de primer plano al pegar en una ventana que no estaba en primer plano al iniciar el atajo. |
+
+**El foco se captura en una instantánea al iniciar el atajo.** El pegado
+apunta al campo original incluso si el foco se desplaza durante la
+transcripción / refinamiento — ese es el comportamiento de "pega desde donde
+estabas hablando, no donde estás mirando *ahora*".
+
+<Callout type="info">
+  El pegado automático es opcional. Si el permiso de Accesibilidad no está
+  concedido (macOS), o prefieres mantener desactivada la entrada sintética, el
+  dictado sigue funcionando — las transcripciones aparecen en la pestaña
+  Capturas y puedes copiarlas manualmente. El ajuste vive en línea junto al
+  aviso de Accesibilidad en Ajustes → Capturas → Dictado, no como un banner
+  global.
+</Callout>
+
+## Refinamiento
+
+Si el refinamiento automático está activado, un LLM local limpia la
+transcripción cruda de Whisper antes de pegarla. El objetivo es eliminar el
+ruido verbal sin reescribir lo que realmente dijiste.
+
+Lo que el refinamiento suele corregir:
+
+- Muletillas (`um`, `uh`, `like` usado como pausa, `you know`)
+- Autocorrecciones — el LLM conserva la versión final y descarta los intentos
+  anteriores (`could you uh run the migration real quick, and then, yeah,
+  check the logs` → `Could you run the migration, then check the logs?`)
+- Puntuación y mayúsculas básicas
+- Alucinaciones de bucle de Whisper — Voicebox elimina los tokens repetidos
+  (seis o más tokens idénticos seguidos, sin distinguir mayúsculas) *antes* de
+  que el LLM vea la transcripción, de modo que un modelo de refinamiento
+  pequeño no pueda devolverlos como eco
+
+Lo que el refinamiento conserva deliberadamente:
+
+- Términos técnicos e identificadores de código (`npm install`, `handleSubmit`)
+- Repetición legítima (`no, no, no, no, no` tiene menos de seis tokens
+  idénticos, así que sobrevive)
+- Tu intención — el refinamiento es limpieza, no reescritura
+
+Los flags se capturan en una instantánea por captura, de modo que puedes
+volver a refinar la misma transcripción cruda más tarde con flags distintos
+sin perder el original. El selector de modelo de refinamiento (**Ajustes →
+Capturas → Refinamiento**) ofrece tres tamaños de Qwen3 incluidos:
+
+| Modelo | Tamaño | Mejor para |
+|---|---|---|
+| Qwen3 0.6B | ~400 MB | Por defecto. Muy rápido, bueno para dictado casual. |
+| Qwen3 1.7B | ~1.1 GB | El punto óptimo cuando las transcripciones contienen identificadores de código. |
+| Qwen3 4B | ~2.5 GB | Calidad completa, el más lento. |
+
+Este es el mismo LLM local que usan los modos de personalidad por perfil — un
+solo LLM en la app, no dos. Consulta [Personalidades de voz](/overview/voice-personalities).
+
+## Notas por plataforma
+
+### macOS
+
+- **El permiso de Accesibilidad** es necesario para el pegado automático. El
+  aviso vive en línea junto a la alternancia en **Ajustes → Capturas →
+  Dictado**, con un enlace directo a **Ajustes del Sistema → Privacidad y
+  Seguridad → Accesibilidad**.
+- **Mitigación del crash de TSM.** El escucha de atajos globales se ejecuta en
+  un hilo en segundo plano con `set_is_main_thread(false)` para esquivar un
+  crash conocido en macOS 14+ de la librería `rdev`. Si te topas con un fallo
+  de dictado inesperado en macOS, revisa los logs en busca de mensajes
+  relacionados con TSM.
+
+### Windows
+
+- **Salvedad de UAC / UIPI.** El pegado sintético en una ventana *elevada*
+  desde un Voicebox no elevado lo bloquea el propio Windows. Ejecuta Voicebox
+  elevado si dictas habitualmente en apps elevadas (p. ej. un terminal elevado
+  o el Administrador de tareas).
+- **El atajo por defecto de la mano derecha** (`Ctrl+Shift`) evita las
+  colisiones de AltGr en las distribuciones de teclado donde `Ctrl+Alt` es la
+  tecla de composición (alemán, francés, español, algunas otras).
+
+### Linux
+
+- **Todavía no en esta versión.** El shim de Rust incluye las rutas de macOS y
+  Windows en 0.5.0. El soporte de `uinput` / AT-SPI en Linux y el asunto del
+  pegado en Wayland se siguen en `docs/plans/VOICE_IO.md`.
+
+## Cuándo el pegado automático se omite a sí mismo
+
+Algunos casos en los que Voicebox deliberadamente *no* sintetiza un pegado:
+
+- **El foco estaba dentro de Voicebox** cuando empezó el atajo. La
+  transcripción va a la pestaña Capturas para que un ciclo de dictado dentro
+  de Voicebox no pegue accidentalmente en la caja de generación.
+- **No se detectó ningún foco de texto.** La transcripción aparece igualmente
+  en la pestaña Capturas; cópiala desde ahí con un clic.
+- **El permiso de Accesibilidad no está concedido** en macOS. Lo mismo — solo
+  la pestaña Capturas.
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Capturas" href="/overview/captures">
+    El archivo emparejado de audio + transcripción en el que aterriza cada dictado.
+  </Card>
+  <Card title="Personalidades de voz" href="/overview/voice-personalities">
+    El mismo LLM local impulsa la redacción por perfil y la reescritura de persona.
+  </Card>
+  <Card title="Transcripción" href="/developer/transcription">
+    Detalles a nivel de desarrollador sobre Whisper, Whisper Turbo y el backend de STT.
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/dictation.es.mdx
+++ b/docs/content/docs/overview/dictation.es.mdx
@@ -45,7 +45,7 @@ la máquina.
 
 En cualquier caso, cada captura aparece también en la **pestaña Capturas** con
 el audio original y la transcripción emparejados. Consulta
-[Capturas](/overview/captures) para ver qué puedes hacer con ellas después.
+[Capturas](./captures.mdx) para ver qué puedes hacer con ellas después.
 
 ## Modos de pulsar para hablar y de alternancia
 
@@ -159,7 +159,7 @@ Capturas → Refinamiento**) ofrece tres tamaños de Qwen3 incluidos:
 | Qwen3 4B | ~2.5 GB | Calidad completa, el más lento. |
 
 Este es el mismo LLM local que usan los modos de personalidad por perfil — un
-solo LLM en la app, no dos. Consulta [Personalidades de voz](/overview/voice-personalities).
+solo LLM en la app, no dos. Consulta [Personalidades de voz](./voice-personalities.mdx).
 
 ## Notas por plataforma
 

--- a/docs/content/docs/overview/docker.es.mdx
+++ b/docs/content/docs/overview/docker.es.mdx
@@ -1,0 +1,240 @@
+---
+title: "Despliegue con Docker"
+description: "Ejecuta Voicebox como un servidor headless con una interfaz web usando Docker"
+---
+
+## Visión general
+
+Voicebox puede ejecutarse como un contenedor Docker con una interfaz web completa, sin necesidad de la aplicación de escritorio. Esto es ideal para servidores headless, máquinas con GPU compartida o despliegues autoalojados.
+
+## Inicio rápido
+
+```bash
+git clone https://github.com/jamiepine/voicebox.git
+cd voicebox
+docker compose up
+```
+
+Abre [http://localhost:17493](http://localhost:17493) en tu navegador. La interfaz completa de Voicebox se sirve directamente desde el backend.
+
+<Callout type="info">
+  La primera compilación tarda unos minutos (compilar el frontend, instalar las dependencias de Python). Los arranques posteriores son rápidos gracias al almacenamiento en caché de capas de Docker.
+</Callout>
+
+## Cómo funciona
+
+La imagen de Docker usa una compilación de 3 etapas:
+
+1. **Frontend** -- compila la SPA de React con Bun y Vite
+2. **Backend** -- instala las dependencias de Python y los paquetes de modelos de TTS
+3. **Runtime** -- combina ambos en una imagen mínima que ejecuta el servidor de FastAPI
+
+El backend sirve la interfaz web automáticamente cuando el frontend compilado está presente. Todas las rutas de la API funcionan exactamente igual que en la aplicación de escritorio.
+
+## Configuración
+
+### docker-compose.yml
+
+El `docker-compose.yml` por defecto se enlaza solo a localhost, monta volúmenes persistentes para los datos y la caché de modelos, y establece límites de recursos razonables:
+
+```yaml
+services:
+  voicebox:
+    build: .
+    container_name: voicebox
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:17493:17493"
+    volumes:
+      - ./output:/app/data/generations
+      - voicebox-data:/app/data
+      - huggingface-cache:/home/voicebox/.cache/huggingface
+    environment:
+      - LOG_LEVEL=info
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 8G
+```
+
+### Exponerlo a tu red
+
+Por defecto, el contenedor solo escucha en `127.0.0.1`. Para permitir que otras máquinas de tu red se conecten, cambia el enlace del puerto:
+
+```yaml
+ports:
+  - "0.0.0.0:17493:17493"
+```
+
+<Callout type="warn">
+  La API no tiene autenticación integrada. Expónla solo a redes de confianza, o pon delante un proxy inverso con autenticación.
+</Callout>
+
+### Variables de entorno
+
+| Variable | Por defecto | Descripción |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `info` | Nivel de detalle del registro (`debug`, `info`, `warning`, `error`) |
+| `VOICEBOX_MODELS_DIR` | (caché de HuggingFace) | Ruta personalizada para el almacenamiento de modelos |
+| `VOICEBOX_CORS_ORIGINS` | (orígenes locales) | Orígenes CORS adicionales, separados por comas |
+
+### Límites de recursos
+
+El archivo compose por defecto limita el contenedor a 4 CPUs y 8GB de RAM. Ajústalos según tu hardware:
+
+```yaml
+deploy:
+  resources:
+    limits:
+      cpus: '8'
+      memory: 16G
+```
+
+<Callout type="info">
+  La inferencia de modelos de TTS consume mucha memoria. 8GB es el mínimo para ejecutar un solo motor. Se recomiendan 16GB o más si quieres tener varios motores cargados simultáneamente.
+</Callout>
+
+## Volúmenes
+
+| Volumen | Ruta en el contenedor | Propósito |
+|--------|---------------|---------|
+| `./output` | `/app/data/generations` | Archivos de audio generados (bind-mount, acceso fácil desde el host) |
+| `voicebox-data` | `/app/data` | Perfiles, base de datos, caché |
+| `huggingface-cache` | `/home/voicebox/.cache/huggingface` | Modelos descargados (persisten entre recompilaciones) |
+
+El volumen `huggingface-cache` es importante: sin él, los modelos se volverían a descargar cada vez que se recompila el contenedor.
+
+## Aceleración por GPU
+
+### GPU NVIDIA (CUDA)
+
+Para usar tu GPU NVIDIA dentro del contenedor, instala el [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) y añade acceso a la GPU a tu archivo compose:
+
+```yaml
+services:
+  voicebox:
+    build: .
+    # ... existing config ...
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+```
+
+### GPU AMD (ROCm)
+
+Para GPUs AMD, usa el runtime de ROCm:
+
+```yaml
+services:
+  voicebox:
+    build: .
+    # ... existing config ...
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+```
+
+### Solo CPU
+
+La configuración por defecto se ejecuta en CPU. Esto funciona bien, pero la generación será más lenta. LuxTTS es el motor más rápido en CPU (150x en tiempo real).
+
+## Seguridad
+
+La imagen de Docker sigue las mejores prácticas de seguridad:
+
+- **Usuario no root** -- el servidor se ejecuta como `voicebox`, no como `root`
+- **Enlace a localhost** -- solo accesible desde la máquina host por defecto
+- **Comprobaciones de estado** -- reinicio automático si el servidor se cuelga (el endpoint `/health` se consulta cada 30s)
+- **CORS restringido** -- solo se permiten orígenes locales por defecto
+
+### Ejecutar detrás de un proxy inverso
+
+Para despliegues en producción, pon Voicebox detrás de nginx o Caddy con TLS y autenticación:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name voicebox.example.com;
+
+    ssl_certificate /etc/ssl/certs/voicebox.pem;
+    ssl_certificate_key /etc/ssl/private/voicebox.key;
+
+    auth_basic "Voicebox";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    location / {
+        proxy_pass http://127.0.0.1:17493;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+## Solución de problemas
+
+### El contenedor arranca pero la interfaz muestra JSON
+
+Si ves `{"message": "voicebox API", ...}` en lugar de la interfaz web, puede que la compilación del frontend haya fallado durante la compilación de Docker. Revisa los registros de compilación:
+
+```bash
+docker compose build --no-cache
+```
+
+Busca errores en la etapa "Build frontend".
+
+### Los modelos se descargan en cada reinicio
+
+Asegúrate de que el volumen `huggingface-cache` está configurado. Sin él, la caché de modelos se pierde cuando el contenedor se detiene:
+
+```yaml
+volumes:
+  - huggingface-cache:/home/voicebox/.cache/huggingface
+```
+
+### Sin memoria
+
+Los modelos de TTS son grandes. Si el contenedor es terminado por el OOM killer, aumenta el límite de memoria:
+
+```yaml
+deploy:
+  resources:
+    limits:
+      memory: 16G
+```
+
+### El puerto ya está en uso
+
+```bash
+# Check what's using port 17493
+lsof -i :17493
+
+# Or use a different port
+ports:
+  - "127.0.0.1:8080:17493"
+```
+
+## Imágenes precompiladas (próximamente)
+
+Tenemos previsto publicar imágenes de Docker precompiladas en GitHub Container Registry para que no necesites compilar localmente:
+
+```bash
+# Not available yet — coming in a future release
+docker run -p 17493:17493 ghcr.io/jamiepine/voicebox:latest
+```
+
+La imagen para CPU pesará alrededor de 3-4 GB (Python + PyTorch + paquetes de TTS). Habrá una etiqueta CUDA separada (~6-8 GB) disponible para los usuarios de GPU NVIDIA. Esto es normal en los contenedores de ML.
+
+Por ahora, usa `docker compose up` para compilar desde el código fuente como se describe arriba.
+
+## Conectar la aplicación de escritorio
+
+También puedes usar la aplicación de escritorio como frontend de un backend alojado en Docker. En la aplicación de escritorio, ve a **Ajustes -> Server**, activa el **modo remoto** e introduce `http://<server-ip>:17493`.
+
+Consulta la [guía del modo remoto](/overview/remote-mode) para más detalles.

--- a/docs/content/docs/overview/docker.es.mdx
+++ b/docs/content/docs/overview/docker.es.mdx
@@ -235,6 +235,6 @@ Por ahora, usa `docker compose up` para compilar desde el código fuente como se
 
 ## Conectar la aplicación de escritorio
 
-También puedes usar la aplicación de escritorio como frontend de un backend alojado en Docker. En la aplicación de escritorio, ve a **Ajustes -> Server**, activa el **modo remoto** e introduce `http://<server-ip>:17493`.
+También puedes usar la aplicación de escritorio como frontend de un backend alojado en Docker. En la aplicación de escritorio, ve a **Ajustes -> Servidor**, activa el **modo remoto** e introduce `http://<server-ip>:17493`.
 
-Consulta la [guía del modo remoto](/overview/remote-mode) para más detalles.
+Consulta la [guía del modo remoto](./remote-mode.mdx) para más detalles.

--- a/docs/content/docs/overview/generating-speech.es.mdx
+++ b/docs/content/docs/overview/generating-speech.es.mdx
@@ -1,0 +1,65 @@
+---
+title: "Generar voz"
+description: "Genera voz de alta calidad a partir de texto"
+---
+
+## Generación básica
+
+<Steps>
+  <Step title="Selecciona un perfil">
+    Elige un perfil de voz en el desplegable
+  </Step>
+  <Step title="Introduce el texto">
+    Escribe o pega tu texto
+  </Step>
+  <Step title="Genera">
+    Haz clic en **Generar** y espera unos segundos
+  </Step>
+  <Step title="Reproduce y exporta">
+    Previsualiza y descarga el resultado
+  </Step>
+</Steps>
+
+## Consejos de formato de texto
+
+La forma en que das formato al texto afecta a la calidad del resultado.
+
+### Puntuación
+
+Usa la puntuación correcta para conseguir pausas naturales:
+
+```
+Good: "Hello! How are you today? I'm doing great."
+Bad: "Hello how are you today Im doing great"
+```
+
+### Énfasis
+
+Usa el formato para sugerir énfasis:
+
+```
+- ALL CAPS for louder/emphasized: "That was AMAZING!"
+- Italics for subtle emphasis: "I *really* enjoyed that"
+- Bold for strong emphasis: "This is **very** important"
+```
+
+<Callout type="info">
+  El modelo interpreta estas pistas, pero los resultados pueden variar.
+</Callout>
+
+## Funciones avanzadas
+
+### Generación por lotes
+
+Para contenido extenso, divídelo en fragmentos más pequeños para tener mejor control y un procesamiento más rápido.
+
+### Caché de voz
+
+Voicebox cachea los prompts de voz para acelerar la regeneración con el mismo perfil.
+
+## Próximamente
+
+- Streaming en tiempo real
+- Control de sincronización a nivel de palabra
+- Controles de emoción y estilo
+- Compatibilidad con SSML

--- a/docs/content/docs/overview/generation-history.es.mdx
+++ b/docs/content/docs/overview/generation-history.es.mdx
@@ -1,0 +1,88 @@
+---
+title: "Historial de generación"
+description: "Sigue y gestiona todo tu audio generado"
+---
+
+## Visión general
+
+Voicebox mantiene un historial completo de todo el audio generado, lo que facilita encontrar, reutilizar y gestionar tus creaciones.
+
+## Características
+
+<Cards>
+  <Card title="Historial completo" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>}>
+    Cada generación se guarda automáticamente
+  </Card>
+  <Card title="Buscar y filtrar" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>}>
+    Encuentra por texto, voz o fecha
+  </Card>
+  <Card title="Regenerar" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>}>
+    Regenera cualquier generación anterior con un solo clic
+  </Card>
+  <Card title="Exportar" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>}>
+    Descarga exportaciones individuales o por lotes
+  </Card>
+</Cards>
+
+## Ver el historial
+
+Ve a la pestaña **History** para ver todas tus generaciones.
+
+Cada entrada muestra:
+- Texto generado
+- Perfil de voz utilizado
+- Marca de tiempo
+- Duración del audio
+- Idioma
+
+## Acciones
+
+### Reproducir
+Haz clic en cualquier generación para reproducirla al instante.
+
+### Regenerar
+Regenera con los mismos ajustes o modifica el texto/la voz.
+
+### Descargar
+Exporta como WAV, MP3 o M4A.
+
+### Eliminar
+Elimina generaciones no deseadas para liberar espacio.
+
+### Añadir a una historia
+Arrastra generaciones a la línea de tiempo del Stories Editor.
+
+## Buscar y filtrar
+
+<Tabs items={["By Text", "By Voice", "By Date"]}>
+  <Tab value="By Text">
+    Busca contenido de texto específico
+    ```
+    "Hello world"
+    ```
+  </Tab>
+  <Tab value="By Voice">
+    Filtra por perfil de voz
+    ```
+    Select from dropdown
+    ```
+  </Tab>
+  <Tab value="By Date">
+    Filtra por rango de fechas
+    ```
+    Last 7 days, Last 30 days, Custom range
+    ```
+  </Tab>
+</Tabs>
+
+## Almacenamiento
+
+El historial se almacena localmente:
+
+- **macOS**: `~/Library/Application Support/sh.voicebox.app/data/`
+- **Windows**: `%APPDATA%/sh.voicebox.app/data/`
+- **Linux**: `~/.config/sh.voicebox.app/data/`
+
+<Callout type="warn">
+  Eliminar el directorio de datos borrará todo el historial. Exporta primero los archivos importantes.
+</Callout>

--- a/docs/content/docs/overview/gpu-acceleration.es.mdx
+++ b/docs/content/docs/overview/gpu-acceleration.es.mdx
@@ -1,0 +1,236 @@
+---
+title: "Aceleración por GPU"
+description: "Cómo usa Voicebox tu GPU — detección automática, configuración manual, resolución de problemas"
+---
+
+## Resumen
+
+Voicebox detecta automáticamente los aceleradores disponibles en el primer arranque y elige el backend más rápido que puede usar. Para la mayoría de la gente esto simplemente funciona — abres la app y ya estás en el backend correcto.
+
+Esta página es para los casos en los que no:
+
+- Tienes una GPU pero Voicebox se está ejecutando en CPU
+- Has actualizado de GPU (especialmente a la serie RTX 50 / Blackwell) y la generación dejó de funcionar
+- Quieres cambiar de backend manualmente (p. ej. forzar MLX en lugar de PyTorch en Apple Silicon)
+- Ves `[UNSUPPORTED - see logs]` junto a tu GPU en Ajustes
+
+## Matriz de backends
+
+| Plataforma                  | Backend autoseleccionado  | Notas                                                |
+| --------------------------- | ------------------------- | ---------------------------------------------------- |
+| **macOS Apple Silicon**     | MLX (Metal)               | 4-5x más rápido que PyTorch vía Apple Neural Engine  |
+| **macOS Intel**             | PyTorch CPU               | Sin aceleración por GPU disponible; solo PyTorch ≥ 2.2 |
+| **Windows + NVIDIA**        | PyTorch CUDA (cu128)      | Descarga automática del binario del backend CUDA en el primer uso |
+| **Windows + Intel Arc**     | PyTorch XPU (IPEX)        | Nuevo en 0.4 — funciona con Arc serie A y serie B    |
+| **Windows GPU genérica**    | DirectML                  | Soporte universal de GPU en Windows; más lento que CUDA |
+| **Linux + NVIDIA**          | PyTorch CUDA (cu128)      | Mismo flujo de descarga automática que en Windows    |
+| **Linux + AMD**             | PyTorch ROCm              | Configura automáticamente `HSA_OVERRIDE_GFX_VERSION` |
+| **Linux + Intel Arc**       | PyTorch XPU (IPEX)        |                                                      |
+| **Cualquiera (sin GPU)**    | PyTorch CPU               | Funciona en todas partes; espera entre 5 y 50x más lento que con GPU |
+
+El backend detectado se muestra en Ajustes → GPU. Los logs de arranque también imprimen el backend elegido y el nombre del dispositivo.
+
+## Apple Silicon — MLX vs PyTorch
+
+En los Mac con chip serie M, Voicebox incluye un backend optimizado con MLX que usa el Apple Neural Engine. Es **4-5x más rápido** que la ruta de PyTorch (CPU/Metal) para los motores compatibles.
+
+| Motor                | Soporte MLX | Notas                                       |
+| -------------------- | ----------- | ------------------------------------------- |
+| Qwen3-TTS            | ✅ Nativo   | Usa MLX exclusivamente cuando está disponible |
+| Chatterbox / Turbo   | PyTorch MPS | Recurre a Metal vía PyTorch                 |
+| LuxTTS               | PyTorch MPS |                                             |
+| TADA                 | PyTorch MPS |                                             |
+| Kokoro               | PyTorch MPS | Requiere `PYTORCH_ENABLE_MPS_FALLBACK=1`    |
+| Qwen CustomVoice     | PyTorch MPS |                                             |
+| Whisper (transcribe) | ✅ Nativo   | MLX-Whisper es el predeterminado en Apple Silicon |
+
+La combinación Whisper Turbo + MLX redujo la latencia de transcripción de ~20s a ~2-3s en los chips de la serie M (consulta la entrada del CHANGELOG para v0.1.10).
+
+## Windows / Linux + NVIDIA — El intercambio del backend CUDA
+
+Voicebox no incluye CUDA en el instalador principal (haría que las descargas se dispararan al territorio de varios gigabytes para usuarios que no tienen una GPU NVIDIA). En su lugar, cuando lo necesitas por primera vez, la app descarga un **binario del backend CUDA** independiente que contiene el runtime de PyTorch + CUDA.
+
+<Steps>
+  <Step title="Abre Ajustes → GPU">
+    Si se detecta una GPU NVIDIA, verás "Install CUDA backend" en el panel de GPU
+  </Step>
+  <Step title="Haz clic en Install">
+    La app descarga dos archivos por separado:
+    - **Núcleo del servidor** (~200-400 MB) — versionado con cada versión de Voicebox
+    - **Librerías CUDA** (~4 GB) — las pesadas DLL de PyTorch + CUDA, versionadas de forma independiente
+  </Step>
+  <Step title="Reinicia">
+    Voicebox se reinicia para activar el backend CUDA
+  </Step>
+</Steps>
+
+<Callout type="info">
+  El diseño de archivos divididos (añadido en v0.4) significa que la mayoría de las actualizaciones de Voicebox solo vuelven a descargar el pequeño archivo del núcleo del servidor. El archivo de librerías de 4 GB solo se actualiza cuando cambia el toolkit de CUDA subyacente o la versión mayor de torch.
+</Callout>
+
+### Actualización automática
+
+Cuando llega una nueva versión de Voicebox, el panel de GPU comprueba si el núcleo del servidor incluido coincide con la versión de CUDA instalada. Si solo cambió el núcleo (lo habitual), descarga el nuevo núcleo en segundo plano. Si cambió la versión de las librerías (raro — solo ocurre en saltos de tipo cu126 → cu128), se te pedirá confirmar la descarga más grande.
+
+## Serie RTX 50 / Blackwell
+
+Voicebox 0.4 añadió soporte explícito para la serie RTX 50:
+
+- Toolkit de CUDA actualizado a **cu128** (las versiones anteriores usaban cu126, que carece de kernels para Blackwell)
+- Compilación fijada con `TORCH_CUDA_ARCH_LIST=...12.0+PTX` para compatibilidad hacia adelante
+
+Si tienes una RTX 5070 / 5080 / 5090 y ves errores de "no kernel image is available":
+
+1. Asegúrate de estar en Voicebox **≥ 0.4.0** (Ajustes → About)
+2. Reinstala el backend CUDA (Ajustes → GPU → Reinstall CUDA backend) — las instalaciones más antiguas pueden tener librerías cu126 obsoletas
+3. Si los errores persisten, consulta la sección de avisos de compatibilidad de GPU más abajo
+
+## Intel Arc (XPU)
+
+Nuevo en 0.4. Funciona tanto con Arc serie A (Alchemist: A380, A580, A750, A770) como con la serie B (Battlemage).
+
+### Configuración
+
+Voicebox detecta automáticamente las GPU Arc y enruta a través del backend PyTorch XPU de Intel (impulsado por IPEX — Intel Extension for PyTorch). No hay ningún paso de instalación adicional más allá de la instalación estándar de Voicebox.
+
+Verifica que funciona:
+- Ajustes → GPU debería mostrar **XPU** seguido del nombre de tu modelo Arc (p. ej. `XPU (Intel Arc A770)`)
+- Los logs de arranque imprimen `Backend: PYTORCH` y `GPU: XPU (Intel Arc ...)`
+
+### Motores en XPU
+
+Todos los motores basados en PyTorch funcionan en XPU. El rendimiento generalmente se sitúa entre el de CPU y el de CUDA — espera una mejora de ~2-3x sobre CPU para los modelos más grandes.
+
+## DirectML
+
+La opción de reserva para usuarios de Windows con GPU que no sean NVIDIA ni Intel Arc (AMD discretas más antiguas, GPU integradas, etc.). Más lento que CUDA y XPU, pero aporta algo de aceleración sobre CPU.
+
+Se autoselecciona cuando no hay ningún otro backend de GPU disponible.
+
+## AMD ROCm (Linux)
+
+ROCm proporciona aceleración por GPU con PyTorch en GPU discretas de AMD. Voicebox configura automáticamente `HSA_OVERRIDE_GFX_VERSION` para las tarjetas comunes que necesitan el override.
+
+### Verificación
+
+```bash
+# In a terminal
+echo $HSA_OVERRIDE_GFX_VERSION
+# Should show e.g. 10.3.0 for RX 6000 series
+```
+
+Si la detección falla, define la variable manualmente antes de lanzar Voicebox:
+
+```bash
+export HSA_OVERRIDE_GFX_VERSION=10.3.0
+voicebox
+```
+
+Valores comunes:
+- `10.3.0` — serie RX 6000 (RDNA 2)
+- `11.0.0` — serie RX 7000 (RDNA 3)
+- `9.0.0` — tarjetas Vega más antiguas
+
+## Avisos de compatibilidad de GPU
+
+Voicebox 0.4 añadió una comprobación en tiempo de ejecución que compara la capacidad de cómputo de tu GPU con las arquitecturas para las que se compiló el PyTorch incluido. Si no coinciden, verás:
+
+- Una línea en el log de arranque: `WARNING: GPU COMPATIBILITY: <your GPU> is not supported by this PyTorch build...`
+- La etiqueta de la GPU en Ajustes muestra `[UNSUPPORTED - see logs]`
+- La API `/health` devuelve un campo `gpu_compatibility_warning` con datos
+
+### Qué hacer
+
+El desencadenante más común es una arquitectura de GPU recién salida que las ruedas precompiladas de PyTorch aún no cubren de forma nativa. En orden de preferencia:
+
+1. **Actualiza Voicebox** — las versiones más nuevas incluyen un PyTorch más reciente con soporte de arquitecturas más amplio
+2. **Reinstala el backend CUDA** — Ajustes → GPU → Reinstall CUDA backend
+3. **Para GPU de última hornada (más nuevas que el Blackwell actual):** instala PyTorch nightly manualmente:
+   ```bash
+   pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128 --force-reinstall
+   ```
+   Luego apunta Voicebox a ese entorno vía [Modo remoto](/overview/remote-mode) hasta que el PyTorch estable se ponga al día.
+4. **Recurre a la CPU** temporalmente — define `VOICEBOX_FORCE_CPU=1` antes de lanzar
+
+## Reserva solo con CPU
+
+Cuando no hay ninguna GPU disponible (o la has forzado a desactivarse), Voicebox ejecuta el backend de PyTorch en CPU. Espera:
+
+- Generación entre 5 y 50x más lenta según el motor y la longitud del texto
+- Uso intensivo de CPU durante la generación
+- Algunos motores funcionan mejor que otros en CPU:
+  - **Kokoro 82M** — funciona en tiempo real en CPU modernas
+  - **LuxTTS** — supera las 150x el tiempo real en CPU
+  - **Chatterbox Turbo (350M)** — utilizable pero lento
+  - Modelos más grandes (Qwen 1.7B, Chatterbox Multilingual, TADA 3B) — penosos
+
+Para casos de uso limitados a CPU, prefiere los motores más pequeños y ligeros.
+
+## Verificar tu configuración
+
+Tres lugares para comprobar que se está usando el backend correcto:
+
+<Steps>
+  <Step title="Ajustes → GPU">
+    Muestra el backend detectado, el modelo de GPU y la VRAM (cuando aplica). Fíjate en el sufijo `[UNSUPPORTED - see logs]`
+  </Step>
+  <Step title="Ajustes → Logs">
+    La pestaña "Server logs" muestra el banner de arranque con `Backend: <type>` y `GPU: <name>`
+  </Step>
+  <Step title="Endpoint de salud">
+    `curl http://localhost:17493/health` devuelve un payload JSON con `backend_type`, `backend_variant` y `gpu_compatibility_warning` (cuando aplica)
+  </Step>
+</Steps>
+
+## Resolución de problemas
+
+<AccordionGroup>
+  <Accordion title="Ajustes muestra CPU en lugar de mi GPU">
+    - En NVIDIA: instala el backend CUDA (Ajustes → GPU)
+    - En Intel Arc: confirma la detección de IPEX en los logs de arranque; reinicia la app tras actualizar el driver
+    - En AMD Linux: comprueba que `HSA_OVERRIDE_GFX_VERSION` esté definido
+  </Accordion>
+
+  <Accordion title="'no kernel image is available' / 'CUDA error'">
+    Casi siempre significa que el PyTorch incluido no tiene kernels para la capacidad de cómputo de tu GPU.
+
+    1. Actualiza a Voicebox ≥ 0.4.0 (el soporte de Blackwell se añadió ahí)
+    2. Reinstala el backend CUDA
+    3. Si sigue roto, instala PyTorch nightly vía Modo remoto
+  </Accordion>
+
+  <Accordion title="Sin memoria (CUDA)">
+    - Cambia a un tamaño de modelo más pequeño (p. ej. Qwen3 0.6B en lugar de 1.7B)
+    - Usa Ajustes → Models para descargar otros motores que no estés usando
+    - `low_cpu_mem_usage` ya está activado para CPU; para CUDA, el `device_map` del motor gestiona la descarga automáticamente
+    - Cierra otras aplicaciones que usen la GPU
+  </Accordion>
+
+  <Accordion title="Errores de reserva de MPS en macOS">
+    Algunas operaciones no tienen implementación en Metal. Voicebox define `PYTORCH_ENABLE_MPS_FALLBACK=1` para los motores que lo necesitan (notablemente Kokoro), pero si lanzas desde un entorno personalizado, defínelo manualmente:
+    ```bash
+    export PYTORCH_ENABLE_MPS_FALLBACK=1
+    ```
+  </Accordion>
+
+  <Accordion title="La generación funciona pero es lenta en mi GPU">
+    - Comprueba que Ajustes → GPU muestre tu GPU (no CPU)
+    - Comprueba el uso de VRAM — puede que estés paginando a la memoria del sistema
+    - Prueba un modelo más pequeño
+    - En NVIDIA: confirma que cu128 está instalado (Ajustes → GPU → version)
+  </Accordion>
+</AccordionGroup>
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Modo remoto" href="/overview/remote-mode">
+    Ejecuta el backend en una máquina diferente con una GPU más potente
+  </Card>
+  <Card title="Gestión de modelos" href="/developer/model-management">
+    Descarga modelos para liberar memoria de GPU
+  </Card>
+  <Card title="Resolución de problemas" href="/overview/troubleshooting">
+    Resolución de problemas general más allá de la GPU
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/gpu-acceleration.es.mdx
+++ b/docs/content/docs/overview/gpu-acceleration.es.mdx
@@ -149,7 +149,7 @@ El desencadenante más común es una arquitectura de GPU recién salida que las 
    ```bash
    pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128 --force-reinstall
    ```
-   Luego apunta Voicebox a ese entorno vía [Modo remoto](/overview/remote-mode) hasta que el PyTorch estable se ponga al día.
+   Luego apunta Voicebox a ese entorno vía [Modo remoto](./remote-mode.mdx) hasta que el PyTorch estable se ponga al día.
 4. **Recurre a la CPU** temporalmente — define `VOICEBOX_FORCE_CPU=1` antes de lanzar
 
 ## Reserva solo con CPU

--- a/docs/content/docs/overview/installation.es.mdx
+++ b/docs/content/docs/overview/installation.es.mdx
@@ -1,0 +1,119 @@
+---
+title: "Instalación"
+description: "Descarga e instala Voicebox en macOS, Windows o Linux"
+---
+
+## Descarga
+
+Voicebox está disponible para macOS y Windows, y las compilaciones para Linux llegarán pronto.
+
+<Cards>
+  <Card title="macOS" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2c-1.5 0-2.8.4-3.9 1.1A5.5 5.5 0 0 0 4 2.5C2.5 2.5 1 4 1 6c0 3.5 2.5 6 5 7.5C5 16 4 18 4 20c0 1.5.5 2.5 1.5 3C6.5 23.5 8 24 9.5 24c2 0 3.5-.5 5-2 1.5 1.5 3 2 5 2 1.5 0 3-.5 4-1 1-.5 1.5-1.5 1.5-3 0-2-1-4-2-6.5 2.5-1.5 5-4 5-7.5 0-2-1.5-3.5-3-3.5-.9 0-2.1.4-3.1 1.1A6.5 6.5 0 0 0 12 2Z"/></svg>}>
+    Descarga para Macs con Apple Silicon o Intel
+  </Card>
+  <Card title="Windows" icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>}>
+    Descarga el instalador MSI o el ejecutable Setup
+  </Card>
+</Cards>
+
+### macOS
+
+<Tabs items={["Apple Silicon", "Intel"]}>
+  <Tab value="Apple Silicon">
+    Descarga: [voicebox_aarch64.app.tar.gz](https://github.com/jamiepine/voicebox/releases/latest/download/voicebox_aarch64.app.tar.gz)
+
+    ```bash
+    # Extract the archive
+    tar -xzf voicebox_aarch64.app.tar.gz
+
+    # Move to Applications
+    mv Voicebox.app /Applications/
+    ```
+  </Tab>
+  <Tab value="Intel">
+    Descarga: [voicebox_x64.app.tar.gz](https://github.com/jamiepine/voicebox/releases/latest/download/voicebox_x64.app.tar.gz)
+
+    ```bash
+    # Extract the archive
+    tar -xzf voicebox_x64.app.tar.gz
+
+    # Move to Applications
+    mv Voicebox.app /Applications/
+    ```
+  </Tab>
+</Tabs>
+
+### Windows
+
+<Tabs items={["MSI Installer", "Setup Executable"]}>
+  <Tab value="MSI Installer">
+    Descarga: [voicebox_x64_en-US.msi](https://github.com/jamiepine/voicebox/releases/latest/download/voicebox_x64_en-US.msi)
+
+    Haz doble clic en el archivo MSI y sigue el asistente de instalación.
+  </Tab>
+  <Tab value="Setup Executable">
+    Descarga: [voicebox_x64-setup.exe](https://github.com/jamiepine/voicebox/releases/latest/download/voicebox_x64-setup.exe)
+
+    Ejecuta el archivo y sigue el asistente de instalación.
+  </Tab>
+</Tabs>
+
+### Linux
+
+<Callout type="info">
+  Las compilaciones para Linux llegarán pronto. Actualmente están bloqueadas por las limitaciones de espacio en disco del runner de GitHub.
+</Callout>
+
+## Primer arranque
+
+Cuando inicias Voicebox por primera vez:
+
+1. **Descarga del modelo** — El motor de TTS con el que generes primero descargará su modelo automáticamente. Los tamaños van desde ~350 MB (Kokoro) hasta ~8 GB (TADA 3B). La mayoría de los usuarios empiezan con Qwen 1.7B (~3.5 GB).
+2. **Directorio de datos** — Los perfiles de voz y el audio generado se almacenan en:
+   - macOS: `~/Library/Application Support/sh.voicebox.app/`
+   - Windows: `%APPDATA%/sh.voicebox.app/`
+   - Linux: `~/.config/sh.voicebox.app/`
+
+3. **Servidor backend** — El servidor de Python incluido se inicia automáticamente
+
+<Callout type="info">
+  La primera generación será más lenta debido a las descargas de modelos. Las ejecuciones posteriores usan modelos en caché.
+</Callout>
+
+## Requisitos del sistema
+
+### Mínimos
+
+- **SO:** macOS 11+, Windows 10+ o Linux
+- **RAM:** 8 GB
+- **Almacenamiento:** 5 GB de espacio libre (para modelos y datos)
+- **CPU:** Procesador multinúcleo moderno
+
+### Recomendados
+
+- **RAM:** 16 GB o más
+- **GPU:** GPU de NVIDIA compatible con CUDA (para una generación más rápida)
+- **Almacenamiento:** 10 GB o más de espacio libre
+
+<Callout type="info">
+  La inferencia en CPU es compatible, pero significativamente más lenta que en GPU. Se recomienda encarecidamente una GPU compatible con CUDA para flujos de trabajo en tiempo real.
+</Callout>
+
+## Verificación
+
+Tras la instalación, comprueba que todo funciona:
+
+1. Inicia Voicebox
+2. Comprueba el indicador de estado del servidor en la esquina inferior izquierda (debería estar verde)
+3. Ve a **Perfiles** y crea un perfil de prueba
+4. Genera un breve clip de audio para verificar que el motor de TTS funciona
+
+<Callout type="success">
+  Si ves un indicador de estado verde y puedes generar audio, ¡ya está todo listo!
+</Callout>
+
+## Siguientes pasos
+
+<Card title="Guía de inicio rápido" href="/overview/quick-start">
+  Crea tu primer perfil de voz y genera voz
+</Card>

--- a/docs/content/docs/overview/introduction.es.mdx
+++ b/docs/content/docs/overview/introduction.es.mdx
@@ -26,16 +26,16 @@ y un LLM compartido entre la entrada y la salida.
 ## Qué incluye la app
 
 - **Dictado** — atajo global, modos de pulsar para hablar y de alternancia,
-  pegado automático en el campo enfocado en macOS y Windows (consulta [Dictado](/overview/dictation))
+  pegado automático en el campo enfocado en macOS y Windows (consulta [Dictado](./dictation.mdx))
 - **Pestaña de capturas** — archivo emparejado de audio + transcripción,
-  retranscribir, refinar, reproducir como voz, promover a muestra (consulta [Capturas](/overview/captures))
+  retranscribir, refinar, reproducir como voz, promover a muestra (consulta [Capturas](./captures.mdx))
 - **Clonación de voz** — 5 motores de clonación que cubren 23 idiomas. Clonación
-  zero-shot a partir de una muestra de referencia (consulta [Clonación de voz](/overview/voice-cloning))
+  zero-shot a partir de una muestra de referencia (consulta [Clonación de voz](./voice-cloning.mdx))
 - **Voces de preajuste** — más de 50 voces seleccionadas mediante Kokoro y Qwen CustomVoice
-  para cuando no quieras clonar (consulta [Voces de preajuste](/overview/preset-voices))
+  para cuando no quieras clonar (consulta [Voces de preajuste](./preset-voices.mdx))
 - **Personalidades de voz** — personalidad opcional de formato libre en cualquier perfil
   más un botón de redacción y una alternancia de reescritura de persona impulsada por un LLM local (consulta
-  [Personalidades de voz](/overview/voice-personalities))
+  [Personalidades de voz](./voice-personalities.mdx))
 - **Efectos de postprocesado** — cambio de tono, reverberación, retardo, coro,
   compresión, filtros (Pedalboard de Spotify)
 - **Voz expresiva** — etiquetas paralingüísticas como `[laugh]` y `[sigh]`

--- a/docs/content/docs/overview/introduction.es.mdx
+++ b/docs/content/docs/overview/introduction.es.mdx
@@ -1,0 +1,110 @@
+---
+title: "Introducción"
+description: "Voicebox es el estudio de voz con IA de código abierto y local-first — una alternativa gratuita a ElevenLabs y WisprFlow, que se ejecuta por completo en tu máquina."
+---
+
+## ¿Qué es Voicebox?
+
+Voicebox es el **estudio de voz con IA de código abierto y local-first**. Cierra
+el bucle de E/S de voz en ambas direcciones en una sola máquina, sin nube y sin
+cuentas:
+
+- **Los humanos hablan** — mantén pulsado un acorde en cualquier parte de tu
+  máquina y tu dictado aparece como texto limpio en el campo de texto que
+  tuvieras enfocado
+- **Los agentes responden** — cualquier agente compatible con MCP puede llamar a
+  Voicebox para hablar con una de tus voces clonadas
+- **Las voces hablan por sí mismas** — los perfiles de voz pueden llevar una
+  personalidad que redacta líneas nuevas o reescribe el texto antes de
+  pronunciarlo
+
+Es la alternativa gratuita y local tanto a ElevenLabs (clonación de voz y TTS)
+como a WisprFlow (dictado por voz para agentes y usuarios avanzados) — cubriendo
+ambos lados del mismo bucle en una sola app, con un único directorio de modelos
+y un LLM compartido entre la entrada y la salida.
+
+## Qué incluye la app
+
+- **Dictado** — atajo global, modos de pulsar para hablar y de alternancia,
+  pegado automático en el campo enfocado en macOS y Windows (consulta [Dictado](/overview/dictation))
+- **Pestaña de capturas** — archivo emparejado de audio + transcripción,
+  retranscribir, refinar, reproducir como voz, promover a muestra (consulta [Capturas](/overview/captures))
+- **Clonación de voz** — 5 motores de clonación que cubren 23 idiomas. Clonación
+  zero-shot a partir de una muestra de referencia (consulta [Clonación de voz](/overview/voice-cloning))
+- **Voces de preajuste** — más de 50 voces seleccionadas mediante Kokoro y Qwen CustomVoice
+  para cuando no quieras clonar (consulta [Voces de preajuste](/overview/preset-voices))
+- **Personalidades de voz** — personalidad opcional de formato libre en cualquier perfil
+  más un botón de redacción y una alternancia de reescritura de persona impulsada por un LLM local (consulta
+  [Personalidades de voz](/overview/voice-personalities))
+- **Efectos de postprocesado** — cambio de tono, reverberación, retardo, coro,
+  compresión, filtros (Pedalboard de Spotify)
+- **Voz expresiva** — etiquetas paralingüísticas como `[laugh]` y `[sigh]`
+  mediante Chatterbox Turbo; control de interpretación en lenguaje natural mediante Qwen CustomVoice
+- **Longitud ilimitada** — fragmentación automática con fundido cruzado para guiones largos
+- **Editor de historias** — línea de tiempo multipista para conversaciones y podcasts
+- **API-first** — API REST + WebSocket; servidor MCP para integraciones de agentes
+- **Funciona en todas partes** — macOS (MLX/Metal), Windows (CUDA / DirectML), Linux
+  (ROCm / CPU), Intel Arc, Docker
+
+## Motores de TTS
+
+Siete motores con diferentes puntos fuertes, conmutables por generación:
+
+| Motor | Tipo de perfil | Idiomas | Puntos fuertes |
+|--------|--------------|-----------|-----------|
+| **Qwen3-TTS** (0.6B / 1.7B) | Clonado | 10 | Clonación multilingüe de alta calidad |
+| **Qwen CustomVoice** (0.6B / 1.7B) | Preajuste (9 voces) | 10 | Control de interpretación en lenguaje natural (tono, emoción, ritmo) |
+| **LuxTTS** | Clonado | Inglés | Ligero (~1GB VRAM), salida a 48kHz, 150x tiempo real en CPU |
+| **Chatterbox Multilingual** | Clonado | 23 | La cobertura de idiomas más amplia |
+| **Chatterbox Turbo** | Clonado | Inglés | Modelo rápido de 350M con etiquetas paralingüísticas de emoción/sonido |
+| **TADA** (1B / 3B) | Clonado | 10 | Modelo de lenguaje-voz de HumeAI — más de 700s de audio coherente |
+| **Kokoro** | Preajuste (50 voces) | 9 | 82M de parámetros, tiempo real en CPU, la menor VRAM de cualquier motor |
+
+## STT y LLM local
+
+Voicebox también ejecuta una pila completa de reconocimiento de voz y LLM local,
+compartida entre el dictado, la pestaña de capturas y los modos de personalidad por perfil:
+
+| Capa | Modelos |
+|---|---|
+| **STT** | Whisper Base / Small / Medium / Large / Turbo (PyTorch o MLX) |
+| **LLM** | Qwen3 0.6B / 1.7B / 4B (refinamiento + redacción por perfil / reescritura de persona) |
+
+Sin recurso a la nube, sin traer tu propia clave de API. Lo local es el producto.
+
+## Compatibilidad con GPU
+
+| Plataforma | Backend | Notas |
+|----------|---------|-------|
+| macOS (Apple Silicon) | MLX (Metal) | 4-5x más rápido mediante Neural Engine |
+| Windows / Linux (NVIDIA) | PyTorch (CUDA) | Descarga automáticamente el binario CUDA desde dentro de la app |
+| Linux (AMD) | PyTorch (ROCm) | Configura automáticamente HSA_OVERRIDE_GFX_VERSION |
+| Windows (cualquier GPU) | DirectML | Compatibilidad universal con GPU en Windows |
+| Intel Arc | IPEX/XPU | Aceleración de GPU discreta de Intel |
+| Cualquiera | CPU | Funciona en todas partes, solo que más lento |
+
+## Casos de uso
+
+- **Dictado para humanos y agentes** — habla en lugar de escribir, en cualquier app
+- **Salida de voz para agentes** — cualquier agente compatible con MCP puede hablar con una voz clonada
+- **Desarrollo de videojuegos** — genera diálogos dinámicos para personajes
+- **Creación de contenido** — podcasts, voces en off para vídeos, audiolibros
+- **Accesibilidad** — voz a texto para cualquier campo, TTS con una voz que te pertenece
+- **Asistentes de voz** — interfaces de voz personalizadas sin una factura en la nube
+- **Pipelines de producción** — automatiza flujos de trabajo de voz mediante la API REST
+
+## Pila tecnológica
+
+| Capa | Tecnología |
+|-------|------------|
+| App de escritorio | Tauri (Rust) |
+| Frontend | React, TypeScript, Tailwind CSS |
+| Estado | Zustand, React Query |
+| Backend | FastAPI (Python) |
+| Motores de TTS | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
+| STT | Whisper / Whisper Turbo (PyTorch o MLX) |
+| LLM local | Qwen3 0.6B / 1.7B / 4B (MLX o PyTorch) |
+| Efectos | Pedalboard (Spotify) |
+| Inferencia | MLX (Apple Silicon) / PyTorch (CUDA/ROCm/XPU/CPU) |
+| Base de datos | SQLite |
+| Audio | WaveSurfer.js, librosa |

--- a/docs/content/docs/overview/mcp-server.es.mdx
+++ b/docs/content/docs/overview/mcp-server.es.mdx
@@ -16,8 +16,8 @@ indicador en pantalla muestra el nombre de la voz durante toda la duración para
 siempre veas lo que sale de tu máquina.
 
 <Callout type="info">
-  MCP llegó en la **0.5.0** junto con el [Dictado](/overview/dictation) y las
-  [Personalidades de Voz](/overview/voice-personalities). El objetivo de diseño es
+  MCP llegó en la **0.5.0** junto con el [Dictado](./dictation.mdx) y las
+  [Personalidades de Voz](./voice-personalities.mdx). El objetivo de diseño es
   "una capa de voz local para cada agente de tu máquina" — la misma app que
   captura tu voz puede generar una respuesta con cualquier perfil de voz que hayas
   clonado.
@@ -136,7 +136,7 @@ Devuelve:
 
 - **TTS plano** — `personality: false` (u omitido + el valor por defecto de la vinculación es false). El texto se habla tal cual.
 - **Modo personaje** — `personality: true` y el perfil debe tener configurado un prompt de personalidad.
-  El LLM reescribe el texto en personaje antes del TTS. Consulta las [Personalidades de Voz](/overview/voice-personalities).
+  El LLM reescribe el texto en personaje antes del TTS. Consulta las [Personalidades de Voz](./voice-personalities.mdx).
 
 ### `voicebox.transcribe`
 
@@ -204,7 +204,7 @@ agente. Cada fila incluye:
 ## El indicador de habla
 
 Cada vez que un agente inicia una orden de hablar aparece el indicador flotante de la misma forma
-que con el [Dictado](/overview/dictation), en un nuevo estado `Speaking` que muestra el
+que con el [Dictado](./dictation.mdx), en un nuevo estado `Speaking` que muestra el
 nombre del perfil y un temporizador transcurrido. El indicador es intencionadamente imposible de pasar por alto —
 un TTS silencioso en segundo plano es un riesgo de confianza, así que Voicebox siempre muestra qué
 se está hablando y con qué voz.
@@ -261,7 +261,7 @@ generación aparece en la pestaña Capturas.
 - **Las lecturas de `audio_path` no tienen restricciones** dentro del mismo límite de
   confianza. Si estás haciendo scripting contra un host compartido, prefiere
   `audio_base64` para no tener que pensar en el sandboxing de rutas.
-- **Se aplica el consentimiento para clonar voces.** Consulta [Clonación de Voz](/overview/voice-cloning#limitations)
+- **Se aplica el consentimiento para clonar voces.** Consulta [Clonación de Voz](./voice-cloning.mdx#limitations)
   — que un agente pueda llamar a `voicebox.speak` con la voz de alguien
   no cambia la ética de a quién clonas la voz.
 

--- a/docs/content/docs/overview/mcp-server.es.mdx
+++ b/docs/content/docs/overview/mcp-server.es.mdx
@@ -1,0 +1,299 @@
+---
+title: "Servidor MCP"
+description: "Deja que Claude Code, Cursor, Cline o cualquier agente compatible con MCP hable con una de tus voces clonadas — de forma local, sin nube."
+---
+
+## Visión general
+
+Voicebox incluye un servidor de **Model Context Protocol** integrado para que los
+agentes de IA locales puedan llamar a tu instalación de Voicebox directamente: hablar
+texto con un perfil de voz, transcribir audio y listar capturas o perfiles. El servidor
+se ejecuta dentro del mismo proceso que el resto de Voicebox y está montado en `/mcp`
+sobre Streamable HTTP.
+
+El agente pide hablar → Voicebox reproduce el audio por tus altavoces → un
+indicador en pantalla muestra el nombre de la voz durante toda la duración para que
+siempre veas lo que sale de tu máquina.
+
+<Callout type="info">
+  MCP llegó en la **0.5.0** junto con el [Dictado](/overview/dictation) y las
+  [Personalidades de Voz](/overview/voice-personalities). El objetivo de diseño es
+  "una capa de voz local para cada agente de tu máquina" — la misma app que
+  captura tu voz puede generar una respuesta con cualquier perfil de voz que hayas
+  clonado.
+</Callout>
+
+## Instalación rápida
+
+### Claude Code
+
+```
+claude mcp add voicebox \
+  --transport http \
+  --url http://127.0.0.1:17493/mcp \
+  --header "X-Voicebox-Client-Id: claude-code"
+```
+
+### Cursor / Windsurf / VS Code MCP / cualquier cliente MCP por HTTP
+
+Pega esto en la configuración MCP del cliente (normalmente `.mcp.json` o una interfaz de Ajustes):
+
+```json
+{
+  "mcpServers": {
+    "voicebox": {
+      "url": "http://127.0.0.1:17493/mcp",
+      "headers": { "X-Voicebox-Client-Id": "cursor" }
+    }
+  }
+}
+```
+
+Cambia `cursor` por el nombre que quieras que aparezca para la vinculación en
+Voicebox → Ajustes → MCP. El valor es solo un identificador para la
+vinculación de voz por cliente — no es un secreto ni una credencial.
+
+### Clientes que solo hablan stdio
+
+Con la app de escritorio se incluye un binario puente para stdio llamado `voicebox-mcp`. Apunta
+el cliente a la ruta absoluta de ese binario:
+
+<Tabs items={["macOS", "Windows", "Linux"]}>
+  <Tab value="macOS">
+  ```json
+  {
+    "mcpServers": {
+      "voicebox": {
+        "command": "/Applications/Voicebox.app/Contents/MacOS/voicebox-mcp",
+        "env": { "VOICEBOX_CLIENT_ID": "claude-desktop" }
+      }
+    }
+  }
+  ```
+  </Tab>
+  <Tab value="Windows">
+  ```json
+  {
+    "mcpServers": {
+      "voicebox": {
+        "command": "C:\\Program Files\\Voicebox\\voicebox-mcp.exe",
+        "env": { "VOICEBOX_CLIENT_ID": "claude-desktop" }
+      }
+    }
+  }
+  ```
+  </Tab>
+  <Tab value="Linux">
+  ```json
+  {
+    "mcpServers": {
+      "voicebox": {
+        "command": "/opt/voicebox/voicebox-mcp",
+        "env": { "VOICEBOX_CLIENT_ID": "claude-desktop" }
+      }
+    }
+  }
+  ```
+  </Tab>
+</Tabs>
+
+El puente espera hasta 30 segundos a que arranque el backend de Voicebox y luego
+hace de proxy del JSON-RPC desde stdio sobre Streamable HTTP. Voicebox debe estar en
+ejecución para que el puente pueda conectarse.
+
+## Herramientas
+
+| Herramienta | Uso |
+|---|---|
+| `voicebox.speak` | Habla texto con un perfil de voz. Devuelve un `generation_id` para consultar. |
+| `voicebox.transcribe` | Transcripción con Whisper de audio en base64 o de una ruta local absoluta. |
+| `voicebox.list_captures` | Capturas recientes con transcripciones, paginadas. |
+| `voicebox.list_profiles` | Perfiles de voz disponibles (clonados + preajuste). |
+
+### `voicebox.speak`
+
+```ts
+voicebox.speak({
+  text: "Deploy complete.",
+  profile?: "Morgan",            // name or id; falls back to per-client binding, then default
+  engine?: "qwen",               // qwen | qwen_custom_voice | luxtts | chatterbox | chatterbox_turbo | tada | kokoro
+  personality?: true,            // rewrite via the profile's personality LLM before TTS; default comes from the per-client binding
+  language?: "en",
+})
+```
+
+Devuelve:
+
+```json
+{
+  "generation_id": "…",
+  "status": "generating",
+  "profile": "Morgan",
+  "source": "mcp",
+  "poll_url": "/generate/<id>/status"
+}
+```
+
+- **TTS plano** — `personality: false` (u omitido + el valor por defecto de la vinculación es false). El texto se habla tal cual.
+- **Modo personaje** — `personality: true` y el perfil debe tener configurado un prompt de personalidad.
+  El LLM reescribe el texto en personaje antes del TTS. Consulta las [Personalidades de Voz](/overview/voice-personalities).
+
+### `voicebox.transcribe`
+
+```ts
+voicebox.transcribe({
+  audio_base64?: "<base64>",    // exactly one of these two
+  audio_path?: "/absolute/path/to/file.wav",
+  language?: "en",
+  model?: "turbo",              // base | small | medium | large | turbo
+})
+```
+
+Devuelve `{ text, duration, language, model }`. Límite de 200 MB en cualquiera de las dos rutas.
+
+### `voicebox.list_captures`
+
+`{ limit?: 20, offset?: 0 }` → `{ captures: [...], total }`. `limit` se
+ajusta al rango `1..=200`.
+
+### `voicebox.list_profiles`
+
+Sin argumentos → `{ profiles: [{ id, name, voice_type, language, has_personality }] }`.
+
+## Resolución de la voz
+
+Cada llamada a `voicebox.speak` (y a `POST /speak`) resuelve el perfil de voz
+en este orden:
+
+<Steps>
+  <Step title="Argumento `profile` explícito">
+    Se pasa como nombre (sin distinguir mayúsculas) o id. Si el nombre/id no coincide,
+    la llamada da error — el servidor no recurre a una alternativa de forma silenciosa.
+  </Step>
+  <Step title="Vinculación por cliente">
+    Se busca mediante la cabecera `X-Voicebox-Client-Id`. Se gestiona en
+    **Voicebox → Ajustes → MCP**. Te permite fijar Claude Code a Morgan,
+    Cursor a Scarlett, etc.
+  </Step>
+  <Step title="Valor por defecto global">
+    `capture_settings.default_playback_voice_id` — la misma voz por defecto
+    que usa la acción "Reproducir como voz" de la pestaña Capturas.
+  </Step>
+</Steps>
+
+Si ninguno de los tres produce un perfil, la herramienta devuelve un error útil
+que apunta a Ajustes.
+
+## Vinculaciones por cliente
+
+Voicebox → Ajustes → MCP muestra una fila por cada `client_id` del que Voicebox ha
+recibido peticiones, además de los fragmentos de configuración que puedes copiar en cada
+agente. Cada fila incluye:
+
+| Campo | Propósito |
+|---|---|
+| `label` | Nombre visible en la interfaz de Ajustes (p. ej. "Claude Code"). |
+| `profile_id` | La voz que usa este cliente cuando no se pasa `profile`. |
+| `default_engine` | Anula el motor de TTS para este cliente. |
+| `default_personality` | Cuando es true, `voicebox.speak` enruta por defecto a través del LLM de personalidad del perfil (reescritura). |
+| `last_seen_at` | Última vez que el servidor vio una petición de este cliente. |
+
+`last_seen_at` lo marca automáticamente el middleware en cada petición a `/mcp/*`
+— útil cuando no estás seguro de si tu configuración ha surtido efecto.
+
+## El indicador de habla
+
+Cada vez que un agente inicia una orden de hablar aparece el indicador flotante de la misma forma
+que con el [Dictado](/overview/dictation), en un nuevo estado `Speaking` que muestra el
+nombre del perfil y un temporizador transcurrido. El indicador es intencionadamente imposible de pasar por alto —
+un TTS silencioso en segundo plano es un riesgo de confianza, así que Voicebox siempre muestra qué
+se está hablando y con qué voz.
+
+Entre bastidores, el backend emite eventos `speak-start` y `speak-end`
+en `GET /events/speak`, a los que `DictateWindow` se suscribe mediante SSE.
+El indicador prevalece sobre la sesión de captura cuando ambos se renderizarían — no puedes
+oír dos indicadores a la vez.
+
+## Superficie REST sin MCP
+
+`POST /speak` es una envoltura ligera sobre la misma ruta de código para quienes
+no hablan MCP — scripts de shell, ACP, A2A, GitHub Actions, lo que sea.
+
+```bash
+curl -X POST http://127.0.0.1:17493/speak \
+  -H 'Content-Type: application/json' \
+  -H 'X-Voicebox-Client-Id: ci' \
+  -d '{"text":"Build complete.","profile":"Morgan"}'
+```
+
+Los campos del cuerpo coinciden con la herramienta MCP: `text`, opcionalmente `profile`, `engine`,
+`personality`, `language`. Devuelve un `GenerationResponse` — la misma forma que
+`POST /generate`.
+
+## Depuración
+
+Usa el MCP Inspector para probar las herramientas directamente sin pasar por
+un agente:
+
+```
+npx @modelcontextprotocol/inspector http://127.0.0.1:17493/mcp
+```
+
+Empieza con `voicebox.list_profiles` para confirmar la conexión, y luego
+`voicebox.speak` para una prueba de extremo a extremo — deberías oír audio y ver que la
+generación aparece en la pestaña Capturas.
+
+<Callout type="info">
+  Si un agente no puede llegar al servidor, lo primero que hay que comprobar es que
+  Voicebox esté en ejecución — el backend solo escucha mientras la app de escritorio está
+  abierta. El puente de stdio lo muestra como un error de JSON-RPC en el lado del
+  cliente una vez transcurre su ventana de espera de salud de 30 segundos.
+</Callout>
+
+## Seguridad
+
+- **Solo localhost.** El servidor se enlaza a `127.0.0.1`. Si en algún momento apuntas
+  Voicebox a una interfaz que no sea de loopback (p. ej. modo remoto sobre una red
+  de confianza), añade un token bearer — está en la hoja de ruta pero no en la 0.5.0.
+- **Sin autenticación hoy.** Cualquier proceso que pueda conectarse a tu loopback puede
+  llamar a MCP. Es el mismo límite de confianza que el resto de la API REST de Voicebox
+  y es apropiado para una herramienta local de un solo usuario.
+- **Las lecturas de `audio_path` no tienen restricciones** dentro del mismo límite de
+  confianza. Si estás haciendo scripting contra un host compartido, prefiere
+  `audio_base64` para no tener que pensar en el sandboxing de rutas.
+- **Se aplica el consentimiento para clonar voces.** Consulta [Clonación de Voz](/overview/voice-cloning#limitations)
+  — que un agente pueda llamar a `voicebox.speak` con la voz de alguien
+  no cambia la ética de a quién clonas la voz.
+
+## Notas de implementación
+
+- **Transporte:** Streamable HTTP (especificación MCP de noviembre de 2025, posterior a SSE). Claude
+  Code, Cursor, Windsurf y las extensiones MCP de VS Code lo soportan todas.
+- **Nombrado del paquete:** el paquete del backend es `backend/mcp_server/`, no
+  `mcp`, para evitar ensombrecer el paquete `mcp` de PyPI que FastMCP importa
+  internamente.
+- **Dependencias:** `fastmcp>=3.0,<4.0`, `sse-starlette>=2.0`.
+- **Lifespan:** montar FastMCP requiere el argumento `lifespan=` en
+  `FastAPI()` — los decoradores de eventos de arranque/apagado son incompatibles
+  con el gestor de sesiones de Streamable HTTP de FastMCP. El app.py de Voicebox
+  combina ambos en un único context manager asíncrono.
+
+Para un recorrido completo orientado a desarrolladores por la estructura del código, consulta
+`backend/mcp_server/README.md` en el repositorio.
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Personalidades de Voz" href="/overview/voice-personalities">
+    El modo personaje (`personality: true`) para agentes que deben
+    transformar el texto en personaje antes de hablar.
+  </Card>
+  <Card title="Dictado" href="/overview/dictation">
+    El indicador que muestra el habla del agente es el mismo que muestra
+    tus dictados — un único modelo mental para ambas direcciones del bucle.
+  </Card>
+  <Card title="Capturas" href="/overview/captures">
+    Cada vez que un agente inicia el habla, aparece en la pestaña Capturas con su
+    audio generado — vuelve a reproducirlo, descárgalo, reutilízalo.
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/meta.es.json
+++ b/docs/content/docs/overview/meta.es.json
@@ -1,0 +1,25 @@
+{
+  "title": "Visión general",
+  "defaultOpen": true,
+  "pages": [
+    "introduction",
+    "installation",
+    "docker",
+    "quick-start",
+    "gpu-acceleration",
+    "dictation",
+    "captures",
+    "voice-cloning",
+    "preset-voices",
+    "voice-personalities",
+    "mcp-server",
+    "stories-editor",
+    "recording-transcription",
+    "generation-history",
+    "remote-mode",
+    "creating-voice-profiles",
+    "generating-speech",
+    "building-stories",
+    "troubleshooting"
+  ]
+}

--- a/docs/content/docs/overview/preset-voices.es.mdx
+++ b/docs/content/docs/overview/preset-voices.es.mdx
@@ -15,7 +15,7 @@ Dos motores en la versión 0.4 incluyen voces de preajuste:
 | **Qwen CustomVoice**  | 9 (premium curadas)     | 4         | Control del estilo en lenguaje natural sobre tono, emoción y ritmo |
 
 <Callout type="info">
-  ¿Buscas clonar la voz de una persona concreta en su lugar? Consulta [Clonación de voz](/overview/voice-cloning).
+  ¿Buscas clonar la voz de una persona concreta en su lugar? Consulta [Clonación de voz](./voice-cloning.mdx).
 </Callout>
 
 ## Cuándo usar voces de preajuste
@@ -171,11 +171,11 @@ La página completa Generar también muestra el campo de instrucción como una e
 
 | Quieres…                                           | Usa                                       |
 | -------------------------------------------------- | ----------------------------------------- |
-| Replicar la voz de una persona concreta            | [Clonación de voz](/overview/voice-cloning) |
+| Replicar la voz de una persona concreta            | [Clonación de voz](./voice-cloning.mdx) |
 | Voces listas para producción sin preparar audio    | Kokoro o Qwen CustomVoice                 |
 | La huella más pequeña posible (solo CPU)           | Kokoro                                    |
 | Control fino de la interpretación (tono, ritmo, emoción) | Qwen CustomVoice                    |
-| La cobertura de idiomas más amplia                 | [Clonación de voz](/overview/voice-cloning) mediante Chatterbox Multilingual (23 idiomas) |
+| La cobertura de idiomas más amplia                 | [Clonación de voz](./voice-cloning.mdx) mediante Chatterbox Multilingual (23 idiomas) |
 
 ## Limitaciones
 

--- a/docs/content/docs/overview/preset-voices.es.mdx
+++ b/docs/content/docs/overview/preset-voices.es.mdx
@@ -1,0 +1,202 @@
+---
+title: "Voces de preajuste"
+description: "Usa voces integradas y listas para usar sin grabar muestras de audio"
+---
+
+## Resumen
+
+Algunos motores de Voicebox incluyen un conjunto curado de voces preconstruidas. En lugar de clonar a partir de tu propia muestra de audio, eliges una voz de un catálogo fijo y el modelo habla con esa voz. Sin grabación, sin subir nada, sin entrenamiento por voz.
+
+Dos motores en la versión 0.4 incluyen voces de preajuste:
+
+| Motor                 | Voces                   | Idiomas   | Puntos fuertes                                          |
+| --------------------- | ----------------------- | --------- | ------------------------------------------------------- |
+| **Kokoro 82M**        | 50                      | 9         | Modelo diminuto, apto para CPU, la VRAM más baja de todos los motores |
+| **Qwen CustomVoice**  | 9 (premium curadas)     | 4         | Control del estilo en lenguaje natural sobre tono, emoción y ritmo |
+
+<Callout type="info">
+  ¿Buscas clonar la voz de una persona concreta en su lugar? Consulta [Clonación de voz](/overview/voice-cloning).
+</Callout>
+
+## Cuándo usar voces de preajuste
+
+<Cards>
+  <Card title="Sin audio de referencia">
+    No tienes (o no quieres proporcionar) una grabación de la voz objetivo
+  </Card>
+  <Card title="Fiabilidad en producción">
+    Las voces curadas tienen una calidad predecible con cualquier texto de entrada
+  </Card>
+  <Card title="Velocidad">
+    Sáltate la limpieza del audio, la preparación de muestras y el ciclo de iteración de calidad
+  </Card>
+  <Card title="Configuración ligera">
+    Kokoro corre a tiempo real en CPU con ~150 MB en disco, sin necesidad de GPU
+  </Card>
+</Cards>
+
+## Crear un perfil de voz de preajuste
+
+<Steps>
+  <Step title="Abre Perfiles → Nuevo perfil">
+    El mismo punto de entrada que para los perfiles de clonación
+  </Step>
+  <Step title="Elige el motor">
+    Selecciona **Kokoro** o **Qwen CustomVoice** en el desplegable de motores
+  </Step>
+  <Step title="Elige una voz de preajuste">
+    Aparece el catálogo de voces del motor elegido — previsualiza cada una haciendo clic en ella
+  </Step>
+  <Step title="Ponle nombre y guarda">
+    Dale un nombre al perfil. No hace falta ninguna muestra de audio — solo guarda
+  </Step>
+  <Step title="Genera">
+    Usa el perfil como cualquier otro en el cuadro flotante de generación o en la página Generar
+  </Step>
+</Steps>
+
+<Callout type="info">
+  Los perfiles de preajuste están bloqueados a su motor de origen — cambiar de motor no funcionará, ya que la voz solo existe para ese modelo. La cuadrícula de perfiles atenúa los perfiles de preajuste cuando cambias a un motor distinto, y al hacer clic en uno se vuelve a cambiar automáticamente al motor correcto.
+</Callout>
+
+## Kokoro 82M — 50 voces en 9 idiomas
+
+Kokoro es el motor más pequeño de Voicebox, con 82M de parámetros. Corre a tiempo real en CPU con una VRAM insignificante, lo que lo convierte en la mejor opción para inferencia local ligera. Las voces son vectores de estilo preconstruidos entrenados dentro del modelo — aquí no existe el concepto de clonar.
+
+**Repositorio:** [`hexgrad/Kokoro-82M`](https://huggingface.co/hexgrad/Kokoro-82M) · con licencia Apache 2.0
+
+### Inglés americano
+
+| Femeninas | Masculinas |
+| --------- | ---------- |
+| Alloy     | Adam       |
+| Aoede     | Echo       |
+| Bella     | Eric       |
+| Heart     | Fenrir     |
+| Jessica   | Liam       |
+| Kore      | Michael    |
+| Nicole    | Onyx       |
+| Nova      | Puck       |
+| River     | Santa      |
+| Sarah     |            |
+| Sky       |            |
+
+### Inglés británico
+
+| Femeninas | Masculinas |
+| --------- | ---------- |
+| Alice     | Daniel     |
+| Emma      | Fable      |
+| Isabella  | George     |
+| Lily      | Lewis      |
+
+### Otros idiomas
+
+| Idioma            | Voces                                       |
+| ----------------- | ------------------------------------------- |
+| Español (`es`)    | Dora (f), Alex (m), Santa (m)               |
+| Francés (`fr`)    | Siwis (f)                                   |
+| Hindi (`hi`)      | Alpha (f), Beta (f), Omega (m), Psi (m)     |
+| Italiano (`it`)   | Sara (f), Nicola (m)                        |
+| Japonés (`ja`)    | Alpha (f), Gongitsune (f), Nezumi (f), Tebukuro (f), Kumo (m) |
+| Portugués (`pt`)  | Dora (f), Alex (m), Santa (m)               |
+| Chino (`zh`)      | Xiaobei (f), Xiaoni (f), Xiaoxiao (f), Xiaoyi (f) |
+
+### Kokoro de un vistazo
+
+| Propiedad         | Valor                                        |
+| ----------------- | -------------------------------------------- |
+| Parámetros        | 82M                                          |
+| Frecuencia de muestreo | 24 kHz                                  |
+| VRAM              | ~150 MB (insignificante en CPU)              |
+| Velocidad         | Tiempo real en CPU, más rápido en GPU        |
+| Instruct          | No compatible (la voz de preajuste lleva el estilo) |
+| Licencia          | Apache 2.0                                   |
+
+## Qwen CustomVoice — 9 voces premium con control Instruct
+
+Qwen CustomVoice incluye 9 hablantes curados y admite **control del estilo en lenguaje natural** — le dices al modelo cómo interpretar la frase ("habla despacio y con calidez", "con autoridad y claridad") y este adapta el tono, la emoción y el ritmo.
+
+Dos tamaños de modelo:
+- **1.7B** — calidad completa, predeterminado recomendado
+- **0.6B** — más ligero, más rápido, para hardware de gama baja
+
+**Repositorio:** [`Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice) (y variante 0.6B) · de Alibaba
+
+### Catálogo de voces
+
+| Hablante  | Género    | Idioma   | Descripción                                                  |
+| --------- | --------- | -------- | ------------------------------------------------------------ |
+| Vivian    | femenino  | Chino    | Voz femenina joven, brillante y con un punto atrevido        |
+| Serena    | femenino  | Chino    | Voz femenina joven, cálida y suave                           |
+| Uncle Fu  | masculino | Chino    | Voz masculina madura con un timbre grave y suave             |
+| Dylan     | masculino | Chino    | Voz masculina joven de Pekín con un timbre claro y natural   |
+| Eric      | masculino | Chino    | Voz masculina animada de Chengdu con un brillo ligeramente ronco |
+| Ryan      | masculino | Inglés   | Voz masculina dinámica con un fuerte empuje rítmico (predeterminada) |
+| Aiden     | masculino | Inglés   | Voz masculina americana radiante con un registro medio claro |
+| Ono Anna  | femenino  | Japonés  | Voz femenina japonesa juguetona con un timbre ligero y ágil  |
+| Sohee     | femenino  | Coreano  | Voz femenina coreana cálida y con mucha emoción              |
+
+### Usar el modo Instruct
+
+En el cuadro flotante de generación, cambia a un perfil de Qwen CustomVoice y haz clic en la alternancia de **instrucciones de interpretación** (icono de deslizador, a la izquierda del botón de generar). Aparece un segundo cuadro de texto debajo del texto principal:
+
+- Texto principal → lo que quieres que diga la voz
+- Texto de instrucción → cómo quieres que se interprete
+
+Ejemplos de instrucciones efectivas:
+
+```
+Speak slowly with emphasis, like reading bedtime stories
+Warm and friendly, conversational tone
+Professional and authoritative, broadcast quality
+Whisper, intimate and close
+Excited and energetic, like sports commentary
+```
+
+La página completa Generar también muestra el campo de instrucción como una entrada aparte.
+
+### Qwen CustomVoice de un vistazo
+
+| Propiedad         | Valor                                              |
+| ----------------- | -------------------------------------------------- |
+| Parámetros        | 1.7B / 0.6B                                        |
+| Idiomas           | Chino, inglés, japonés, coreano (10 compatibles)   |
+| Voces             | 9 hablantes de preajuste curados                   |
+| VRAM              | ~3.5 GB (1.7B), ~1.2 GB (0.6B)                     |
+| Instruct          | Sí — control del estilo en lenguaje natural        |
+| Clonación         | No — el motor emparejado Base Qwen3-TTS gestiona la clonación |
+
+## Clonación frente a preajuste — decisión rápida
+
+| Quieres…                                           | Usa                                       |
+| -------------------------------------------------- | ----------------------------------------- |
+| Replicar la voz de una persona concreta            | [Clonación de voz](/overview/voice-cloning) |
+| Voces listas para producción sin preparar audio    | Kokoro o Qwen CustomVoice                 |
+| La huella más pequeña posible (solo CPU)           | Kokoro                                    |
+| Control fino de la interpretación (tono, ritmo, emoción) | Qwen CustomVoice                    |
+| La cobertura de idiomas más amplia                 | [Clonación de voz](/overview/voice-cloning) mediante Chatterbox Multilingual (23 idiomas) |
+
+## Limitaciones
+
+<Callout type="warn">
+  Las voces de preajuste son fijas — no puedes ajustarlas ni modificar la voz subyacente. Si quieres una voz concreta que no está en el catálogo, usa un motor de clonación y proporciona una muestra de referencia.
+</Callout>
+
+- Las voces de preajuste no se pueden exportar como audio para usarlas en otras instalaciones de Voicebox (solo como metadatos de perfil que apuntan al mismo motor + ID de voz)
+- El catálogo de voces de Kokoro lo define el modelo original — aparecen voces nuevas solo cuando hexgrad publica nuevas versiones del modelo
+- Los 9 hablantes de Qwen CustomVoice forman parte del checkpoint del modelo — la misma restricción
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Clonación de voz" href="/overview/voice-cloning">
+    Clona una voz concreta a partir de tu propio audio
+  </Card>
+  <Card title="Generar voz" href="/overview/generating-speech">
+    Usa un perfil para generar audio
+  </Card>
+  <Card title="Crear historias" href="/overview/building-stories">
+    Compón narraciones con varias voces
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/quick-start.es.mdx
+++ b/docs/content/docs/overview/quick-start.es.mdx
@@ -1,0 +1,164 @@
+---
+title: "Inicio rápido"
+description: "Empieza con Voicebox en 5 minutos"
+---
+
+Esta guía te llevará paso a paso por la creación de tu primer perfil de voz y la generación de voz.
+
+## Requisitos previos
+
+Asegúrate de haber [instalado Voicebox](/overview/installation) e iniciado la app.
+
+## Paso 1: Crea un perfil de voz
+
+Los perfiles de voz son la base de Voicebox. Cada perfil contiene muestras de voz que la IA usa para clonar la voz.
+
+<Steps>
+  <Step title="Ve a Perfiles">
+    Haz clic en la pestaña **Perfiles** en la barra lateral
+  </Step>
+
+  <Step title="Crea un perfil nuevo">
+    Haz clic en el botón **+ Nuevo perfil**
+
+    Rellena los detalles:
+    - **Nombre:** Un nombre descriptivo (p. ej., "John Smith")
+    - **Idioma:** Selecciona el idioma principal
+    - **Descripción:** Notas opcionales sobre la voz
+  </Step>
+
+  <Step title="Añade una muestra de voz">
+    Tienes dos opciones:
+
+    **Opción A: Subir audio**
+    - Haz clic en **Subir muestra**
+    - Selecciona un archivo de audio (WAV, MP3 o M4A)
+    - Duración ideal: 10-30 segundos de habla clara
+
+    **Opción B: Grabar en directo**
+    - Haz clic en **Grabar muestra**
+    - Habla con claridad durante 10-30 segundos
+    - Haz clic en detener cuando termines
+  </Step>
+
+  <Step title="Guarda el perfil">
+    Haz clic en **Crear perfil** para guardar
+  </Step>
+</Steps>
+
+<Callout type="info">
+  Para obtener mejores resultados, usa audio limpio con el mínimo ruido de fondo y un tono de habla constante.
+</Callout>
+
+## Paso 2: Genera voz
+
+Ahora usemos tu nuevo perfil de voz para generar voz.
+
+<Steps>
+  <Step title="Ve a Generación">
+    Haz clic en la pestaña **Generar** en la barra lateral
+  </Step>
+
+  <Step title="Selecciona el perfil de voz">
+    Elige el perfil que acabas de crear en el desplegable
+  </Step>
+
+  <Step title="Introduce el texto">
+    Escribe o pega el texto que quieres generar:
+
+    ```
+    Hello! This is my first voice generation with Voicebox.
+    ```
+
+    <Callout type="info">
+      Las etiquetas paralingüísticas como `[laugh]`, `[sigh]` y `[gasp]` solo
+      funcionan con **Chatterbox Turbo**. Qwen3-TTS, LuxTTS, Chatterbox Multilingual y
+      HumeAI TADA leerán esas etiquetas literalmente en lugar de convertirlas en
+      sonidos expresivos.
+    </Callout>
+
+    Para insertar etiquetas compatibles, selecciona **Chatterbox Turbo** y escribe `/` en el
+    campo de texto para abrir el insertador de etiquetas.
+  </Step>
+
+  <Step title="Genera">
+    Haz clic en **Generar** y espera unos segundos
+
+    <Callout type="info">
+      La primera generación puede tardar más debido a la inicialización del modelo. Las generaciones siguientes serán más rápidas.
+    </Callout>
+  </Step>
+
+  <Step title="Reproduce y descarga">
+    - Haz clic en **Reproducir** para previsualizar el audio
+    - Haz clic en **Descargar** para guardar el archivo de audio
+    - La generación también se guarda en tu **Historial**
+  </Step>
+</Steps>
+
+## Paso 3: Construye una historia (opcional)
+
+El editor de historias te permite crear narrativas con varias voces mediante una interfaz basada en una línea de tiempo.
+
+<Steps>
+  <Step title="Crea una historia nueva">
+    Ve a **Historias** y haz clic en **+ Nueva historia**
+  </Step>
+
+  <Step title="Añade pistas de voz">
+    Haz clic en **+ Añadir pista** para crear pistas de distintos hablantes
+  </Step>
+
+  <Step title="Añade clips de audio">
+    - Arrastra audio generado desde tu Historial
+    - O genera nuevos clips directamente en la línea de tiempo
+    - Organiza los clips en la línea de tiempo
+  </Step>
+
+  <Step title="Edita y exporta">
+    - Recorta los clips arrastrando sus extremos
+    - Ajusta la sincronización y el espaciado
+    - Haz clic en **Exportar** para renderizar el audio final
+  </Step>
+</Steps>
+
+## ¿Y ahora qué?
+
+<Cards>
+  <Card title="Guía de clonación de voz" href="/overview/creating-voice-profiles">
+    Aprende técnicas avanzadas para clonar voz con alta calidad
+  </Card>
+  <Card title="Integración con la API" href="/api-reference">
+    Integra Voicebox en tus propias aplicaciones
+  </Card>
+  <Card title="Editor de historias" href="/overview/stories-editor">
+    Domina el editor de línea de tiempo multipista
+  </Card>
+  <Card title="Modo remoto" href="/overview/remote-mode">
+    Conéctate a un servidor con GPU para generar más rápido
+  </Card>
+</Cards>
+
+## Consejos para tener éxito
+
+<AccordionGroup>
+  <Accordion title="Obtener la mejor calidad de voz">
+    - Usa 10-30 segundos de habla clara y constante
+    - Evita el ruido de fondo y el eco
+    - Varias muestras del mismo hablante mejoran la calidad
+    - Imita el estilo de habla que quieres generar
+  </Accordion>
+
+  <Accordion title="Mejorar la velocidad de generación">
+    - Usa una GPU compatible con CUDA para generar de 5 a 10 veces más rápido
+    - Activa la caché del prompt de voz para generaciones repetidas
+    - Considera ejecutar el backend en un servidor con GPU remoto
+  </Accordion>
+
+  <Accordion title="Solución de problemas comunes">
+    - **El servidor no arranca:** Comprueba si el puerto 17493 está disponible
+    - **Mala calidad de audio:** Prueba a añadir más muestras de voz
+    - **Generación lenta:** Verifica que la aceleración por GPU está activada
+    - Consulta la [guía de solución de problemas](/overview/troubleshooting) completa para más información
+  </Accordion>
+</AccordionGroup>

--- a/docs/content/docs/overview/quick-start.es.mdx
+++ b/docs/content/docs/overview/quick-start.es.mdx
@@ -7,7 +7,7 @@ Esta guía te llevará paso a paso por la creación de tu primer perfil de voz y
 
 ## Requisitos previos
 
-Asegúrate de haber [instalado Voicebox](/overview/installation) e iniciado la app.
+Asegúrate de haber [instalado Voicebox](./installation.mdx) e iniciado la app.
 
 ## Paso 1: Crea un perfil de voz
 
@@ -159,6 +159,6 @@ El editor de historias te permite crear narrativas con varias voces mediante una
     - **El servidor no arranca:** Comprueba si el puerto 17493 está disponible
     - **Mala calidad de audio:** Prueba a añadir más muestras de voz
     - **Generación lenta:** Verifica que la aceleración por GPU está activada
-    - Consulta la [guía de solución de problemas](/overview/troubleshooting) completa para más información
+    - Consulta la [guía de solución de problemas](./troubleshooting.mdx) completa para más información
   </Accordion>
 </AccordionGroup>

--- a/docs/content/docs/overview/recording-transcription.es.mdx
+++ b/docs/content/docs/overview/recording-transcription.es.mdx
@@ -11,9 +11,9 @@ enlaces para ver el detalle.
 
 | Objetivo | Dónde | Documentación |
 |---|---|---|
-| Hablar y que tus palabras aterricen en otra app | Atajo global → pestaña Capturas + pegado automático | [Dictado](/overview/dictation) |
-| Grabar una idea, una reunión o una nota de voz dentro de Voicebox | Pestaña Capturas | [Capturas](/overview/captures) |
-| Grabar un clip del que clonar una voz | Pestaña Voces → muestras de perfil | [Crear perfiles de voz](/overview/creating-voice-profiles) |
+| Hablar y que tus palabras aterricen en otra app | Atajo global → pestaña Capturas + pegado automático | [Dictado](./dictation.mdx) |
+| Grabar una idea, una reunión o una nota de voz dentro de Voicebox | Pestaña Capturas | [Capturas](./captures.mdx) |
+| Grabar un clip del que clonar una voz | Pestaña Voces → muestras de perfil | [Crear perfiles de voz](./creating-voice-profiles.mdx) |
 
 Las tres vías comparten el mismo backend STT — lo que difiere es el flujo de
 trabajo que las rodea.
@@ -26,7 +26,7 @@ enfocado, depurada por un LLM local si tienes activado el refinamiento automáti
 Las capturas se acumulan en la pestaña Capturas para reproducirlas o retranscribirlas
 más tarde.
 
-Se cubre de principio a fin en [Dictado](/overview/dictation).
+Se cubre de principio a fin en [Dictado](./dictation.mdx).
 
 ## Pestaña Capturas
 
@@ -37,7 +37,7 @@ que ya aterrizaron ahí. Cada captura conserva su audio original, puede retransc
 con un modelo diferente y puede reproducirse a través de cualquier perfil de voz
 que tengas.
 
-Se cubre en [Capturas](/overview/captures).
+Se cubre en [Capturas](./captures.mdx).
 
 ## Muestras de perfil de voz
 
@@ -51,7 +51,7 @@ Puedes promover una captura a muestra desde el menú Enviar a de la pestaña Cap
 referencia para que puedas corregir el último ~10% de precisión de la transcripción
 antes de guardar.
 
-Se cubre en [Crear perfiles de voz](/overview/creating-voice-profiles).
+Se cubre en [Crear perfiles de voz](./creating-voice-profiles.mdx).
 
 ## Modelos de transcripción
 
@@ -91,7 +91,7 @@ preprocesamiento y el endpoint `/transcribe` vive en la
 [guía de transcripción para desarrolladores](/developer/transcription). El pipeline
 de Capturas también expone `/captures` como un endpoint de más alto nivel que envuelve
 STT + archivado + refinamiento opcional en una sola llamada — consulta
-[Capturas](/overview/captures#api-surface).
+[Capturas](./captures.mdx#api-surface).
 
 ## Próximos pasos
 

--- a/docs/content/docs/overview/recording-transcription.es.mdx
+++ b/docs/content/docs/overview/recording-transcription.es.mdx
@@ -1,0 +1,108 @@
+---
+title: "Grabación y transcripción"
+description: "Un mapa de los tres lugares donde puedes grabar y transcribir audio en Voicebox — dictado, capturas y muestras de perfil de voz."
+---
+
+## Visión general
+
+Voicebox graba y transcribe audio en tres contextos diferentes, cada uno
+alimentando una superficie distinta de la app. Esta página es un mapa; sigue los
+enlaces para ver el detalle.
+
+| Objetivo | Dónde | Documentación |
+|---|---|---|
+| Hablar y que tus palabras aterricen en otra app | Atajo global → pestaña Capturas + pegado automático | [Dictado](/overview/dictation) |
+| Grabar una idea, una reunión o una nota de voz dentro de Voicebox | Pestaña Capturas | [Capturas](/overview/captures) |
+| Grabar un clip del que clonar una voz | Pestaña Voces → muestras de perfil | [Crear perfiles de voz](/overview/creating-voice-profiles) |
+
+Las tres vías comparten el mismo backend STT — lo que difiere es el flujo de
+trabajo que las rodea.
+
+## Dictado
+
+La función estrella de la 0.5.0. Mantén pulsado un acorde en cualquier parte de tu
+máquina, habla, suelta. La transcripción aterriza en el campo de texto que tuvieras
+enfocado, depurada por un LLM local si tienes activado el refinamiento automático.
+Las capturas se acumulan en la pestaña Capturas para reproducirlas o retranscribirlas
+más tarde.
+
+Se cubre de principio a fin en [Dictado](/overview/dictation).
+
+## Pestaña Capturas
+
+Cuando no necesitas pegar en otra app — solo quieres una transcripción limpia de
+algún audio — la pestaña Capturas es su hogar. Graba dentro de la app, suelta un
+archivo (`.wav`, `.mp3`, `.m4a`, `.webm`, `.opus`, `.flac`), o revisa los dictados
+que ya aterrizaron ahí. Cada captura conserva su audio original, puede retranscribirse
+con un modelo diferente y puede reproducirse a través de cualquier perfil de voz
+que tengas.
+
+Se cubre en [Capturas](/overview/captures).
+
+## Muestras de perfil de voz
+
+Un flujo aparte, en la pestaña Voces. Cuando estás creando un perfil a partir de un
+clip de audio, la muestra es de lo que realmente aprende el motor de clonado —
+el `reference_text` de una muestra debe coincidir con el audio *al pie de la letra*,
+y por eso las muestras son un modelo de datos distinto al de las capturas.
+
+Puedes promover una captura a muestra desde el menú Enviar a de la pestaña Capturas
+("Usar como muestra de voz…"), que abre un diálogo de confirmación del texto de
+referencia para que puedas corregir el último ~10% de precisión de la transcripción
+antes de guardar.
+
+Se cubre en [Crear perfiles de voz](/overview/creating-voice-profiles).
+
+## Modelos de transcripción
+
+Las tres vías comparten los mismos modelos de Whisper. Elige uno por defecto en
+**Ajustes → Capturas → Transcripción**; anúlalo por captura si lo necesitas.
+
+| Modelo | Tamaño | Cuándo elegirlo |
+|---|---|---|
+| Whisper Base | ~300 MB | Rápido. Por defecto. Bueno para habla limpia. |
+| Whisper Small | ~500 MB | Mejor calidad, aún rápido. |
+| Whisper Medium | ~1.5 GB | Alta calidad. |
+| Whisper Large | ~3 GB | La mejor calidad, lento en CPU. |
+| Whisper Turbo | ~1.5 GB | Calidad de nivel Large, ~5× más rápido que Large. |
+
+En Apple Silicon el modelo corre a través de **MLX-Whisper** (~8× más rápido que
+PyTorch). En el resto de plataformas corre a través de `transformers` de PyTorch. El
+backend elige el correcto — tú no lo configuras.
+
+<Callout type="info">
+  Para clips ruidosos, prefiere **Turbo** o **Large**. Base puede alucinar con
+  entradas difíciles — el caso más famoso es el bucle "thanks for watching". Voicebox
+  elimina esos bucles de forma determinista antes de que corra el refinamiento por LLM,
+  de modo que una captura puede re-refinarse limpiamente aunque la transcripción en
+  bruto los contenga.
+</Callout>
+
+## Idioma
+
+Puedes pasar una pista de idioma para clips cortos (de menos de ~5 segundos) donde
+la detección automática de Whisper no es fiable. Establece un bloqueo de idioma por
+defecto en **Ajustes → Capturas → Transcripción → Idioma**, o anúlalo por captura.
+
+## API de transcripción
+
+El detalle a nivel de desarrollador sobre el backend STT, la carga de modelos, el
+preprocesamiento y el endpoint `/transcribe` vive en la
+[guía de transcripción para desarrolladores](/developer/transcription). El pipeline
+de Capturas también expone `/captures` como un endpoint de más alto nivel que envuelve
+STT + archivado + refinamiento opcional en una sola llamada — consulta
+[Capturas](/overview/captures#api-surface).
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Dictado" href="/overview/dictation">
+    Mantén pulsado un acorde en cualquier parte de tu máquina, habla, suelta.
+  </Card>
+  <Card title="Capturas" href="/overview/captures">
+    El archivo emparejado de audio + transcripción.
+  </Card>
+  <Card title="Crear perfiles de voz" href="/overview/creating-voice-profiles">
+    Graba o sube muestras para clonado de voz.
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/remote-mode.es.mdx
+++ b/docs/content/docs/overview/remote-mode.es.mdx
@@ -143,4 +143,4 @@ Rendimiento esperado en varias GPUs:
 
 ## Resolución de problemas
 
-Consulta la [Guía de resolución de problemas](/overview/troubleshooting) para problemas comunes.
+Consulta la [Guía de resolución de problemas](./troubleshooting.mdx) para problemas comunes.

--- a/docs/content/docs/overview/remote-mode.es.mdx
+++ b/docs/content/docs/overview/remote-mode.es.mdx
@@ -1,0 +1,146 @@
+---
+title: "Modo remoto"
+description: "Conéctate a un servidor GPU para una generación más rápida"
+---
+
+## Visión general
+
+El modo remoto te permite ejecutar el backend de Voicebox en una máquina aparte (como un servidor GPU) mientras usas la aplicación de escritorio en tu máquina local.
+
+## Casos de uso
+
+- **Sin GPU local** - Usa una GPU en la nube o una estación de trabajo remota
+- **Generación más rápida** - Aprovecha hardware remoto potente
+- **Infraestructura compartida** - Varios usuarios se conectan a un solo servidor
+- **Flujos de trabajo con portátil** - Mantén tu portátil fresco y ahorra batería
+
+## Arquitectura
+
+En el modo remoto, la aplicación de escritorio de Voicebox (que se ejecuta en tu máquina local) se comunica con el servidor backend (que se ejecuta en una máquina remota) vía HTTP. La aplicación local solo proporciona la interfaz de usuario, mientras que el servidor remoto gestiona todo el procesamiento pesado, incluidos los modelos TTS, los endpoints de la API y la generación de audio.
+
+## Configurar el modo remoto
+
+### En el servidor
+
+<Steps>
+  <Step title="Instalar dependencias">
+    ```bash
+    # Clone the repo
+    git clone https://github.com/jamiepine/voicebox.git
+    cd voicebox/backend
+
+    # Install Python dependencies
+    pip install -r requirements.txt
+
+    # Engines with incompatible transitive pins — install with --no-deps
+    pip install --no-deps chatterbox-tts
+    pip install --no-deps hume-tada
+
+    # Qwen3-TTS from source
+    pip install git+https://github.com/QwenLM/Qwen3-TTS.git
+    ```
+
+    O simplemente ejecuta `just setup` desde la raíz del repositorio, que se encarga de todo esto.
+  </Step>
+
+  <Step title="Iniciar el servidor">
+    ```bash
+    # Allow external connections
+    uvicorn main:app --host 0.0.0.0 --port 17493
+    ```
+
+    <Callout type="warn">
+      Esto expone el servidor a tu red. Usa un firewall o una VPN por seguridad.
+    </Callout>
+  </Step>
+
+  <Step title="Abrir el firewall">
+    ```bash
+    # Ubuntu/Debian
+    sudo ufw allow 17493
+
+    # Or use your cloud provider's firewall settings
+    ```
+  </Step>
+</Steps>
+
+### En el cliente
+
+<Steps>
+  <Step title="Abrir Ajustes">
+    En Voicebox, ve a **Ajustes → Servidor**
+  </Step>
+
+  <Step title="Activar el modo remoto">
+    Activa **Usar servidor remoto**
+  </Step>
+
+  <Step title="Introducir la URL del servidor">
+    ```
+    http://<server-ip>:17493
+    ```
+
+    Reemplaza `<server-ip>` por la dirección IP de tu servidor
+  </Step>
+
+  <Step title="Probar la conexión">
+    Haz clic en **Probar conexión** para verificar
+  </Step>
+</Steps>
+
+## Despliegue en la nube
+
+### AWS EC2
+
+```bash
+# Launch a GPU instance (e.g., g4dn.xlarge)
+# Install dependencies
+# Start server with --host 0.0.0.0
+```
+
+### Vast.ai
+
+```bash
+# Rent a GPU instance
+# SSH in and clone repo
+# Start server
+```
+
+### RunPod
+
+```bash
+# Deploy a pod with CUDA support
+# Install Voicebox backend
+# Expose port 17493
+```
+
+## Consideraciones de seguridad
+
+<Callout type="warn">
+  La API actualmente no tiene autenticación. Úsala solo en redes de confianza o con una VPN.
+</Callout>
+
+**Buenas prácticas:**
+- Usa una VPN (WireGuard, Tailscale) en lugar de exponerla a internet
+- Ejecútala detrás de un proxy inverso con autenticación (nginx + autenticación básica)
+- Usa HTTPS con certificados SSL
+- Reglas de firewall para limitar el acceso a IPs específicas
+
+## Rendimiento
+
+Rendimiento esperado en varias GPUs:
+
+| GPU | Velocidad de generación |
+|-----|------------------|
+| RTX 4090 | ~2-3s por cada 10 palabras |
+| RTX 3090 | ~3-4s por cada 10 palabras |
+| RTX 3060 | ~5-7s por cada 10 palabras |
+| CPU (12 núcleos) | ~20-30s por cada 10 palabras |
+
+<Callout type="info">
+  Se recomienda una GPU con 8GB+ de VRAM para obtener el mejor rendimiento.
+</Callout>
+
+## Resolución de problemas
+
+Consulta la [Guía de resolución de problemas](/overview/troubleshooting) para problemas comunes.

--- a/docs/content/docs/overview/stories-editor.es.mdx
+++ b/docs/content/docs/overview/stories-editor.es.mdx
@@ -1,0 +1,64 @@
+---
+title: "Editor de Historias"
+description: "Crea narrativas multivoz con un editor basado en línea de tiempo"
+---
+
+## Resumen
+
+El Editor de Historias es una interfaz de línea de tiempo tipo DAW para crear narrativas multivoz, pódcasts y conversaciones.
+
+## Características
+
+<Cards>
+  <Card title="Línea de tiempo multipista">
+    Organiza varias pistas de voz en paralelo
+  </Card>
+  <Card title="Edición en línea">
+    Recorta y divide clips directamente en la línea de tiempo
+  </Card>
+  <Card title="Reproducción automática">
+    Previsualiza con un cabezal sincronizado
+  </Card>
+  <Card title="Mezcla de voces">
+    Construye conversaciones con varios locutores
+  </Card>
+</Cards>
+
+## Crear una historia
+
+<Steps>
+  <Step title="Crear historia nueva">
+    Ve a **Stories** y haz clic en **+ New Story**
+  </Step>
+  <Step title="Añadir pistas">
+    Crea pistas separadas para cada voz/locutor
+  </Step>
+  <Step title="Añadir clips">
+    - Arrastra desde el historial de generación
+    - Genera clips nuevos en línea
+    - Sube archivos de audio
+  </Step>
+  <Step title="Organizar y editar">
+    - Coloca los clips en la línea de tiempo
+    - Recorta los bordes de los clips
+    - Ajusta el espaciado y la sincronización
+  </Step>
+  <Step title="Exportar">
+    Renderiza el audio mezclado final
+  </Step>
+</Steps>
+
+## Casos de uso
+
+- **Pódcasts**: Conversaciones con varios presentadores
+- **Audiolibros**: Voz del narrador + voces de personajes
+- **Diálogos de videojuegos**: Interacciones entre personajes
+- **Voces en off para vídeo**: Varios locutores
+- **Drama de audio**: Repartos de voces completos
+
+## Próximamente
+
+- Edición a nivel de palabra
+- Fundidos cruzados y transiciones
+- Efectos de audio (reverberación, ecualización)
+- Colaboración en tiempo real

--- a/docs/content/docs/overview/troubleshooting.es.mdx
+++ b/docs/content/docs/overview/troubleshooting.es.mdx
@@ -1,0 +1,596 @@
+---
+title: "Resolución de problemas"
+description: "Problemas comunes y soluciones para Voicebox"
+---
+
+Esta guía cubre los problemas comunes que podrías encontrar al usar o desarrollar Voicebox, junto con sus soluciones.
+
+## Problemas de instalación
+
+### macOS: "La app está dañada y no se puede abrir"
+
+Esto ocurre porque la app no está firmada con un certificado de Apple Developer.
+
+**Solución:**
+```bash
+# Remove the quarantine attribute
+xattr -cr /Applications/Voicebox.app
+```
+
+### Windows: aviso de SmartScreen
+
+Windows SmartScreen puede avisar de que la app no está reconocida.
+
+**Solución:**
+- Haz clic en "Más información"
+- Haz clic en "Ejecutar de todas formas"
+
+<Callout type="info">
+  Esto es lo esperado para aplicaciones sin firmar. Estamos trabajando en la firma de código para futuras versiones.
+</Callout>
+
+### Linux: el AppImage no se ejecuta
+
+**Solución:**
+```bash
+chmod +x voicebox-*.AppImage
+./voicebox-*.AppImage
+```
+
+## Problemas del servidor
+
+### El servidor backend no arranca
+
+**Síntomas:**
+- Indicador de estado en rojo en la esquina inferior izquierda
+- Error "Failed to connect to server"
+
+**Soluciones:**
+
+<AccordionGroup>
+  <Accordion title="El puerto ya está en uso">
+    Comprueba si el puerto 17493 ya está en uso:
+
+    ```bash
+    # macOS/Linux
+    lsof -i :17493
+
+    # Windows
+    powershell -Command "Get-NetTCPConnection -LocalPort 17493 -State Listen"
+    ```
+
+    Termina el proceso que está usando el puerto:
+    ```bash
+    # macOS/Linux
+    kill -9 <PID>
+
+    # Windows
+    taskkill /PID <PID> /F
+    ```
+  </Accordion>
+
+  <Accordion title="Problemas de permisos">
+    Puede que el binario del servidor no tenga permisos de ejecución:
+
+    ```bash
+    # macOS/Linux
+    chmod +x ~/Library/Application\ Support/sh.voicebox.app/backend/voicebox-server
+    ```
+  </Accordion>
+
+  <Accordion title="Revisar los registros">
+    Consulta los registros del servidor para ver errores:
+
+    **macOS:**
+    ```bash
+    tail -f ~/Library/Application\ Support/sh.voicebox.app/logs/server.log
+    ```
+
+    **Windows:**
+    ```bash
+    type %APPDATA%\sh.voicebox.app\logs\server.log
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Aviso `flash-attn is not installed` en los registros del servidor
+
+**Síntomas:**
+```
+Warning: flash-attn is not installed. Will only run the manual PyTorch version.
+Please install flash-attn for faster inference.
+```
+
+**Esto es inofensivo.** El aviso lo emiten nuestros motores basados en transformers (Chatterbox / Qwen) en cada arranque. FlashAttention es una librería de aceleración opcional: cuando no está presente, se ejecuta en su lugar la atención de producto escalar escalado (SDPA) integrada de PyTorch, que ofrece un rendimiento casi igual al de FA2 en las GPU modernas. La generación funciona con normalidad.
+
+**Por qué aparece en todas las plataformas:**
+- **Windows:** `flash-attn` no tiene soporte oficial para Windows. El proyecto original (Dao-AILab/flash-attention) sigue diciendo solo que *podría* funcionar, y las compilaciones desde el código fuente suelen fallar con combinaciones recientes de CUDA/MSVC.
+- **macOS (Apple Silicon):** FlashAttention es exclusivo de CUDA y aquí no aplica en absoluto. MLX tiene sus propios kernels de atención optimizados.
+- **Linux:** No está fijado en nuestros requisitos porque instalarlo es frágil y sensible a la versión; quienes lo quieren lo instalan por su cuenta.
+
+**Soluciones (todas opcionales):**
+
+<AccordionGroup>
+  <Accordion title="Ignóralo (recomendado)">
+    PyTorch SDPA es lo que realmente ejecuta el modelo, y en las GPU Ampere/Ada/Hopper está a un pequeño porcentaje de FA2 para nuestras cargas de trabajo. No notarás una diferencia de velocidad significativa.
+  </Accordion>
+
+  <Accordion title="Instalar flash-attn en Linux">
+    ```bash
+    pip install flash-attn --no-build-isolation
+    ```
+
+    Requiere un toolkit de CUDA compatible. La compilación puede tardar más de 20 minutos.
+  </Accordion>
+
+  <Accordion title="Instalar flash-attn en Windows (wheels de la comunidad)">
+    No existen compilaciones oficiales, pero mantenedores de la comunidad publican wheels precompiladas:
+
+    - [kingbri1/flash-attention releases](https://github.com/kingbri1/flash-attention/releases)
+    - [bdashore3/flash-attention releases](https://github.com/bdashore3/flash-attention/releases)
+
+    Elige la wheel que coincida con tu combinación exacta de CUDA + PyTorch + Python. Ejemplo:
+
+    ```bash
+    pip install https://github.com/kingbri1/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu128torch2.8.0cxx11abiFALSE-cp312-cp312-win_amd64.whl
+    ```
+
+    Alternativamente, ejecuta el backend de Voicebox dentro de WSL2 y usa las wheels estándar de Linux.
+  </Accordion>
+</AccordionGroup>
+
+### Tiempo de espera de conexión agotado
+
+**Síntomas:**
+- Tiempos de carga largos
+- Errores de "Connection timeout"
+
+**Solución:**
+- Reinicia la app
+- Comprueba la configuración de tu cortafuegos
+- Asegúrate de que localhost sea accesible
+
+## Problemas de generación
+
+### La primera generación es muy lenta
+
+**Síntomas:**
+- La primera generación tarda de 2 a 5 minutos
+- El indicador de progreso se queda en "Loading model..."
+
+**Explicación:**
+Este es el comportamiento esperado. La primera generación descarga el modelo del motor de TTS seleccionado y lo inicializa. Los tamaños van desde 350 MB (Kokoro) hasta 8 GB (TADA 3B).
+
+**Solución:**
+- Espera a que termine la descarga inicial (el progreso se muestra en Ajustes → Models)
+- Las generaciones siguientes reutilizan el modelo en caché y son mucho más rápidas
+- Comprueba tu conexión a internet
+- Para configuraciones con poco ancho de banda, empieza con Kokoro (~350 MB) o LuxTTS (~300 MB)
+
+### Mala calidad de voz
+
+**Síntomas:**
+- Voz robótica o poco natural
+- Falta de emoción o prosodia
+- Errores de pronunciación
+
+**Soluciones:**
+
+<Steps>
+  <Step title="Mejorar las muestras de voz">
+    - Usa de 10 a 30 segundos de audio claro
+    - Evita el ruido de fondo
+    - Asegura un tono de habla constante
+    - Añade varias muestras del mismo hablante
+  </Step>
+
+  <Step title="Igualar el estilo de habla">
+    La voz generada imitará el tono y el estilo de tus muestras. Si tu muestra es monótona, la generación también lo será.
+  </Step>
+
+  <Step title="Ajustar el formato del texto">
+    - Usa una puntuación adecuada
+    - Añade comas para hacer pausas naturales
+    - Escribe los nombres propios en mayúsculas
+  </Step>
+</Steps>
+
+### La generación falla con "Out of Memory"
+
+**Síntomas:**
+- La generación se bloquea
+- "CUDA out of memory" o "RuntimeError: out of memory"
+
+**Soluciones:**
+
+<AccordionGroup>
+  <Accordion title="Liberar memoria de la GPU">
+    Cierra otras aplicaciones que hagan un uso intensivo de la GPU:
+    - Juegos
+    - Editores de vídeo
+    - Múltiples pestañas del navegador con WebGL
+
+    Después reinicia Voicebox.
+  </Accordion>
+
+  <Accordion title="Usar el modo CPU">
+    Si tu GPU no tiene suficiente VRAM (se necesitan más de 6 GB), usa el modo CPU:
+
+    Ajustes → Generation → Use CPU instead of GPU
+
+    <Callout type="warn">
+      La generación con CPU es de 5 a 10 veces más lenta, pero usa la RAM del sistema en lugar de la VRAM.
+    </Callout>
+  </Accordion>
+
+  <Accordion title="Reducir el tamaño del lote">
+    Para textos largos, divídelos en fragmentos más pequeños en lugar de generarlo todo de una vez.
+  </Accordion>
+</AccordionGroup>
+
+### MLX "Failed to load the default metallib" (Apple Silicon)
+
+**Síntomas:**
+- La generación falla con errores de "library not found" o "metallib"
+- Los registros del servidor mencionan librerías de shaders de Metal que faltan
+
+**Soluciones:**
+
+<AccordionGroup>
+  <Accordion title="Recompilar el binario del servidor">
+    ```bash
+    just build-server
+    ```
+
+    El script de compilación empaqueta automáticamente las librerías de shaders de Metal de MLX en Apple Silicon.
+  </Accordion>
+
+  <Accordion title="Reinstalar las dependencias de MLX">
+    ```bash
+    pip install -r backend/requirements-mlx.txt
+    ```
+  </Accordion>
+
+  <Accordion title="Verificar la detección del backend">
+    Consulta Ajustes → Server Status. Debería mostrar **Backend: MLX** en Apple Silicon. Si muestra **Backend: PYTORCH**, MLX no está instalado correctamente.
+  </Accordion>
+</AccordionGroup>
+
+## Problemas de audio
+
+### No hay reproducción de audio
+
+**Síntomas:**
+- El audio generado no se reproduce
+- El botón de reproducción no responde
+
+**Soluciones:**
+- Comprueba la configuración de audio del sistema
+- Asegúrate de que el dispositivo de salida de audio esté conectado
+- Prueba a exportarlo y reproducirlo en un reproductor multimedia
+
+### Audio con crujidos o distorsionado
+
+**Síntomas:**
+- El audio tiene estática o distorsión
+- Sonidos de recorte (clipping)
+
+**Soluciones:**
+- Comprueba si tus muestras de entrada tienen distorsión
+- Baja el volumen de reproducción
+- Vuelve a generar con muestras de voz más limpias
+
+## Problemas de desarrollo
+
+### El backend no arranca en modo desarrollo
+
+**Síntomas:**
+- `just dev-backend` o `just dev` falla
+- Errores de importación o módulo no encontrado
+
+**Soluciones:**
+
+<AccordionGroup>
+  <Accordion title="Versión de Python">
+    Asegúrate de tener Python 3.11 o superior:
+
+    ```bash
+    python --version
+    ```
+
+    Si no es así, instala Python 3.11+ y vuelve a crear el entorno virtual.
+  </Accordion>
+
+  <Accordion title="Entorno virtual">
+    Asegúrate de que el venv esté activado:
+
+    ```bash
+    # macOS/Linux
+    source backend/venv/bin/activate
+
+    # Windows
+    backend\venv\Scripts\activate
+    ```
+
+    Deberías ver `(venv)` en tu prompt.
+  </Accordion>
+
+  <Accordion title="Dependencias">
+    Reinstala las dependencias; lo más fácil es mediante `just`:
+
+    ```bash
+    just setup
+    ```
+
+    O manualmente:
+
+    ```bash
+    cd backend
+    pip install -r requirements.txt
+    pip install --no-deps chatterbox-tts
+    pip install --no-deps hume-tada
+    pip install git+https://github.com/QwenLM/Qwen3-TTS.git
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### La compilación de Tauri falla
+
+**Síntomas:**
+- `bun run tauri build` falla
+- Errores de compilación de Rust
+
+**Soluciones:**
+
+```bash
+# Clean build artifacts
+cd tauri/src-tauri
+cargo clean
+
+# Update Rust
+rustup update
+
+# Try building again
+cd ../..
+bun run tauri build
+```
+
+### La generación del cliente de OpenAPI falla
+
+**Síntomas:**
+- `./scripts/generate-api.sh` falla
+- Error "Failed to fetch schema"
+
+**Soluciones:**
+
+<Steps>
+  <Step title="Asegúrate de que el backend esté en ejecución">
+    ```bash
+    curl http://localhost:17493/openapi.json
+    ```
+
+    Debería devolver JSON. Si no, arranca el backend.
+  </Step>
+
+  <Step title="Comprobar el puerto">
+    Asegúrate de que nada más esté usando el puerto 17493
+  </Step>
+
+  <Step title="Regenerar manualmente">
+    ```bash
+    cd backend
+    source venv/bin/activate
+    uvicorn main:app --reload --port 17493
+
+    # In another terminal
+    ./scripts/generate-api.sh
+    ```
+  </Step>
+</Steps>
+
+## Problemas de base de datos
+
+### Error "Database is locked"
+
+**Síntomas:**
+- Las operaciones de perfil o generación fallan
+- Errores de bloqueo de SQLite
+
+**Soluciones:**
+- Cierra todas las instancias de Voicebox
+- Elimina el archivo de bloqueo:
+  ```bash
+  # macOS
+  rm ~/Library/Application\ Support/sh.voicebox.app/data/voicebox.db-shm
+  rm ~/Library/Application\ Support/sh.voicebox.app/data/voicebox.db-wal
+  ```
+
+### Base de datos corrupta
+
+**Síntomas:**
+- La app se bloquea al iniciar
+- Datos faltantes o corruptos
+
+**Soluciones:**
+
+<Callout type="warn">
+  Esto eliminará todos tus perfiles de voz y el historial de generación. Exporta primero los perfiles importantes si es posible.
+</Callout>
+
+```bash
+# macOS
+rm ~/Library/Application\ Support/sh.voicebox.app/data/voicebox.db
+
+# Windows
+del %APPDATA%\sh.voicebox.app\data\voicebox.db
+```
+
+Reinicia la app para crear una base de datos nueva.
+
+## Problemas con los modelos
+
+### La descarga del modelo falla
+
+**Síntomas:**
+- Error "Failed to download model"
+- Se queda en "Downloading..."
+
+**Soluciones:**
+- Comprueba tu conexión a internet
+- Comprueba el estado de HuggingFace Hub
+- Prueba a usar una VPN si HuggingFace está bloqueado en tu región
+- Descarga el modelo manualmente con la CLI de HuggingFace y colócalo en el directorio de caché:
+
+  ```bash
+  pip install huggingface_hub
+  huggingface-cli download Qwen/Qwen3-TTS-12Hz-1.7B-Base
+  ```
+
+### Versión incorrecta del modelo
+
+**Síntomas:**
+- La calidad de la generación empeoró de repente
+- Salida de voz distinta
+
+**Soluciones:**
+Limpia la caché del modelo y vuelve a descargarlo. Sustituye el patrón `Qwen*` por el prefijo de la organización del motor para otros motores (`ResembleAI*` para Chatterbox, `HumeAI*` para TADA, `hexgrad*` para Kokoro, etc.) o usa `DELETE /models/{name}` a través de la API.
+
+```bash
+# macOS / Linux
+rm -rf ~/.cache/huggingface/hub/models--Qwen*
+
+# Windows
+rmdir /s %USERPROFILE%\.cache\huggingface\hub\models--Qwen*
+```
+
+## Problemas de rendimiento
+
+### Generación lenta en la GPU
+
+**Síntomas:**
+- La generación es más lenta de lo esperado
+- La GPU no se está utilizando
+
+**Soluciones:**
+
+<AccordionGroup>
+  <Accordion title="Verificar la instalación de CUDA">
+    ```bash
+    nvidia-smi
+    ```
+
+    Debería mostrar tu GPU. Si no, instala los controladores de CUDA.
+  </Accordion>
+
+  <Accordion title="Comprobar la selección de GPU">
+    Si tienes varias GPU, asegúrate de que Voicebox esté usando la correcta.
+
+    Ajustes → Generation → GPU Device
+  </Accordion>
+
+  <Accordion title="Actualizar los controladores de la GPU">
+    Los controladores desactualizados pueden causar problemas de rendimiento. Actualiza a los últimos controladores de NVIDIA.
+  </Accordion>
+
+  <Accordion title="Apple Silicon: confirmar el backend MLX">
+    Consulta Ajustes → Server Status. Debería mostrar **Backend: MLX** en Apple Silicon: aquí MLX es de 4 a 5 veces más rápido que PyTorch. Si muestra **Backend: PYTORCH**, reinstala MLX:
+
+    ```bash
+    pip install -r backend/requirements-mlx.txt
+    ```
+
+    La disponibilidad de GPU debería indicar "Metal (Apple Silicon via MLX)".
+  </Accordion>
+</AccordionGroup>
+
+### Uso elevado de memoria
+
+**Síntomas:**
+- La app usa demasiada RAM
+- El sistema se vuelve lento
+
+**Soluciones:**
+- Cierra los perfiles de voz que no estés usando
+- Limpia el historial de generación
+- Reinicia la app periódicamente
+
+## Problemas de actualización
+
+### "Update Check Failed"
+
+**Soluciones:**
+- Confirma tu conexión a internet: las actualizaciones se obtienen de las releases de GitHub.
+- Asegúrate de que `github.com` sea accesible y no esté bloqueado por un cortafuegos o proxy.
+- Como alternativa, descarga la última versión desde GitHub e instálala manualmente.
+
+### Error "Invalid Signature"
+
+**Soluciones:**
+- Vuelve a descargar el instalador: la firma puede haberse corrompido durante la transferencia.
+- Verifica que el archivo `.sig` coincida con el instalador; si no coincide, abre una incidencia.
+
+## Problemas del modo remoto
+
+### No se puede conectar al servidor remoto
+
+**Síntomas:**
+- Error "Connection refused"
+- No se encuentra el servidor remoto
+
+**Soluciones:**
+
+<Steps>
+  <Step title="Comprobar el estado del servidor">
+    Asegúrate de que el servidor remoto esté en ejecución:
+
+    ```bash
+    curl http://<server-ip>:17493/health
+    ```
+  </Step>
+
+  <Step title="Comprobar el cortafuegos">
+    Asegúrate de que el puerto 17493 esté abierto en el servidor remoto:
+
+    ```bash
+    # Allow port on Ubuntu/Debian
+    sudo ufw allow 17493
+    ```
+  </Step>
+
+  <Step title="Verificar la red">
+    - Asegúrate de que ambas máquinas estén en la misma red (para servidores locales)
+    - Usa la dirección IP en lugar del nombre de host
+    - Prueba a hacer ping al servidor: `ping <server-ip>`
+  </Step>
+</Steps>
+
+## ¿Sigues teniendo problemas?
+
+Si sigues experimentando problemas:
+
+1. **Consulta las Issues de GitHub:** [github.com/jamiepine/voicebox/issues](https://github.com/jamiepine/voicebox/issues)
+2. **Abre una nueva Issue:** Proporciona:
+   - Sistema operativo y versión
+   - Versión de Voicebox
+   - Pasos para reproducirlo
+   - Mensajes de error o registros
+3. **Únete a Discord:** [discord.gg/voicebox](https://discord.gg/voicebox) (próximamente)
+
+## Información de diagnóstico
+
+Cuando informes de problemas, incluye esta información:
+
+```bash
+# Voicebox version
+# Check Help → About in the app
+
+# Operating system
+uname -a  # macOS/Linux
+systeminfo  # Windows
+
+# Python version (for dev issues)
+python --version
+
+# GPU info (if generation issues)
+nvidia-smi  # NVIDIA GPUs
+```

--- a/docs/content/docs/overview/voice-cloning.es.mdx
+++ b/docs/content/docs/overview/voice-cloning.es.mdx
@@ -18,7 +18,7 @@ Cinco motores en 0.4 admiten clonación:
 | **TADA** (1B / 3B)          | 10        | Modelo de lenguaje de voz con generación coherente de formato largo de más de 700s |
 
 <Callout type="info">
-  ¿No quieres grabar audio? Usa en su lugar una voz curada de Kokoro o Qwen CustomVoice; consulta [Voces predefinidas](/overview/preset-voices).
+  ¿No quieres grabar audio? Usa en su lugar una voz curada de Kokoro o Qwen CustomVoice; consulta [Voces predefinidas](./preset-voices.mdx).
 </Callout>
 
 ## Cómo funciona

--- a/docs/content/docs/overview/voice-cloning.es.mdx
+++ b/docs/content/docs/overview/voice-cloning.es.mdx
@@ -1,0 +1,118 @@
+---
+title: "Clonación de voz"
+description: "Clona cualquier voz a partir de unos segundos de audio de referencia"
+---
+
+## Resumen
+
+Voicebox puede replicar la voz de una persona concreta a partir de una muestra de audio corta, lo que se conoce como **clonación de voz zero-shot**. Tú proporcionas entre 10 y 30 segundos de habla clara, el modelo extrae un embedding de voz y, a partir de ahí, puedes generar cualquier texto con esa voz.
+
+Cinco motores en 0.4 admiten clonación:
+
+| Motor                       | Idiomas   | Puntos fuertes                                                             |
+| --------------------------- | --------- | -------------------------------------------------------------------------- |
+| **Qwen3-TTS** (0.6B / 1.7B) | 10        | Multilingüe de alta calidad, admite instrucciones de interpretación en el mismo kwarg |
+| **Chatterbox Multilingual** | 23        | La cobertura de idiomas más amplia: árabe, hindi, suajili, hebreo y más    |
+| **Chatterbox Turbo**        | Inglés    | Modelo rápido de 350M con etiquetas paralingüísticas de emoción (`[laugh]`, `[sigh]`) |
+| **LuxTTS**                  | Inglés    | Ligero (~1 GB de VRAM), salida a 48 kHz, 150x tiempo real en CPU           |
+| **TADA** (1B / 3B)          | 10        | Modelo de lenguaje de voz con generación coherente de formato largo de más de 700s |
+
+<Callout type="info">
+  ¿No quieres grabar audio? Usa en su lugar una voz curada de Kokoro o Qwen CustomVoice; consulta [Voces predefinidas](/overview/preset-voices).
+</Callout>
+
+## Cómo funciona
+
+<Steps>
+  <Step title="Sube o graba una muestra">
+    Proporciona entre 10 y 30 segundos de habla clara de la voz objetivo
+  </Step>
+  <Step title="Análisis del motor">
+    El motor seleccionado analiza las características vocales, el tono y los patrones de habla
+  </Step>
+  <Step title="Perfil de voz creado">
+    Se genera un embedding de voz y se almacena con tu perfil
+  </Step>
+  <Step title="Generar voz">
+    Usa el perfil para generar cualquier texto con la voz clonada
+  </Step>
+</Steps>
+
+## Elegir un motor para clonar
+
+Distintos motores se adaptan a distintos casos de uso. La cuadrícula de perfiles atenúa los motores no compatibles para que puedas cambiar fácilmente.
+
+| Si quieres…                                        | Elige                 |
+| -------------------------------------------------- | --------------------- |
+| La mejor calidad general en unos pocos idiomas comunes | **Qwen3-TTS 1.7B**    |
+| Generación más rápida, calidad ligeramente inferior | **Qwen3-TTS 0.6B**    |
+| Idiomas fuera de los 10 de Qwen (árabe, hindi, etc.) | **Chatterbox Multilingual** |
+| Inglés expresivo con etiquetas `[laugh]` `[sigh]`  | **Chatterbox Turbo**  |
+| Configuración solo con CPU o GPU ligera, inglés    | **LuxTTS**            |
+| Generación de formato largo (audiolibros, capítulos completos) | **TADA 3B**           |
+
+## Buenas prácticas
+
+### Calidad de la muestra
+
+<Cards>
+  <Card title="Sí">
+    - Usa entre 10 y 30 segundos de audio
+    - Habla clara y constante
+    - Ruido de fondo mínimo
+    - Ritmo de habla natural
+  </Card>
+  <Card title="No">
+    - Clips muy cortos (< 5 segundos)
+    - Ruido de fondo fuerte
+    - Música o voces superpuestas
+    - Audio muy procesado
+  </Card>
+</Cards>
+
+### Múltiples muestras
+
+Añadir varias muestras del mismo hablante puede mejorar la calidad:
+
+- Distintos estilos de habla (informal, formal)
+- Distintas emociones (alegre, serio)
+- Distintas condiciones de grabación
+
+<Callout type="info">
+  El modelo aprenderá una representación más robusta a partir de muestras diversas. Resulta especialmente útil para voces distintivas que, de otro modo, el modelo podría suavizar.
+</Callout>
+
+## Idiomas admitidos por motor
+
+- **Qwen3-TTS** — inglés, chino, japonés, coreano, alemán, francés, ruso, portugués, español, italiano (10)
+- **Chatterbox Multilingual** — árabe, chino, danés, neerlandés, inglés, finés, francés, alemán, griego, hebreo, hindi, italiano, japonés, coreano, malayo, noruego, polaco, portugués, ruso, español, suajili, sueco, turco (23)
+- **Chatterbox Turbo** — inglés
+- **LuxTTS** — inglés
+- **TADA 3B** — 10 multilingües; **TADA 1B** — inglés
+
+Para ver las tablas completas de idiomas y las notas específicas de cada motor, consulta la [guía de desarrollo de motores TTS](/developer/tts-engines).
+
+## Limitaciones
+
+<Callout type="warn">
+  La clonación de voz solo debe usarse con consentimiento. Asegúrate de tener permiso para clonar la voz de alguien. Consulta el [SECURITY.md](https://github.com/jamiepine/voicebox/blob/main/SECURITY.md) del proyecto y tus leyes locales sobre contenido de voz sintética.
+</Callout>
+
+- La calidad depende de la claridad de la muestra: las muestras ruidosas producen clones ruidosos
+- Funciona mejor con un tono de habla constante dentro de una muestra
+- Puede tener dificultades con acentos extremos o impedimentos del habla
+- El ruido de fondo reduce la calidad y puede introducir artefactos
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Crear perfiles de voz" href="/overview/creating-voice-profiles">
+    Guía paso a paso para crear perfiles
+  </Card>
+  <Card title="Voces predefinidas" href="/overview/preset-voices">
+    Usa voces integradas en lugar de clonar
+  </Card>
+  <Card title="Generar voz" href="/overview/generating-speech">
+    Usa un perfil para generar audio
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/voice-personalities.es.mdx
+++ b/docs/content/docs/overview/voice-personalities.es.mdx
@@ -1,0 +1,194 @@
+---
+title: "Personalidades de voz"
+description: "Asocia una personalidad a un perfil de voz, redacta nuevas frases en personaje y reescribe el texto de entrada en su voz — todo impulsado por un LLM local."
+---
+
+## Resumen
+
+Una **personalidad** es una descripción opcional de formato libre asociada a un
+perfil de voz — quién es esta voz, cómo habla, qué le importa. Define una
+y aparecen dos controles nuevos junto al botón de generar, ambos impulsados por
+un LLM Qwen3 incluido que se ejecuta enteramente en local:
+
+- **Redactar** — coloca una nueva frase en personaje dentro del área de texto.
+  Haz clic de nuevo para obtener otra versión.
+- **Hablar en personaje** — una alternancia que reescribe el texto de entrada en
+  la voz del personaje antes del TTS, conservando todas las ideas.
+
+El LLM produce el texto. El perfil de voz lo dice. Sin viajes de ida y vuelta a
+la nube, sin API externa — todo el bucle se ejecuta en tu hardware.
+
+<Callout type="info">
+  Las personalidades llegaron en la **0.5.0**. El mismo LLM local funciona
+  además como modelo de refinamiento para el [Dictado](/overview/dictation) — un
+  LLM en la aplicación, no dos, compartiendo una caché de modelos y una huella de
+  memoria de GPU.
+</Callout>
+
+## Definir una personalidad
+
+Abre la vista de edición de un perfil de voz. El campo **Personalidad** es texto
+de formato libre de hasta **2.000 caracteres**. Describe la voz como mejor te
+sirva — frases pasadas que diría, patrones de habla, tono, límites.
+
+Las buenas descripciones suelen incluir:
+
+- Una identidad de una línea (quién es)
+- Patrones de habla (ritmo, vocabulario, qué evita)
+- Frases representativas — las frases de ejemplo le muestran al LLM el tono
+  objetivo mejor que los adjetivos
+- Qué *no* haría el personaje (no explica, no se disculpa, se niega a salir del
+  personaje, etc.)
+
+Puedes definir una personalidad en cualquier tipo de perfil de voz — clonado o
+preajustado. Los tres modos funcionan de forma idéntica independientemente del
+motor.
+
+## Las dos acciones
+
+Cada acción está afinada para un trabajo específico y la temperatura del LLM se
+ajusta en consecuencia.
+
+### Redactar
+
+Genera una nueva frase en la voz del personaje, sin texto de partida.
+Haz clic en el botón de barajar para colocar una frase directamente en el área
+de texto de generación; haz clic de nuevo para obtener otra versión.
+
+- **Cuándo usarlo:** prototipado, muestrear la voz de un personaje, hacer una
+  lluvia de ideas de una frase sin teclear primero
+- **Temperatura:** alta — la variedad es el objetivo
+- **Salida típica:** una frase corta y contundente que encaja en el registro
+  del personaje
+
+### Hablar en personaje (reescritura)
+
+Activa la alternancia de persona y todo lo que teclees (o dictes) se reescribe en
+la voz del personaje antes del TTS — se conserva cada idea, solo cambia la
+formulación. Modo de alta fidelidad: el contenido no cambia, solo la voz.
+
+- **Cuándo usarlo:** convertir una nota dictada en habla en personaje; elevar un
+  guion en español llano a una voz específica sin editar a mano
+- **Temperatura:** baja — gana la fidelidad
+- **Salida típica:** las mismas ideas, el mismo orden, distinta formulación y
+  cadencia
+
+## Encuadre de solo habla
+
+Ambos modos imponen una salida de **solo habla**. Se le indica al LLM que
+produzca cosas que una persona diría realmente en voz alta — sin narración, sin
+etiquetas de acción (`*sighs*`, `[laughs]`), sin metacomentarios, sin formato
+markdown, sin acotaciones escénicas.
+
+Esto es deliberado: la salida va directa al TTS, y cualquier cosa que no sea
+pronunciable acaba ignorándose o leyéndose literalmente. El encuadre de solo
+habla también hace que la salida encaje limpiamente dentro de un diálogo, de modo
+que puedes colocar un resultado de Responder directamente en una Historia.
+
+## El LLM local
+
+El LLM incluido es **Qwen3**, disponible en tres tamaños:
+
+| Modelo | Tamaño de descarga | Mejor para |
+|---|---|---|
+| Qwen3 0.6B | ~400 MB | Predeterminado. Muy rápido, bueno para uso casual. |
+| Qwen3 1.7B | ~1.1 GB | El punto óptimo para personalidades de personaje con formulación específica. |
+| Qwen3 4B | ~2.5 GB | Calidad completa. El más lento. Útil para un tono muy particular. |
+
+El modelo se ejecuta a través de la misma división de backend que Voicebox ya
+usa para el TTS — **MLX** (cuantizaciones de 4 bits de la comunidad) en Apple
+Silicon, **PyTorch** (transformers `AutoModelForCausalLM`) en el resto. Las
+descargas pasan por la misma caché y la misma interfaz de gestión de modelos que
+los modelos de TTS.
+
+Elige un tamaño en **Ajustes → Capturas → Refinamiento → Modelo de refinamiento**
+— los modos de personalidad lo reutilizan. Si cambias de modelo, tanto el
+refinamiento como la salida de personalidad adoptan el cambio en la siguiente
+llamada.
+
+## Usar los controles
+
+Ambos controles aparecen en el cuadro flotante de generación cuando el perfil
+seleccionado tiene una personalidad definida.
+
+<Steps>
+  <Step title="Redactar — barajar una frase">
+    Haz clic en el botón de barajar. El LLM se ejecuta y el resultado rellena el
+    área de texto de generación. Edítalo si quieres y luego pulsa generar.
+  </Step>
+  <Step title="Hablar en personaje — activar la reescritura de persona">
+    Teclea (o dicta) lo que quieres que se diga. Activa la alternancia de la
+    varita. Pulsa generar — Voicebox pasa primero el texto por el LLM de
+    personalidad y luego el TTS dice la versión reescrita. Deja la alternancia
+    desactivada para un TTS normal.
+  </Step>
+</Steps>
+
+Redactar siempre te da algo distinto al volver a hacer clic. La alternancia de
+persona, en cambio, es un modo — se aplica a cada llamada de generación hasta que
+vuelves a desactivarla.
+
+## Casos de uso
+
+- **Agentes que hablan con una voz que te pertenece.** Combina la alternancia de
+  persona con el [Servidor MCP](/overview/mcp-server) integrado para que Claude
+  Code, Cursor, Cline o cualquier agente compatible con MCP pueda responder a
+  través de un perfil con personalidad. El agente llama a `voicebox.speak({ text,
+  profile, personality: true })` y Voicebox reescribe el texto en personaje antes
+  de hablar.
+- **Personajes interactivos.** Juegos, herramientas narrativas, experiencias de
+  accesibilidad. Un personaje con una descripción de personalidad más una voz
+  clonada se convierte en un recurso reutilizable.
+- **Accesibilidad.** Las personas que no pueden hablar con su voz original pueden
+  conservar una descripción de personalidad de cómo solían sonar y usar la
+  alternancia de reescritura para convertir la entrada tecleada en habla en
+  personaje.
+- **Borradores creativos.** Escribe un guion llano, activa la alternancia de
+  persona, genera frase a frase en la voz del personaje y coloca el audio en una
+  Historia.
+
+## Superficie de la API
+
+Las personalidades son accesibles vía REST:
+
+| Método | Endpoint | Cuerpo |
+|---|---|---|
+| `PUT` | `/profiles/{id}` | Incluye un campo `personality` de hasta 2.000 caracteres para definirla. |
+| `POST` | `/profiles/{id}/compose` | Sin cuerpo. Devuelve una nueva frase en personaje como texto. |
+| `POST` | `/generate` | Incluye `personality: true` para pasar el texto de entrada por el LLM de personalidad antes del TTS. Igual para `POST /speak`. |
+
+`POST /generate` con `personality: true` es la misma primitiva que usa la
+herramienta `voicebox.speak` de MCP cuando pasas `personality: true`. Los scripts
+y los agentes pueden usarla directamente.
+
+## Límites y trampas
+
+- **La personalidad es un prompt, no un ajuste fino.** El LLM a veces se
+  desviará del personaje, especialmente en Redactar con temperatura alta. Haz
+  clic de nuevo para obtener otra versión.
+- **Las personalidades largas no siempre son mejores.** 2.000 caracteres es un
+  techo, no un objetivo. Una descripción nítida de 300 caracteres con dos frases
+  de ejemplo suele superar a una larga.
+- **El encuadre de solo habla se impone, pero no es infalible.** Los prompts muy
+  grandes o las entradas inusuales pueden colar una etiqueta de acción. Si ves
+  `[laughs]` en la salida del TTS, suele ser una pista del campo de personalidad
+  a la que el modelo se ha aferrado — quítala de la descripción.
+- **La reescritura es más estricta que Responder.** Si la salida está cambiando
+  tu significado, probablemente quieras Responder (o un Redactar completo con
+  contexto en la entrada), no Reescribir.
+
+## Próximos pasos
+
+<Cards>
+  <Card title="Dictado" href="/overview/dictation">
+    Dicta la entrada para Reescribir o Responder desde cualquier parte de tu
+    máquina.
+  </Card>
+  <Card title="Capturas" href="/overview/captures">
+    Las capturas alimentan las personalidades de forma natural — dicta una nota,
+    reescríbela en una voz de personaje, genera voz.
+  </Card>
+  <Card title="Crear perfiles de voz" href="/overview/creating-voice-profiles">
+    Añade una personalidad a un perfil existente.
+  </Card>
+</Cards>

--- a/docs/content/docs/overview/voice-personalities.es.mdx
+++ b/docs/content/docs/overview/voice-personalities.es.mdx
@@ -7,7 +7,7 @@ description: "Asocia una personalidad a un perfil de voz, redacta nuevas frases 
 
 Una **personalidad** es una descripción opcional de formato libre asociada a un
 perfil de voz — quién es esta voz, cómo habla, qué le importa. Define una
-y aparecen dos controles nuevos junto al botón de generar, ambos impulsados por
+personalidad y aparecen dos controles nuevos junto al botón de generar, ambos impulsados por
 un LLM Qwen3 incluido que se ejecuta enteramente en local:
 
 - **Redactar** — coloca una nueva frase en personaje dentro del área de texto.
@@ -20,7 +20,7 @@ la nube, sin API externa — todo el bucle se ejecuta en tu hardware.
 
 <Callout type="info">
   Las personalidades llegaron en la **0.5.0**. El mismo LLM local funciona
-  además como modelo de refinamiento para el [Dictado](/overview/dictation) — un
+  además como modelo de refinamiento para el [Dictado](./dictation.mdx) — un
   LLM en la aplicación, no dos, compartiendo una caché de modelos y una huella de
   memoria de GPU.
 </Callout>
@@ -131,7 +131,7 @@ vuelves a desactivarla.
 ## Casos de uso
 
 - **Agentes que hablan con una voz que te pertenece.** Combina la alternancia de
-  persona con el [Servidor MCP](/overview/mcp-server) integrado para que Claude
+  persona con el [Servidor MCP](./mcp-server.mdx) integrado para que Claude
   Code, Cursor, Cline o cualquier agente compatible con MCP pueda responder a
   través de un perfil con personalidad. El agente llama a `voicebox.speak({ text,
   profile, personality: true })` y Voicebox reescribe el texto en personaje antes

--- a/docs/lib/i18n.ts
+++ b/docs/lib/i18n.ts
@@ -1,0 +1,8 @@
+import { defineI18n } from 'fumadocs-core/i18n';
+
+// English stays at `/`, Spanish at `/es`.
+export const i18n = defineI18n({
+  languages: ['en', 'es'],
+  defaultLanguage: 'en',
+  hideLocale: 'default-locale',
+});

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -1,7 +1,9 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { i18n } from '@/lib/i18n';
 
 export function baseOptions(): BaseLayoutProps {
   return {
+    i18n,
     nav: {
       title: 'Voicebox',
     },

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -1,10 +1,12 @@
 import { type InferPageType, loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { docs } from '@/.source';
+import { i18n } from '@/lib/i18n';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: '/',
+  i18n,
   source: docs.toFumadocsSource(),
   plugins: [lucideIconsPlugin()],
 });

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -1,0 +1,11 @@
+import { createI18nMiddleware } from 'fumadocs-core/i18n/middleware';
+import { i18n } from '@/lib/i18n';
+
+export default createI18nMiddleware(i18n);
+
+export const config = {
+  // Run on every path except API, Next internals, static assets and special routes.
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|images|og|llms-full.txt|robots.txt|sitemap.xml).*)',
+  ],
+};


### PR DESCRIPTION
## What

Enables i18n on the Fumadocs docs site and adds a full Spanish (`es`) translation of the **overview** user guides. Implements the approach proposed in #800.

## i18n wiring (standard Fumadocs v16)

- `lib/i18n.ts` — `defineI18n({ languages: ['en','es'], defaultLanguage: 'en', hideLocale: 'default-locale' })` → English stays at `/`, Spanish at `/es`.
- `lib/source.ts` — pass `i18n` to the loader.
- `proxy.ts` — `createI18nMiddleware` for locale routing (Next 16 `proxy` convention, replacing the deprecated `middleware`).
- Routes moved under `app/[lang]/`; the root layout is a pass-through and the real `<html lang>`/`<body>` + `RootProvider` live in `app/[lang]/layout.tsx`, with Spanish UI strings via `defineI18nUI` and a language toggle.
- `app/api/search` — locale-aware (orama `english`/`spanish` tokenizers).
- `llms-full.txt` — pinned to the default language.

## Content

- `index.es.mdx` + all **19** `overview/*.es.mdx` guides translated. Frontmatter `title`/`description` translated; MDX components, code fences, links and brand/model names preserved (verified: components + fences match `en` 19/19).
- `meta.es.json` for the root and overview nav.
- Sections not yet translated (`developer/`, `api-reference/`) fall back to English under `/es` — intentional first-pass scope (see #800).

## Verification

- `bun run build` succeeds: **232 static pages** (56 `es` + 56 `en`); `/es` pages render Spanish content.
- No new deprecation warnings (uses `proxy.ts`).

## Notes

- Convention (`*.es.mdx` siblings + `[lang]` routing) follows the standard Fumadocs setup and is adjustable to your preference per #800.
- `CHANGELOG.md` untouched (auto-compiled at release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spanish-language documentation and contribution/security guides.
  * Introduced an English/Español language selector for the docs experience.
  * Implemented language-aware docs routing, page metadata, and search (including Spanish labels).
  * Expanded Spanish docs with new/updated guides across installation, quick start, dictation, captures, profiles, voice cloning, generating speech, stories, MCP server, remote mode, GPU acceleration, Docker, and troubleshooting.
* **Bug Fixes**
  * Improved localized documentation rendering so the correct language content and metadata display per route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->