### PR TITLE
feat: french translation

### DIFF
--- a/app/src/i18n/index.ts
+++ b/app/src/i18n/index.ts
@@ -5,12 +5,14 @@ import en from './locales/en/translation.json';
 import ja from './locales/ja/translation.json';
 import zhCN from './locales/zh-CN/translation.json';
 import zhTW from './locales/zh-TW/translation.json';
+import fr from './locales/fr/translation.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'ja', label: '日本語' },
   { code: 'zh-CN', label: '简体中文' },
   { code: 'zh-TW', label: '繁體中文' },
+  { code: 'fr', label: 'Français' },
 ] as const;
 
 export type LanguageCode = (typeof SUPPORTED_LANGUAGES)[number]['code'];
@@ -24,6 +26,7 @@ i18n
       ja: { translation: ja },
       'zh-CN': { translation: zhCN },
       'zh-TW': { translation: zhTW },
+      fr: { translation: fr },
     },
     fallbackLng: 'en',
     supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),

--- a/app/src/i18n/locales/fr/translation.json
+++ b/app/src/i18n/locales/fr/translation.json
@@ -1,0 +1,1241 @@
+{
+  "common": {
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "confirm": "Confirmer",
+    "loading": "Chargement…",
+    "error": "Erreur",
+    "unknown": "Inconnu",
+    "unknownError": "Erreur inconnue"
+  },
+  "nav": {
+    "generate": "Générer",
+    "stories": "Histoires",
+    "captures": "Captures",
+    "voices": "Voix",
+    "effects": "Effets",
+    "audio": "Audio",
+    "models": "Modèles",
+    "settings": "Paramètres",
+    "updateBadge": "Mise à jour"
+  },
+  "captures": {
+    "title": "Captures",
+    "beta": "Bêta",
+    "searchPlaceholder": "Rechercher dans les transcriptions…",
+    "snippetEmpty": "(aucune transcription)",
+    "noTranscriptError": "Cette capture n'a pas encore de transcription",
+    "captureCardLabel": "Capture · {{when}}",
+    "header": {
+      "modelSummary": "Whisper {{stt}} · Qwen3 · {{llm}}"
+    },
+    "source": {
+      "dictation": "Dictée",
+      "recording": "Enregistrement",
+      "file": "Fichier"
+    },
+    "transcript": {
+      "refined": "Corrigé",
+      "raw": "Brut",
+      "refinedHint": "Corrigé avec Qwen3 · {{model}}",
+      "rawHint": "Transcrit avec Whisper {{model}}"
+    },
+    "actions": {
+      "configure": "Configurer",
+      "import": "Importer",
+      "importing": "Téléchargement…",
+      "dictate": "Dicter",
+      "stop": "Arrêter",
+      "copy": "Copier",
+      "refine": "Corriger",
+      "reRefine": "Recorriger",
+      "export": "Exporter",
+      "exportDropdownLabel": "Exporter la capture en",
+      "exportAudio": "Audio (WAV)",
+      "exportTranscript": "Transcription (TXT)",
+      "exportMarkdown": "Markdown (MD)",
+      "delete": "Supprimer",
+      "playAs": "Lire avec {{name}}",
+      "playAsFallback": "Lire avec…",
+      "playAsGenerating": "Génération…",
+      "playAsStop": "Arrêter · {{name}}",
+      "playAsStopFallback": "Arrêter · Voix",
+      "playAsDropdownLabel": "Lire la transcription avec"
+    },
+    "empty": {
+      "noMatches": "Aucune capture ne correspond à \"{{query}}\"",
+      "none": "Encore aucune capture.",
+      "loading": "Chargement des captures…",
+      "pickOne": "Sélectionnez une capture pour voir la transcription.",
+      "holdToRecord": "Maintenir pour enregistrer",
+      "toggleHandsFree": "Activer/désactiver le mains-libres",
+      "pressShortcut": "Appuyez sur le raccourci depuis n'importe quelle application pour lancer votre première capture.",
+      "turnOnShortcut": "Activez le raccourci global pour dicter depuis n'importe où — ou cliquez sur Dicter ci-dessus pour une capture dans l'application.",
+      "openSettings": "Ouvrir les paramètres de Captures"
+    },
+    "deleteDialog": {
+      "title": "Supprimer la capture",
+      "description": "Cela supprimera définitivement la capture, son audio et sa transcription. Cette action est irréversible.",
+      "deleting": "Suppression…"
+    },
+    "toast": {
+      "deleteFailed": "Échec de la suppression",
+      "playAsFailed": "Échec de la lecture",
+      "noVoice": "Aucun profil vocal",
+      "noVoiceDescription": "Créez un profil vocal avant d'utiliser Lire avec.",
+      "transcriptCopied": "Transcription copiée",
+      "copyFailed": "Échec de la copie",
+      "exportSuccess": "Exporté vers {{path}}",
+      "exportFailed": "Échec de l'exportation",
+      "exportEmpty": "Rien à exporter",
+      "shortcutNotArmed": "Raccourci activé, mais pas encore armé",
+      "shortcutNotArmedDescription_one": "{{names}} doit encore être téléchargé. Ouvrez l'onglet Captures pour commencer.",
+      "shortcutNotArmedDescription_other": "{{names}} doivent encore être téléchargés. Ouvrez l'onglet Captures pour commencer."
+    },
+    "pill": {
+      "recording": "Enregistrement",
+      "transcribing": "Transcription",
+      "refining": "Correction",
+      "speaking": "Parole",
+      "completed": "Terminé",
+      "stopAria": "Arrêter l'enregistrement",
+      "errorFallback": "Une erreur s'est produite",
+      "errorCopyTooltip": "Cliquez pour copier l'erreur"
+    },
+    "chord": {
+      "capturing": "Capture…",
+      "pressShortcut": "Appuyez sur votre raccourci",
+      "noKeys": "Aucune touche",
+      "unsupported": "\"{{key}}\" n'est pas pris en charge dans les combinaisons. Essayez une touche modificatrice ou alphabétique.",
+      "notSet": "Non défini"
+    },
+    "readiness": {
+      "title": "Quelques prérequis avant de pouvoir dicter",
+      "subheading": "Le raccourci reste désactivé jusqu'à ce que tout soit prêt ci-dessous.",
+      "downloadButton": "Télécharger",
+      "downloading": "Téléchargement…",
+      "downloadingPercent": "Téléchargement… {{pct}}%",
+      "downloadStarted": "Téléchargement démarré",
+      "downloadStartedDescription": "{{name}} est en cours de téléchargement. Le raccourci s'armera automatiquement.",
+      "downloadFailed": "Échec du téléchargement",
+      "stt": {
+        "label": "{{name}} (reconnaissance vocale)",
+        "ready": "Modèle téléchargé.",
+        "missing": "Nécessaire pour transcrire votre audio",
+        "missingWithSize": "Nécessaire pour transcrire votre audio · {{size}}"
+      },
+      "llm": {
+        "label": "{{name}} (correction)",
+        "ready": "Modèle téléchargé.",
+        "missing": "Nettoie la transcription brute avant collage",
+        "missingWithSize": "Nettoie la transcription brute avant collage · {{size}}"
+      },
+      "inputMonitoring": {
+        "label": "Autorisation de surveillance d'entrée",
+        "ready": "macOS permet à Voicebox de détecter votre raccourci global.",
+        "missing": "macOS doit autoriser Voicebox à détecter le raccourci global.",
+        "openSettings": "Ouvrir les réglages"
+      },
+      "accessibility": {
+        "label": "Autorisation d'accessibilité",
+        "ready": "Voicebox peut coller les transcriptions dans d'autres applications.",
+        "missing": "Requis pour que les transcriptions puissent être collées dans l'application active.",
+        "openSettings": "Ouvrir les réglages"
+      }
+    },
+    "permissions": {
+      "accessibility": {
+        "title": "Accordez l'autorisation d'accessibilité pour activer le collage automatique",
+        "body": "Voicebox a besoin de <path>Réglages Système → Confidentialité et Sécurité → Accessibilité</path> pour coller les transcriptions dans d'autres applications. Vos dictées arriveront quand même dans l'onglet Captures sans cela.",
+        "openSettings": "Ouvrir les réglages",
+        "recheck": "Je l'ai activé",
+        "rechecking": "Vérification…",
+        "stillMissing": "Toujours pas détecté. macOS nécessite généralement de quitter et rouvrir Voicebox après avoir activé l'autorisation."
+      },
+      "inputMonitoring": {
+        "title": "Accordez la surveillance d'entrée pour activer le raccourci global",
+        "body": "Voicebox a besoin de <path>Réglages Système → Confidentialité et Sécurité → Surveillance d'entrée</path> pour détecter votre combinaison de dictée. L'interrupteur est activé, mais macOS bloque les événements clavier tant que vous ne l'autorisez pas.",
+        "openSettings": "Ouvrir les réglages",
+        "recheck": "Je l'ai activé",
+        "rechecking": "Vérification…",
+        "stillMissing": "Toujours pas détecté. macOS nécessite généralement de quitter et rouvrir Voicebox après avoir activé l'autorisation."
+      }
+    }
+  },
+  "voicesTab": {
+    "title": "Voix",
+    "loading": "Chargement des voix…",
+    "searchPlaceholder": "Rechercher des voix…",
+    "newVoice": "Nouvelle voix",
+    "avatarAlt": "Avatar de {{name}}",
+    "selectChannels": "Sélectionner des canaux…",
+    "channelDefaultLabel": "{{name}} (Par défaut)",
+    "columns": {
+      "name": "Nom",
+      "language": "Langue",
+      "generations": "Générations",
+      "samples": "Échantillons",
+      "effects": "Effets",
+      "channels": "Canaux"
+    }
+  },
+  "voiceInspector": {
+    "loading": "Chargement…",
+    "defaultEffectsHint": "Appliqué automatiquement aux nouvelles générations avec cette voix.",
+    "fields": {
+      "description": "Description"
+    },
+    "toast": {
+      "invalidImageFormat": "Veuillez sélectionner un fichier PNG, JPG ou WebP",
+      "avatarUpdated": "Avatar mis à jour",
+      "savedDescription": "\"{{name}}\" enregistré."
+    }
+  },
+  "audioChannels": {
+    "title": "Canaux audio",
+    "newChannel": "Nouveau canal",
+    "loading": "Chargement…",
+    "confirmDelete": "Supprimer ce canal ?",
+    "noVoicesAssigned": "Aucune voix assignée",
+    "selectDevice": "Sélectionner un périphérique",
+    "addDevice": "Ajouter un périphérique",
+    "addVoice": "Ajouter une voix",
+    "defaultSuffix": "par défaut",
+    "empty": {
+      "message": "Encore aucun canal audio. Créez votre premier canal pour router les voix vers des périphériques spécifiques.",
+      "action": "Créer un canal"
+    },
+    "labels": {
+      "outputDevices": "Périphériques de sortie",
+      "assignedVoices": "Voix assignées"
+    },
+    "devices": {
+      "title": "Périphériques disponibles",
+      "defaultNote": "Le canal par défaut utilise le périphérique système par défaut",
+      "toggleHint": "Cliquez sur les périphériques pour les ajouter ou retirer du canal sélectionné",
+      "selectHint": "Sélectionnez un canal pour assigner des périphériques",
+      "empty": "Aucun périphérique audio trouvé",
+      "requiresTauri": "La sélection de périphérique audio nécessite Tauri"
+    },
+    "fields": {
+      "name": "Nom du canal",
+      "namePlaceholder": "ex. Câble virtuel, Diffusion"
+    },
+    "createDialog": {
+      "title": "Créer un canal audio",
+      "description": "Créez un nouveau canal audio (bus) pour router les voix vers des périphériques de sortie spécifiques.",
+      "action": "Créer"
+    },
+    "editDialog": {
+      "title": "Modifier le canal",
+      "description": "Mettez à jour les paramètres du canal et les assignations de voix."
+    }
+  },
+  "profileForm": {
+    "createTitle": "Créer une voix",
+    "editTitle": "Modifier la voix",
+    "createDescription": "Créez un nouveau profil vocal à partir d'un échantillon audio ou d'une voix intégrée.",
+    "editDescription": "Mettez à jour les détails de votre profil vocal et gérez les échantillons.",
+    "draftRestored": "Brouillon restauré",
+    "discard": "Annuler",
+    "source": {
+      "clone": "Cloner à partir de l'audio",
+      "builtin": "Voix intégrée"
+    },
+    "builtin": {
+      "hint": "Choisissez une voix pré-construite. Ces voix ne nécessitent pas d'échantillon audio.",
+      "badge": "Voix intégrée",
+      "note": "Ce profil utilise une voix intégrée. La voix ne peut pas être modifiée après la création."
+    },
+    "sampleTabs": {
+      "upload": "Importer",
+      "record": "Enregistrer",
+      "system": "Audio système"
+    },
+    "fields": {
+      "engine": "Moteur",
+      "voice": "Voix",
+      "name": "Nom",
+      "namePlaceholder": "Ma voix",
+      "descriptionLabel": "Description (optionnelle)",
+      "descriptionPlaceholder": "Décrivez cette voix…",
+      "language": "Langue",
+      "referenceText": "Texte de référence",
+      "referenceTextPlaceholder": "Saisissez le texte exact prononcé dans l'audio…",
+      "defaultEngine": "Moteur par défaut",
+      "noPreference": "Aucune préférence",
+      "defaultEngineHint": "Sélectionne automatiquement ce moteur lorsque le profil est choisi.",
+      "defaultEffects": "Effets par défaut",
+      "defaultEffectsHint": "Effets appliqués automatiquement à toutes les nouvelles générations avec cette voix.",
+      "personalityLabel": "Personnalité",
+      "personalityPlaceholder": "ex. « un pirate grincheux qui ne parle qu'en métaphores maritimes »",
+      "personalityHint": "Qui est cette voix et comment elle parle. Contrôle le bouton Composer et le bouton d'écriture dans le personnage sur la page de génération. Laissez vide pour masquer les deux."
+    },
+    "avatar": {
+      "alt": "Aperçu de l'avatar"
+    },
+    "actions": {
+      "saving": "Enregistrement…",
+      "saveChanges": "Enregistrer les modifications",
+      "createProfile": "Créer le profil"
+    },
+    "validation": {
+      "nameRequired": "Le nom est requis",
+      "referenceRequired": "Le texte de référence est requis lors de l'ajout d'un échantillon",
+      "sampleRequired": "Un échantillon audio est requis",
+      "referenceTextRequired": "Le texte de référence est requis",
+      "audioTooLong": "L'audio est trop long ({{duration}}). La durée maximale est de {{max}}.",
+      "audioFailed": "Échec de la validation du fichier audio. Veuillez essayer un autre fichier."
+    },
+    "toast": {
+      "recordingComplete": "Enregistrement terminé",
+      "recordingCompleteDescription": "L'audio a été enregistré avec succès.",
+      "recordingError": "Erreur d'enregistrement",
+      "systemAudioCaptured": "Audio système capturé",
+      "systemAudioCapturedDescription": "L'audio a été capturé avec succès.",
+      "systemAudioError": "Erreur de capture audio système",
+      "transcribeFailed": "Échec de la transcription",
+      "transcribeFailedFallback": "Échec de la transcription audio",
+      "noFile": "Aucun fichier sélectionné",
+      "noFileDescription": "Veuillez d'abord sélectionner un fichier audio.",
+      "invalidFile": "Type de fichier invalide",
+      "invalidImageFormat": "Veuillez sélectionner un fichier image (PNG, JPG ou WebP)",
+      "fileTooLarge": "Fichier trop volumineux",
+      "imageTooLargeDescription": "L'image doit faire moins de 5 Mo",
+      "avatarRemoved": "Avatar supprimé",
+      "avatarRemovedDescription": "L'image de l'avatar a été supprimée avec succès.",
+      "avatarRemoveFailed": "Échec de la suppression de l'avatar",
+      "avatarUploadFailed": "Échec du téléchargement de l'avatar",
+      "avatarUploadFailedFallback": "Échec du téléchargement de l'avatar",
+      "effectsUpdateFailed": "Échec de la mise à jour des effets",
+      "effectsUpdateFailedFallback": "Échec de l'enregistrement de la chaîne d'effets",
+      "voiceUpdated": "Voix mise à jour",
+      "voiceUpdatedDescription": "\"{{name}}\" a été mis à jour avec succès.",
+      "noVoiceSelected": "Aucune voix sélectionnée",
+      "noVoiceSelectedDescription": "Veuillez sélectionner une voix intégrée.",
+      "profileCreated": "Profil créé",
+      "profileCreatedBuiltin": "\"{{name}}\" a été créé avec une voix intégrée.",
+      "profileCreatedSample": "\"{{name}}\" a été créé avec un échantillon.",
+      "sampleRequired": "Échantillon audio requis",
+      "sampleRequiredDescription": "Veuillez fournir un échantillon audio pour créer le profil vocal.",
+      "referenceTextRequired": "Texte de référence requis",
+      "referenceTextRequiredDescription": "Veuillez fournir le texte de référence pour l'échantillon audio.",
+      "invalidAudio": "Fichier audio invalide",
+      "invalidAudioDescription": "La durée audio est de {{duration}}, mais le maximum est {{max}}.",
+      "validationError": "Erreur de validation",
+      "rollbackFailed": "Échec de l'annulation",
+      "rollbackFailedDescription": "Le profil créé n'a pas pu être supprimé après l'échec du téléchargement de l'échantillon.",
+      "profileRolledBack": "Le profil a été annulé.",
+      "sampleFailed": "Échec de l'ajout de l'échantillon",
+      "sampleFailedDescription": "Échec de l'ajout de l'échantillon.",
+      "sampleFailedRolledBack": "Échec de l'ajout de l'échantillon. Le profil a été annulé.",
+      "saveFailed": "Échec de l'enregistrement du profil"
+    }
+  },
+  "audioSample": {
+    "chooseFile": "Choisir un fichier",
+    "uploadHint": "Cliquez pour choisir un fichier ou glissez-déposez. Durée maximale : 30 secondes.",
+    "fileUploaded": "Fichier téléchargé",
+    "fileLabel": "Fichier : {{name}}",
+    "play": "Lire",
+    "pause": "Pause",
+    "transcribe": "Transcrire",
+    "transcribing": "Transcription…",
+    "remove": "Retirer",
+    "startRecording": "Commencer l'enregistrement",
+    "recordHint": "Cliquez pour commencer l'enregistrement. Durée maximale : 30 secondes.",
+    "stopRecording": "Arrêter l'enregistrement",
+    "remaining": "{{time}} restant",
+    "recordingComplete": "Enregistrement terminé",
+    "recordAgain": "Enregistrer à nouveau",
+    "startCapture": "Démarrer la capture",
+    "systemHint": "Capturez l'audio de votre système. Durée maximale : 30 secondes.",
+    "stopCapture": "Arrêter la capture",
+    "captureComplete": "Capture terminée",
+    "captureAgain": "Capturer à nouveau"
+  },
+  "sampleList": {
+    "loading": "Chargement des échantillons…",
+    "empty": {
+      "title": "Encore aucun échantillon",
+      "hint": "Ajoutez votre premier échantillon audio pour commencer"
+    },
+    "editing": "Modification de la transcription",
+    "placeholder": "Saisissez le texte de référence…",
+    "saving": "Enregistrement…",
+    "editTranscription": "Modifier la transcription",
+    "deleteSample": "Supprimer l'échantillon",
+    "addSample": "Ajouter un échantillon",
+    "note": "Remarque : un seul échantillon de 30 secondes est idéal. La qualité peut diminuer avec plusieurs échantillons. Dans une future mise à jour, les échantillons pourraient être interchangeables et étiquetés pour différents styles d'une même voix.",
+    "deleteDialog": {
+      "title": "Supprimer l'échantillon",
+      "description": "Êtes-vous sûr de vouloir supprimer cet échantillon audio ? Cette action est irréversible.",
+      "deleting": "Suppression…"
+    },
+    "player": {
+      "play": "Lire l'échantillon",
+      "pause": "Pause",
+      "stop": "Arrêter",
+      "stopAria": "Arrêter la lecture",
+      "position": "Position de lecture de l'échantillon",
+      "positionValue": "{{current}} sur {{total}}"
+    },
+    "toast": {
+      "invalidText": "Texte invalide",
+      "invalidTextDescription": "Le texte de référence ne peut pas être vide.",
+      "updated": "Échantillon mis à jour",
+      "updatedDescription": "Le texte de référence a été mis à jour avec succès.",
+      "updateFailed": "Échec de la mise à jour",
+      "updateFailedFallback": "Échec de la mise à jour de l'échantillon"
+    }
+  },
+  "profiles": {
+    "card": {
+      "noDescription": "Aucune description",
+      "designed": "conçu pour",
+      "export": "Exporter le profil",
+      "edit": "Modifier le profil",
+      "delete": "Supprimer le profil",
+      "selectLabel": "{{name}}, {{language}}. Sélectionnez comme voix pour la génération.",
+      "selectLabelSelected": "{{name}}, {{language}}. Sélectionné comme voix pour la génération."
+    },
+    "list": {
+      "errorLoading": "Erreur lors du chargement des profils : {{message}}",
+      "empty": "Encore aucun profil vocal. Créez votre premier profil pour commencer.",
+      "createVoice": "Créer une voix",
+      "unsupportedNote": "Seuls les profils vocaux pris en charge peuvent être sélectionnés pour le modèle actuel."
+    },
+    "deleteDialog": {
+      "title": "Supprimer le profil",
+      "body": "Êtes-vous sûr de vouloir supprimer \"{{name}}\" ? Cette action est irréversible.",
+      "deleting": "Suppression…"
+    }
+  },
+  "effects": {
+    "title": "Effets",
+    "newPreset": "Nouveau préréglage",
+    "noDescription": "Aucune description",
+    "placeholder": "Sélectionnez un préréglage ou créez-en un nouveau",
+    "effectCount_one": "{{count}} effet",
+    "effectCount_other": "{{count}} effets",
+    "sections": {
+      "builtin": "Intégré",
+      "custom": "Personnalisé",
+      "new": "Nouveau"
+    },
+    "badge": {
+      "builtin": "intégré"
+    },
+    "unsaved": {
+      "title": "Préréglage non enregistré",
+      "hint": "Configurez les effets dans le panneau de droite."
+    },
+    "detail": {
+      "newTitle": "Nouveau préréglage",
+      "editTitle": "Modifier le préréglage",
+      "savePreset": "Enregistrer le préréglage",
+      "saveAsCustom": "Enregistrer comme personnalisé",
+      "saving": "Enregistrement…",
+      "deleting": "Suppression…"
+    },
+    "fields": {
+      "name": "Nom",
+      "namePlaceholder": "Mon préréglage…",
+      "description": "Description",
+      "descriptionPlaceholder": "Décrivez ce que fait ce préréglage…"
+    },
+    "preview": {
+      "label": "Aperçu",
+      "button": "Aperçu",
+      "processing": "Traitement…",
+      "hint": "L'aperçu applique les effets à la version nette sans enregistrer."
+    },
+    "saveAs": {
+      "title": "Enregistrer comme préréglage personnalisé",
+      "description": "Créez un nouveau préréglage personnalisé basé sur la chaîne d'effets actuelle.",
+      "suggestedName": "{{name}} (Copie)"
+    },
+    "toast": {
+      "saved": "Préréglage enregistré",
+      "createdDescription": "\"{{name}}\" a été créé.",
+      "updated": "Préréglage mis à jour",
+      "deleted": "Préréglage supprimé",
+      "saveFailed": "Échec de l'enregistrement",
+      "deleteFailed": "Échec de la suppression",
+      "previewFailed": "Échec de l'aperçu",
+      "nameRequired": "Nom requis"
+    },
+    "chain": {
+      "loadPreset": "Charger un préréglage…",
+      "addEffect": "Ajouter un effet…",
+      "clear": "Effacer",
+      "enable": "Activer",
+      "disable": "Désactiver",
+      "remove": "Retirer"
+    },
+    "types": {
+      "chorus": {
+        "label": "Chorus / Flanger",
+        "params": {
+          "rate_hz": "Vitesse LFO (Hz)",
+          "depth": "Profondeur de modulation",
+          "feedback": "Taux de réinjection",
+          "centre_delay_ms": "Délai central (ms)",
+          "mix": "Mélange sec/humide"
+        }
+      },
+      "reverb": {
+        "label": "Réverbération",
+        "params": {
+          "room_size": "Taille de la pièce",
+          "damping": "Amortissement hautes fréquences",
+          "wet_level": "Niveau humide",
+          "dry_level": "Niveau sec",
+          "width": "Largeur stéréo"
+        }
+      },
+      "delay": {
+        "label": "Délai",
+        "params": {
+          "delay_seconds": "Temps de délai (secondes)",
+          "feedback": "Taux de réinjection",
+          "mix": "Mélange sec/humide"
+        }
+      },
+      "compressor": {
+        "label": "Compresseur",
+        "params": {
+          "threshold_db": "Seuil (dB)",
+          "ratio": "Taux de compression",
+          "attack_ms": "Temps d'attaque (ms)",
+          "release_ms": "Temps de relâchement (ms)"
+        }
+      },
+      "gain": {
+        "label": "Gain",
+        "params": {
+          "gain_db": "Gain (dB)"
+        }
+      },
+      "highpass": {
+        "label": "Filtre passe-haut",
+        "params": {
+          "cutoff_frequency_hz": "Fréquence de coupure (Hz)"
+        }
+      },
+      "lowpass": {
+        "label": "Filtre passe-bas",
+        "params": {
+          "cutoff_frequency_hz": "Fréquence de coupure (Hz)"
+        }
+      },
+      "pitch_shift": {
+        "label": "Décalage de tonalité",
+        "params": {
+          "semitones": "Demi-tons de décalage"
+        }
+      }
+    },
+    "builtinPresets": {
+      "Robotic": {
+        "name": "Robotique",
+        "description": "Voix robotique métallique (flanger avec LFO lent et fort feedback)"
+      },
+      "Radio": {
+        "name": "Radio",
+        "description": "Voix de radio AM avec filtrage passe-bande et légère compression"
+      },
+      "Echo Chamber": {
+        "name": "Chambre d'écho",
+        "description": "Réverbération spacieuse avec écho prolongé"
+      },
+      "Deep Voice": {
+        "name": "Voix grave",
+        "description": "Tonalité plus basse avec chaleur ajoutée"
+      }
+    }
+  },
+  "stories": {
+    "title": "Histoires",
+    "newStory": "Nouvelle histoire",
+    "loading": "Chargement des histoires…",
+    "searchPlaceholder": "Rechercher des histoires…",
+    "empty": {
+      "title": "Encore aucune histoire",
+      "hint": "Créez votre première histoire pour commencer",
+      "noMatches": "Aucune histoire ne correspond à \"{{query}}\""
+    },
+    "row": {
+      "itemCount_one": "{{count}} élément",
+      "itemCount_other": "{{count}} éléments",
+      "ariaLabel": "Histoire {{name}}, {{count}} éléments, {{updated}}",
+      "actionsLabel": "Actions pour {{name}}"
+    },
+    "createDialog": {
+      "title": "Créer une nouvelle histoire",
+      "description": "Créez une nouvelle histoire pour organiser vos générations vocales en conversations.",
+      "action": "Créer",
+      "creating": "Création…"
+    },
+    "editDialog": {
+      "title": "Modifier l'histoire",
+      "description": "Mettez à jour le nom et la description de l'histoire.",
+      "saving": "Enregistrement…"
+    },
+    "deleteDialog": {
+      "title": "Êtes-vous sûr ?",
+      "description": "Cela supprimera définitivement l'histoire et tous ses éléments. Cette action est irréversible.",
+      "deleting": "Suppression…"
+    },
+    "fields": {
+      "name": "Nom",
+      "namePlaceholder": "Mon histoire",
+      "descriptionLabel": "Description (optionnelle)",
+      "descriptionPlaceholder": "Une conversation entre…"
+    },
+    "toast": {
+      "nameRequired": "Nom requis",
+      "nameRequiredDescription": "Veuillez saisir un nom pour l'histoire",
+      "created": "Histoire créée",
+      "createdDescription": "\"{{name}}\" a été créé",
+      "createFailed": "Échec de la création de l'histoire",
+      "updateFailed": "Échec de la mise à jour de l'histoire",
+      "deleteFailed": "Échec de la suppression de l'histoire"
+    }
+  },
+  "storyContent": {
+    "selectStory": {
+      "title": "Sélectionnez une histoire",
+      "hint": "Choisissez une histoire dans la liste pour voir son contenu"
+    },
+    "loading": "Chargement de l'histoire…",
+    "notFound": {
+      "title": "Histoire introuvable",
+      "hint": "L'histoire sélectionnée n'a pas pu être chargée"
+    },
+    "generatingCount_one": "Génération de {{count}} audio",
+    "generatingCount_other": "Génération de {{count}} audios",
+    "add": "Ajouter",
+    "searchPlaceholder": "Rechercher par nom ou transcription…",
+    "searchNoMatches": "Aucune génération correspondante trouvée",
+    "searchNoAvailable": "Aucune génération disponible",
+    "exportAudio": "Exporter l'audio",
+    "empty": {
+      "title": "Aucun élément dans cette histoire",
+      "hint": "Générez de la parole avec la zone ci-dessous pour ajouter des éléments"
+    },
+    "itemActions": {
+      "playFromHere": "Lire à partir d'ici",
+      "regenerate": "Régénérer",
+      "removeFromStory": "Retirer de l'histoire"
+    },
+    "importAudio": "Importer de l'audio…",
+    "importing": "Importation…",
+    "dropToImport": "Déposez l'audio pour l'importer",
+    "toast": {
+      "removeFailed": "Échec du retrait de l'élément",
+      "reorderFailed": "Échec du réordonnancement",
+      "exportFailed": "Échec de l'exportation audio",
+      "addFailed": "Échec de l'ajout de la génération",
+      "regenerateFailed": "Échec de la régénération",
+      "importFailed": "Échec de l'importation audio"
+    }
+  },
+  "history": {
+    "empty": "Encore aucune génération vocale…",
+    "actions": {
+      "menu": "Actions",
+      "play": "Lire",
+      "exportAudio": "Exporter l'audio",
+      "exportPackage": "Exporter le package",
+      "applyEffects": "Appliquer les effets",
+      "regenerate": "Régénérer"
+    },
+    "deleteDialog": {
+      "title": "Supprimer la génération",
+      "body": "Êtes-vous sûr de vouloir supprimer cette génération de \"{{name}}\" ? Cette action est irréversible.",
+      "deleting": "Suppression…"
+    },
+    "clearFailedDialog": {
+      "title": "Effacer les générations échouées",
+      "body_one": "Cela supprimera définitivement {{count}} génération échouée de votre historique. Cette action est irréversible.",
+      "body_other": "Cela supprimera définitivement {{count}} générations échouées de votre historique. Cette action est irréversible.",
+      "clearing": "Nettoyage…",
+      "clearAll": "Tout effacer"
+    },
+    "importDialog": {
+      "title": "Importer une génération",
+      "body": "Importez la génération de \"{{name}}\". Cela l'ajoutera à votre historique.",
+      "importing": "Importation…",
+      "action": "Importer"
+    },
+    "effectsDialog": {
+      "title": "Appliquer les effets",
+      "body": "Configurez les effets de post-traitement à appliquer à cette génération. Une nouvelle version sera créée.",
+      "sourceLabel": "Source",
+      "sourcePlaceholder": "Sélectionnez la version source",
+      "apply": "Appliquer",
+      "applying": "Application…"
+    }
+  },
+  "generation": {
+    "placeholder": {
+      "storyWithEffects": "Générer de la parole pour \"{{name}}\"… (tapez / pour les effets)",
+      "story": "Générer de la parole pour \"{{name}}\"…",
+      "profile": "Générer de la parole avec {{name}}…",
+      "effectsHint": "Tapez / pour des effets comme [rire], [soupir]…",
+      "selectVoice": "Sélectionnez un profil vocal ci-dessus…"
+    },
+    "button": {
+      "generate": "Générer la parole",
+      "generating": "Génération…",
+      "selectFirst": "Sélectionnez d'abord un profil vocal"
+    },
+    "instruct": {
+      "show": "Afficher les instructions d'interprétation",
+      "hide": "Masquer les instructions d'interprétation",
+      "tooltip": "Instructions d'interprétation (ton, émotion, rythme)",
+      "placeholder": "Instructions d'interprétation — ex. Parle lentement avec chaleur, Autoritaire et clair…"
+    },
+    "voiceSelector": {
+      "placeholder": "Sélectionnez une voix…"
+    },
+    "effects": {
+      "none": "Aucun effet",
+      "profileDefault": "Profil par défaut"
+    },
+    "compose": {
+      "tooltip": "Composer",
+      "ariaLabel": "Composer une réplique dans le personnage",
+      "failedTitle": "Échec de la composition",
+      "failedDescription": "Impossible de générer du texte à partir de cette personnalité."
+    },
+    "persona": {
+      "tooltipActive": "Parle dans le personnage",
+      "tooltipInactive": "Parler dans le personnage",
+      "ariaLabelActive": "Parle dans le personnage",
+      "ariaLabelInactive": "Parler dans le personnage"
+    }
+  },
+  "main": {
+    "importVoice": "Importer une voix",
+    "createVoice": "Créer une voix",
+    "import": {
+      "invalidTitle": "Type de fichier invalide",
+      "invalidDescription": "Veuillez sélectionner un fichier .voicebox.zip valide",
+      "successTitle": "Profil importé",
+      "successDescription": "Profil vocal importé avec succès",
+      "failedTitle": "Échec de l'importation du profil",
+      "dialogTitle": "Importer le profil",
+      "dialogDescription": "Importez le profil de \"{{name}}\". Cela créera un nouveau profil avec tous les échantillons.",
+      "importing": "Importation…",
+      "action": "Importer"
+    }
+  },
+  "settings": {
+    "tabs": {
+      "general": "Général",
+      "generation": "Génération",
+      "captures": "Captures",
+      "mcp": "MCP",
+      "gpu": "GPU",
+      "logs": "Journaux",
+      "changelog": "Notes de version",
+      "about": "À propos"
+    },
+    "language": {
+      "label": "Langue",
+      "description": "Choisissez la langue d'affichage de Voicebox."
+    },
+    "theme": {
+      "label": "Thème",
+      "description": "Suivez votre système ou choisissez une apparence claire ou sombre fixe.",
+      "options": {
+        "system": "Système",
+        "light": "Clair",
+        "dark": "Sombre"
+      }
+    },
+    "general": {
+      "docs": { "title": "Lire la documentation" },
+      "discord": { "title": "Rejoindre le Discord", "subtitle": "Obtenez de l'aide et partagez des voix" },
+      "serverUrl": {
+        "title": "URL du serveur",
+        "description": "L'adresse de votre serveur Voicebox.",
+        "invalidUrl": "Veuillez saisir une URL valide",
+        "updatedTitle": "URL du serveur mise à jour",
+        "updatedDescription": "Connecté à {{url}}"
+      },
+      "keepServerRunning": {
+        "title": "Garder le serveur actif à la fermeture de l'application",
+        "description": "Le serveur continuera de fonctionner en arrière-plan après la fermeture de l'application.",
+        "failedTitle": "Échec de la mise à jour du paramètre",
+        "failedDescription": "Impossible de synchroniser le paramètre avec le serveur.",
+        "updatedTitle": "Paramètre mis à jour",
+        "runningDescription": "Le serveur continuera de fonctionner à la fermeture de l'application",
+        "stoppedDescription": "Le serveur s'arrêtera à la fermeture de l'application"
+      },
+      "networkAccess": {
+        "title": "Autoriser l'accès réseau",
+        "description": "Rend le serveur accessible depuis d'autres appareils sur votre réseau. Redémarrez l'application après modification.",
+        "updatedTitle": "Paramètre mis à jour",
+        "enabled": "Accès réseau activé. Redémarrez l'application pour appliquer.",
+        "disabled": "Accès réseau désactivé. Redémarrez l'application pour appliquer."
+      },
+      "connection": {
+        "connecting": "Connexion",
+        "offline": "Hors ligne",
+        "online": "En ligne"
+      },
+      "updates": {
+        "title": "Mises à jour de l'application",
+        "devSuffix": " (dev)",
+        "devMode": {
+          "title": "Mode développement",
+          "description": "Les mises à jour automatiques sont désactivées en mode développement."
+        },
+        "check": {
+          "title": "Vérifier les mises à jour",
+          "available": "Version {{version}} disponible",
+          "checking": "Vérification…",
+          "upToDate": "Vous êtes à jour",
+          "button": "Vérifier"
+        },
+        "error": "Erreur de mise à jour",
+        "download": {
+          "title": "Mettre à jour vers {{version}}",
+          "description": "Téléchargez et installez la dernière version.",
+          "button": "Télécharger"
+        },
+        "downloading": "Téléchargement de la mise à jour…",
+        "ready": {
+          "title": "Mise à jour prête à installer",
+          "description": "La version {{version}} a été téléchargée. Redémarrez pour terminer.",
+          "button": "Redémarrer maintenant"
+        }
+      },
+      "api": {
+        "title": "Accès API",
+        "description": "Intégrez Voicebox dans votre flux de travail via l'API REST à <code>{{url}}</code>",
+        "viewReference": "Voir la référence API complète",
+        "endpoints": {
+          "generate": "Générer de la parole",
+          "health": "État du serveur",
+          "profiles": "Lister les voix",
+          "history": "Générations passées"
+        }
+      }
+    },
+    "generation": {
+      "title": "Génération",
+      "description": "Contrôles pour la génération de texte long. Ces paramètres s'appliquent à tous les moteurs.",
+      "chunkLimit": {
+        "title": "Limite de découpage automatique",
+        "description": "Le texte long est divisé en segments aux limites de phrases. Des valeurs plus faibles peuvent améliorer la qualité pour les sorties longues.",
+        "value": "{{chars}} caractères"
+      },
+      "crossfade": {
+        "title": "Fondu enchaîné",
+        "description": "Fusionne l'audio entre les segments pour des transitions fluides. Mettez à 0 pour une coupure nette.",
+        "cut": "Coupure",
+        "ms": "{{ms}}ms"
+      },
+      "normalize": {
+        "title": "Normaliser l'audio",
+        "description": "Ajuste le volume de sortie à un niveau cohérent entre les générations."
+      },
+      "autoplay": {
+        "title": "Lecture automatique",
+        "description": "Lire automatiquement l'audio lorsqu'une génération est terminée."
+      },
+      "folder": {
+        "title": "Dossier des générations",
+        "description": "Où les fichiers audio générés sont stockés sur le disque.",
+        "open": "Ouvrir"
+      },
+      "sidebar": {
+        "aboutTitle": "À propos de la génération vocale",
+        "aboutBody": "Clonez une voix à partir d'un court échantillon, puis générez de la parole dans n'importe quelle voix et n'importe quelle langue. Intégrez la TTS dans des agents IA, des jeux, des podcasts ou des narrations longues.",
+        "differencesTitle": "Ce qui est différent",
+        "clone": {
+          "title": "Clonez n'importe quelle voix en quelques secondes.",
+          "body": "Quelques secondes d'audio de référence suffisent. Prise en charge multi-échantillons pour une qualité supérieure quand vous le souhaitez."
+        },
+        "engines": {
+          "title": "Sept moteurs, 23 langues.",
+          "body": "Choisissez le compromis qui vous convient — qualité, vitesse ou couverture multilingue."
+        },
+        "agentReady": {
+          "title": "Prêt pour les agents.",
+          "body": "API REST avec contrôle par profil — donnez une voix que vous avez clonée à n'importe quelle IA."
+        }
+      }
+    },
+    "captures": {
+      "dictation": {
+        "title": "Dictée",
+        "description": "Capturez depuis n'importe où sur votre machine avec un raccourci global.",
+        "globalShortcut": {
+          "title": "Raccourci global",
+          "description": "Maintenez le raccourci pour enregistrer depuis n'importe où sur votre machine. Relâchez pour transcrire."
+        },
+        "pushToTalk": {
+          "title": "Raccourci push-to-talk",
+          "description": "Maintenez ces touches n'importe où sur votre système pour enregistrer. Relâchez pour arrêter et transcrire.",
+          "change": "Modifier"
+        },
+        "toggle": {
+          "title": "Raccourci bascule",
+          "description": "Appuyez une fois pour démarrer un enregistrement mains-libres. Appuyez à nouveau pour arrêter. Généralement push-to-talk plus Espace.",
+          "change": "Modifier"
+        },
+        "chordPicker": {
+          "pttTitle": "Définir le raccourci push-to-talk",
+          "pttDescription": "Maintenez les touches souhaitées, puis relâchez et cliquez sur Enregistrer. Le badge de modification droite/gauche indique de quel côté est une touche.",
+          "toggleTitle": "Définir le raccourci bascule",
+          "toggleDescription": "Maintenez les touches souhaitées, puis relâchez et cliquez sur Enregistrer. Choisissez quelque chose de distinct de votre combinaison push-to-talk."
+        },
+        "preview": {
+          "title": "Aperçu",
+          "description": "Ce qui s'affiche à l'écran pendant que vous maintenez le raccourci."
+        },
+        "copyToClipboard": {
+          "title": "Copier la transcription dans le presse-papiers",
+          "description": "La transcription nettoyée arrive dans votre presse-papiers à la fin de la capture."
+        },
+        "autoPaste": {
+          "title": "Coller automatiquement dans le champ de texte actif",
+          "description": "Si un champ de texte est actif dans une autre application, collez-y directement. Voicebox sauvegarde et restaure le contenu de votre presse-papiers."
+        }
+      },
+      "transcription": {
+        "title": "Transcription",
+        "description": "Choisissez quel modèle de reconnaissance vocale est utilisé pour vos captures.",
+        "model": {
+          "title": "Modèle de transcription",
+          "description": "Whisper est fourni avec Voicebox et fonctionne entièrement sur votre machine.",
+          "base": "Whisper Base · 74M · {{tail}}",
+          "small": "Whisper Small · 244M · {{tail}}",
+          "medium": "Whisper Medium · 769M · {{tail}}",
+          "large": "Whisper Large · 1,5B · {{tail}}",
+          "turbo": "Whisper Turbo · Pruned Large v3 · {{tail}}",
+          "tail": {
+            "fast": "Rapide",
+            "balanced": "Équilibré",
+            "higher": "Meilleure précision",
+            "best": "Meilleure précision",
+            "nearBest": "Presque meilleur, rapide"
+          }
+        },
+        "language": {
+          "title": "Langue",
+          "description": "La détection automatique fonctionne pour la plupart des captures. Verrouillez-la si vous parlez toujours la même langue.",
+          "auto": "Détection automatique",
+          "en": "Anglais",
+          "es": "Espagnol",
+          "fr": "Français",
+          "de": "Allemand",
+          "ja": "Japonais",
+          "zh": "Chinois",
+          "hi": "Hindi"
+        },
+        "archive": {
+          "title": "Archiver l'audio",
+          "description": "Conservez l'enregistrement original avec chaque transcription."
+        }
+      },
+      "refinement": {
+        "title": "Correction",
+        "description": "Optionnellement, exécutez un LLM local sur les transcriptions pour nettoyer les mots de remplissage, la ponctuation et les auto-corrections.",
+        "auto": {
+          "title": "Corriger automatiquement les transcriptions",
+          "description": "S'exécute après chaque capture. Vous pouvez toujours basculer entre brut et corrigé dans l'onglet Captures."
+        },
+        "model": {
+          "title": "Modèle de correction",
+          "description": "Les modèles plus grands sont plus lents mais gèrent mieux les auto-corrections subtiles et le vocabulaire technique.",
+          "size06": "Qwen3 · 0,6B · 400 Mo · {{tail}}",
+          "size17": "Qwen3 · 1,7B · 1,1 Go · {{tail}}",
+          "size40": "Qwen3 · 4B · 2,5 Go · {{tail}}",
+          "tail": {
+            "veryFast": "Très rapide",
+            "fast": "Rapide",
+            "fullQuality": "Qualité optimale"
+          }
+        },
+        "smartCleanup": {
+          "title": "Nettoyage intelligent",
+          "description": "Supprime les mots de remplissage (euh, hum, genre), rétablit la ponctuation et corrige les majuscules sans reformuler."
+        },
+        "selfCorrection": {
+          "title": "Supprimer les auto-corrections",
+          "description": "Quand vous changez d'avis en milieu de phrase (« en fait non… », « attends, je voulais dire… »), supprimez la partie retirée et gardez l'intention finale."
+        },
+        "preserveTechnical": {
+          "title": "Préserver les termes techniques",
+          "description": "Gardez les identifiants de code, les noms de commandes et les acronymes exactement comme prononcés. Activez quand vous dictez dans une invite de code."
+        }
+      },
+      "playback": {
+        "title": "Lecture",
+        "description": "Voix par défaut pour l'action « Lire avec » dans l'onglet Captures.",
+        "defaultVoice": {
+          "title": "Voix par défaut",
+          "description": "Utilisée quand vous cliquez sur Lire avec sans choisir de voix au préalable. Vous pouvez la changer par capture.",
+          "noClonedVoices": "Aucune voix clonée",
+          "noneSelected": "Aucune sélectionnée",
+          "clonedVoices": "Voix clonées"
+        }
+      },
+      "storage": {
+        "title": "Stockage",
+        "description": "Les captures sont sauvegardées sous forme de paires audio/transcription dans votre répertoire de données Voicebox.",
+        "retention": {
+          "title": "Rétention",
+          "description": "Durée de conservation des captures. S'applique à l'audio et aux transcriptions.",
+          "forever": "Garder indéfiniment",
+          "d90": "90 jours",
+          "d30": "30 jours",
+          "d7": "7 jours"
+        },
+        "folder": {
+          "title": "Dossier des captures",
+          "description": "Où les audios et transcriptions des captures sont stockés sur le disque.",
+          "open": "Ouvrir"
+        }
+      },
+      "sidebar": {
+        "aboutTitle": "À propos des Captures",
+        "aboutBody": "Maintenez un raccourci n'importe où sur votre machine, parlez, et Voicebox transforme votre voix en texte. Rejouez-la avec n'importe quelle voix clonée, collez-la dans n'importe quelle application, ou transmettez-la à votre agent de codage.",
+        "differencesTitle": "Ce qui est différent",
+        "local": {
+          "title": "Entièrement local.",
+          "body": "Whisper et le LLM de correction fonctionnent sur votre matériel. Pas de cloud, pas de comptes, votre voix ne quitte jamais votre machine."
+        },
+        "playAs": {
+          "title": "Lire avec n'importe quelle voix.",
+          "body": "Les transcriptions peuvent être lues avec n'importe quel profil que vous avez cloné."
+        },
+        "crossPlatform": {
+          "title": "Multi-plateforme.",
+          "body": "Même raccourci, même flux sur macOS, Windows et Linux."
+        },
+        "windowsCaveat": {
+          "title": "Attention sur Windows",
+          "body": "Le raccourci ne fonctionne pas lorsque Voicebox ou une application en mode administrateur est active. En cours d'amélioration."
+        }
+      }
+    },
+    "mcp": {
+      "install": {
+        "title": "Installer dans votre agent",
+        "description": "Voicebox expose un serveur MCP local dès que l'application est ouverte. Collez l'un de ces extraits dans la configuration MCP de votre agent.",
+        "http": {
+          "title": "HTTP (recommandé)",
+          "description": "Pour les clients qui parlent HTTP MCP — Claude Code, Cursor, Windsurf, VS Code."
+        },
+        "claudeCode": {
+          "title": "Commande unique Claude Code",
+          "description": "S'enregistre via l'interface CLI de Claude Code."
+        },
+        "stdio": {
+          "title": "Stdio (solution de repli)",
+          "description": "Pour les clients qui ne font que lancer des processus stdio. Le binaire d'adaptation est fourni avec l'application."
+        },
+        "copy": "Copier",
+        "copied": "Copié"
+      },
+      "defaultVoice": {
+        "title": "Voix par défaut",
+        "description": "Utilisée quand un agent appelle voicebox.speak sans profil spécifique et sans liaison par client.",
+        "label": "Voix de lecture par défaut",
+        "labelHint": "Partagé avec la liste déroulante « Lire avec » de l'onglet Captures — une voix par défaut pour la lecture passive.",
+        "none": "(aucune)"
+      },
+      "bindings": {
+        "title": "Voix par agent",
+        "description": "Liez des agents spécifiques à des voix spécifiques pour savoir qui parle sans regarder. L'agent s'identifie via l'en-tête X-Voicebox-Client-Id (ou la variable d'env VOICEBOX_CLIENT_ID pour stdio).",
+        "empty": "Encore aucune liaison. Ajoutez-en une ci-dessous, puis configurez votre client MCP pour envoyer le <code>X-Voicebox-Client-Id</code> correspondant.",
+        "lastSeen": "vu {{when}}",
+        "lastSeenTitle": "Dernière vue {{when}}",
+        "neverConnected": "jamais connecté",
+        "defaultOption": "(par défaut)",
+        "removeAria": "Supprimer la liaison pour {{client}}",
+        "add": {
+          "title": "Ajouter une liaison",
+          "clientIdPlaceholder": "identifiant client (ex. claude-code)",
+          "labelPlaceholder": "étiquette (optionnelle)",
+          "action": "Ajouter la liaison"
+        }
+      },
+      "sidebar": {
+        "aboutTitle": "À propos de MCP",
+        "aboutBody": "Le Model Context Protocol permet à votre agent de codage IA — Claude Code, Cursor, Windsurf — d'appeler les outils de Voicebox. Parlez avec une voix clonée, transcrivez de l'audio, parcourez les captures.",
+        "toolsTitle": "Outils disponibles",
+        "tools": {
+          "speak": "Prononcer un texte avec un profil vocal.",
+          "transcribe": "STT Whisper sur un clip.",
+          "listCaptures": "Dictées / enregistrements récents.",
+          "listProfiles": "Profils vocaux disponibles."
+        },
+        "postSpeak": "Également accessible via <code>POST /speak</code> pour les scripts shell, ACP, A2A."
+      }
+    },
+    "gpu": {
+      "cpuOnly": "CPU uniquement",
+      "vramUsed": "{{mb}} Mo de VRAM",
+      "noAcceleration": "Aucune accélération GPU détectée",
+      "active": "Actif",
+      "cuda": {
+        "title": "Backend CUDA",
+        "description": "Accélération GPU NVIDIA via un backend CUDA téléchargeable.",
+        "downloading": "Téléchargement du backend CUDA…",
+        "downloadingShort": "Téléchargement…",
+        "updating": "Mise à jour…"
+      },
+      "restart": {
+        "ready": "Serveur redémarré avec succès",
+        "waiting": "Redémarrage du serveur…",
+        "stopping": "Arrêt du serveur…"
+      },
+      "download": {
+        "title": "Télécharger le backend CUDA",
+        "description": "~2,4 Go à télécharger. Nécessite un GPU NVIDIA avec support CUDA.",
+        "button": "Télécharger"
+      },
+      "switchToCuda": {
+        "title": "Passer au backend CUDA",
+        "description": "Le backend CUDA est téléchargé et prêt. Redémarrez pour activer.",
+        "button": "Redémarrer"
+      },
+      "switchToCpu": {
+        "title": "Passer au backend CPU",
+        "description": "Désactivez l'accélération GPU. Vous pourrez télécharger CUDA à nouveau plus tard.",
+        "button": "Basculer"
+      },
+      "remove": {
+        "title": "Supprimer le backend CUDA",
+        "description": "Supprimez le binaire CUDA téléchargé pour libérer de l'espace disque.",
+        "button": "Supprimer"
+      },
+      "errors": {
+        "downloadFailed": "Échec du téléchargement",
+        "downloadStart": "Échec du démarrage du téléchargement",
+        "restartFailed": "Échec du redémarrage",
+        "switchCpu": "Échec du basculement vers CPU",
+        "deleteCuda": "Échec de la suppression du backend CUDA"
+      },
+      "footer": "Voicebox détecte et utilise automatiquement le meilleur GPU disponible sur votre système. Sur les Mac Apple Silicon, le backend MLX fonctionne nativement sur le Neural Engine et le GPU via Metal Performance Shaders (MPS), sans configuration supplémentaire. Sur Windows et Linux avec GPU NVIDIA, vous pouvez télécharger un backend CUDA optionnel pour l'inférence accélérée par le matériel. AMD ROCm, Intel XPU et DirectML sont également pris en charge là où disponibles via PyTorch. Quand aucun GPU n'est détecté, Voicebox utilise le CPU — tous les moteurs fonctionnent, mais plus lentement."
+    },
+    "logs": {
+      "title": "Journaux du serveur",
+      "lineCount_one": "{{count}} ligne",
+      "lineCount_other": "{{count}} lignes",
+      "scrollToBottom": "Aller en bas",
+      "clear": "Effacer",
+      "empty": "Aucune sortie de journal pour le moment.",
+      "devHint": "Les journaux du serveur ne sont capturés que lorsque l'application gère le processus serveur (builds de production)."
+    },
+    "changelog": {
+      "devBadge": "dev",
+      "showLess": "Afficher moins",
+      "showMore": "Afficher plus"
+    },
+    "about": {
+      "tagline": "Le studio de synthèse vocale open-source. Clonez des voix, générez de la parole, appliquez des effets et créez des applications vocales — le tout en local sur votre machine.",
+      "createdBy": "Créé par",
+      "buyCoffee": "Offrez-moi un café",
+      "license": "Sous licence <link>MIT</link>"
+    }
+  },
+  "models": {
+    "title": "Modèles",
+    "subtitle": "Téléchargez et gérez les modèles IA pour la génération vocale et la transcription",
+    "defaultName": "Modèle",
+    "unknownSize": "Taille inconnue",
+    "sections": {
+      "voiceGeneration": "Génération vocale",
+      "transcription": "Transcription",
+      "languageModels": "Modèles de langage"
+    },
+    "status": {
+      "loaded": "Chargé"
+    },
+    "storage": {
+      "location": "Emplacement de stockage",
+      "open": "Ouvrir",
+      "change": "Changer",
+      "migrating": "Migration…",
+      "reset": "Réinitialiser",
+      "pickerTitle": "Choisir le dossier de stockage des modèles"
+    },
+    "progress": {
+      "connecting": "Connexion…",
+      "connectingHf": "Connexion à HuggingFace…"
+    },
+    "problems": {
+      "title": "Problèmes",
+      "clearAll": "Tout effacer",
+      "noDetails": "Aucun détail d'erreur disponible. Essayez de télécharger à nouveau.",
+      "startedAt": "démarré à {{time}}"
+    },
+    "detail": {
+      "loadingInfo": "Chargement des infos du modèle…",
+      "byAuthor": "par {{author}}",
+      "downloads": "Téléchargements",
+      "likes": "J'aime",
+      "license": "Licence",
+      "languagesCount": "{{count}} langues prises en charge",
+      "languagesList": "Langues : {{list}}",
+      "onDisk": "{{size}} sur le disque"
+    },
+    "actions": {
+      "download": "Télécharger",
+      "retry": "Réessayer",
+      "unload": "Décharger",
+      "unloading": "Déchargement…",
+      "unloadFirst": "Déchargez le modèle avant de le supprimer",
+      "deleteModel": "Supprimer le modèle"
+    },
+    "deleteDialog": {
+      "title": "Supprimer le modèle",
+      "body": "Êtes-vous sûr de vouloir supprimer <strong>{{name}}</strong> ?",
+      "sizeNote": "Cela libérera {{size}} d'espace disque. Le modèle devra être téléchargé à nouveau pour être utilisé.",
+      "deleting": "Suppression…"
+    },
+    "migrateDialog": {
+      "title": "Déplacer les modèles vers un nouvel emplacement ?",
+      "description": "Le serveur s'arrêtera pendant le déplacement des modèles vers le nouveau dossier. Il redémarrera automatiquement une fois la migration terminée.",
+      "action": "Déplacer les modèles",
+      "preparing": "Préparation…",
+      "restartingServer": "Redémarrage du serveur…"
+    },
+    "migrate": {
+      "title": "Déplacement des modèles",
+      "offline": "Le serveur est hors ligne pendant le déplacement des modèles."
+    },
+    "toast": {
+      "downloadFailed": "Échec du téléchargement",
+      "cancelFailed": "Échec de l'annulation",
+      "cancelFailedDescription": "Impossible d'annuler la tâche de téléchargement.",
+      "deleted": "Modèle supprimé",
+      "deletedDescription": "{{name}} a été supprimé avec succès.",
+      "deleteFailed": "Échec de la suppression",
+      "unloaded": "Modèle déchargé",
+      "unloadedDescription": "{{name}} a été déchargé de la mémoire.",
+      "unloadFailed": "Échec du déchargement",
+      "openFolderFailed": "Échec de l'ouverture du dossier du modèle",
+      "pickerFailed": "Échec de l'ouverture du sélecteur de dossier",
+      "resetToDefault": "Réinitialisation à l'emplacement par défaut. Redémarrage du serveur…",
+      "noModelsToMigrate": "Aucun modèle à migrer",
+      "noModelsToMigrateDescription": "Téléchargez au moins un modèle avant de changer l'emplacement de stockage.",
+      "migrated": "Modèles déplacés avec succès",
+      "migrationFailed": "Échec de la migration",
+      "migrationFailedGeneric": "Échec de la migration des modèles",
+      "migrationConnectionLost": "Connexion perdue pendant la migration"
+    }
+  }
+}

--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -1,5 +1,5 @@
 import { formatDistance } from 'date-fns';
-import { ja, zhCN, zhTW } from 'date-fns/locale';
+import { ja, zhCN, zhTW, fr } from 'date-fns/locale';
 import i18n from '@/i18n';
 
 export function formatDuration(seconds: number): string {
@@ -16,6 +16,8 @@ function getDateLocale() {
       return zhCN;
     case 'zh-TW':
       return zhTW;
+    case 'fr':
+      return fr;
     default:
       return undefined;
   }

--- a/tauri/vite.config.ts
+++ b/tauri/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     strictPort: true,
     // Watch files in the app directory for changes
     watch: {
-      ignored: ['!**/../app/**'],
+      ignored: ['!**/../app/**', '**/target/**'],
     },
   },
   envPrefix: ['VITE_', 'TAURI_'],


### PR DESCRIPTION
## Title
**Add French (fr) language support**

## Description
Adds French as a new UI language for Voicebox. The language selector automatically picks up the new entry from `SUPPORTED_LANGUAGES`.

### Changes
- **`app/src/i18n/locales/fr/translation.json`** — Full French translation of all UI strings (~1240 keys), covering navigation, captures, voices, effects, stories, generations, settings, models, and all dialog/toast messages. Pluralization keys (`_one`/`_other`) are translated correctly for French locale rules.
- **`app/src/i18n/index.ts`** — Registered `fr` in `SUPPORTED_LANGUAGES` and added the resource to i18next initialization.
- **`app/src/lib/utils/format.ts`** — Wired the `fr` locale from `date-fns` so relative dates (e.g., "il y a 3 minutes") display correctly.
- **`tauri/vite.config.ts`** — Added `**/target/**` to the file watcher ignore list to fix an `EBUSY` crash on Windows when Vite tries to watch Rust build artifacts.

### How to test
1. Open Settings → Language → select **Français**
2. The entire UI should display in French
3. Verify date formatting in capture cards and other timestamped elements

### Notes
- No backend changes required — translations are purely frontend.
- The translation file follows the same key structure as `en/translation.json`.
- Built-in preset names (e.g., "Robotic", "Radio") are translated but the English originals remain as-is in the engine layer, which is expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added French language support across the app, including a full French translation set.
  * French now appears as an available language option in settings.
  * Date and relative time formatting now follows French locale conventions when French is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->