### PR TITLE
feat: stream MLX TTS audio chunks

### DIFF
--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -2,24 +2,26 @@
 MLX backend implementation for TTS and STT using mlx-audio.
 """
 
-from typing import Optional, List, Tuple
 import asyncio
 import logging
-import numpy as np
+import threading
 from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage
 # This prevents mlx_audio from making network requests when models are cached
-from ..utils.hf_offline_patch import patch_huggingface_hub_offline, ensure_original_qwen_config_cached
+from ..utils.hf_offline_patch import ensure_original_qwen_config_cached, patch_huggingface_hub_offline
 
 patch_huggingface_hub_offline()
 ensure_original_qwen_config_cached()
 
-from . import TTSBackend, STTBackend, LANGUAGE_CODE_TO_NAME, WHISPER_HF_REPOS
-from .base import is_model_cached, combine_voice_prompts as _combine_voice_prompts, model_load_progress
-from ..utils.cache import get_cache_key, get_cached_voice_prompt, cache_voice_prompt
+from ..utils.cache import cache_voice_prompt, get_cache_key, get_cached_voice_prompt
+from . import LANGUAGE_CODE_TO_NAME, WHISPER_HF_REPOS
+from .base import combine_voice_prompts as _combine_voice_prompts, is_model_cached, model_load_progress
 
 
 class MLXTTSBackend:
@@ -193,61 +195,17 @@ class MLXTTSBackend:
 
         def _generate_sync():
             """Run synchronous generation in thread pool."""
-            # MLX generate() returns a generator yielding GenerationResult objects
             audio_chunks = []
             sample_rate = 24000
-            lang = LANGUAGE_CODE_TO_NAME.get(language, "auto")
 
-            # Set seed if provided (MLX uses numpy random)
-            if seed is not None:
-                import mlx.core as mx
-
-                np.random.seed(seed)
-                mx.random.seed(seed)
-
-            # Extract voice prompt info
-            ref_audio = voice_prompt.get("ref_audio") or voice_prompt.get("ref_audio_path")
-            ref_text = voice_prompt.get("ref_text", "")
-
-            # Validate that the audio file exists
-            if ref_audio and not Path(ref_audio).exists():
-                logger.warning("Audio file not found: %s", ref_audio)
-                logger.warning("This may be due to a cached voice prompt referencing a deleted temp file.")
-                logger.warning("Regenerating without voice prompt.")
-                ref_audio = None
-
-            # Inference runs with the process's default HF_HUB_OFFLINE
-            # state. Forcing offline here (previously used to avoid lazy
-            # mlx_audio lookups hanging when the network drops mid-inference,
-            # issue #462) regressed online users because libraries make
-            # legitimate metadata calls during generation.
-            try:
-                if ref_audio:
-                    # Check if generate accepts ref_audio parameter
-                    import inspect
-
-                    sig = inspect.signature(self.model.generate)
-                    if "ref_audio" in sig.parameters:
-                        # Generate with voice cloning
-                        for result in self.model.generate(text, ref_audio=ref_audio, ref_text=ref_text, lang_code=lang):
-                            audio_chunks.append(np.array(result.audio))
-                            sample_rate = result.sample_rate
-                    else:
-                        # Fallback: generate without voice cloning
-                        for result in self.model.generate(text, lang_code=lang):
-                            audio_chunks.append(np.array(result.audio))
-                            sample_rate = result.sample_rate
-                else:
-                    # No voice prompt, generate normally
-                    for result in self.model.generate(text, lang_code=lang):
-                        audio_chunks.append(np.array(result.audio))
-                        sample_rate = result.sample_rate
-            except Exception as e:
-                # If voice cloning fails, try without it
-                logger.warning("Voice cloning failed, generating without voice prompt: %s", e)
-                for result in self.model.generate(text, lang_code=lang):
-                    audio_chunks.append(np.array(result.audio))
-                    sample_rate = result.sample_rate
+            for chunk, chunk_sample_rate in self._iter_generate_sync(
+                text=text,
+                voice_prompt=voice_prompt,
+                language=language,
+                seed=seed,
+            ):
+                audio_chunks.append(chunk)
+                sample_rate = chunk_sample_rate
 
             # Concatenate all chunks
             if audio_chunks:
@@ -262,6 +220,124 @@ class MLXTTSBackend:
         audio, sample_rate = await asyncio.to_thread(_generate_sync)
 
         return audio, sample_rate
+
+    def _iter_generate_sync(
+        self,
+        *,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+    ):
+        """Yield MLX audio chunks from the synchronous model generator."""
+        lang = LANGUAGE_CODE_TO_NAME.get(language, "auto")
+
+        # Set seed if provided (MLX uses numpy random)
+        if seed is not None:
+            import mlx.core as mx
+
+            np.random.seed(seed)
+            mx.random.seed(seed)
+
+        # Extract voice prompt info
+        ref_audio = voice_prompt.get("ref_audio") or voice_prompt.get("ref_audio_path")
+        ref_text = voice_prompt.get("ref_text", "")
+
+        # Validate that the audio file exists
+        if ref_audio and not Path(ref_audio).exists():
+            logger.warning("Audio file not found: %s", ref_audio)
+            logger.warning("This may be due to a cached voice prompt referencing a deleted temp file.")
+            logger.warning("Regenerating without voice prompt.")
+            ref_audio = None
+
+        def _yield_results(*args, **kwargs):
+            for result in self.model.generate(*args, **kwargs):
+                yield np.asarray(result.audio, dtype=np.float32), result.sample_rate
+
+        # Inference runs with the process's default HF_HUB_OFFLINE
+        # state. Forcing offline here (previously used to avoid lazy
+        # mlx_audio lookups hanging when the network drops mid-inference,
+        # issue #462) regressed online users because libraries make
+        # legitimate metadata calls during generation.
+        try:
+            if ref_audio:
+                # Check if generate accepts ref_audio parameter
+                import inspect
+
+                sig = inspect.signature(self.model.generate)
+                if "ref_audio" in sig.parameters:
+                    # Generate with voice cloning
+                    yield from _yield_results(text, ref_audio=ref_audio, ref_text=ref_text, lang_code=lang)
+                    return
+
+            # No compatible voice prompt, generate normally
+            yield from _yield_results(text, lang_code=lang)
+        except Exception as e:
+            # If voice cloning fails, try without it
+            logger.warning("Voice cloning failed, generating without voice prompt: %s", e)
+            yield from _yield_results(text, lang_code=lang)
+
+    async def generate_stream(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ):
+        """Generate audio chunks as MLX yields them.
+
+        ``mlx_audio`` exposes a synchronous generator. We run that generator
+        in a worker thread and bridge each yielded audio chunk back onto the
+        request's event loop so ``StreamingResponse`` can send bytes without
+        waiting for the full waveform.
+        """
+        await self.load_model_async(None)
+
+        logger.info("Streaming audio for text: %s", text)
+
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+        stop_requested = threading.Event()
+
+        def _put(item):
+            loop.call_soon_threadsafe(queue.put_nowait, item)
+
+        def _generate_sync():
+            try:
+                for chunk, sample_rate in self._iter_generate_sync(
+                    text=text,
+                    voice_prompt=voice_prompt,
+                    language=language,
+                    seed=seed,
+                ):
+                    if stop_requested.is_set():
+                        break
+                    _put((chunk, sample_rate))
+            except Exception as e:
+                _put(e)
+            finally:
+                _put(None)
+
+        worker = asyncio.create_task(asyncio.to_thread(_generate_sync))
+
+        completed = False
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    completed = True
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                yield item
+        finally:
+            stop_requested.set()
+            if not completed and not worker.done():
+                worker.cancel()
+
+        if completed:
+            await worker
 
 
 class MLXSTTBackend:

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -10,11 +10,11 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import config, models
-from ..services import history, personality, profiles, tts
 from ..database import Generation as DBGeneration, VoiceProfile as DBVoiceProfile, get_db
+from ..services import history, personality, profiles, tts
 from ..services.generation import run_generation
 from ..services.task_queue import cancel_generation as cancel_generation_job, enqueue_generation
-from ..utils.audio import load_audio
+from ..utils.audio import audio_to_pcm16_bytes, load_audio, streaming_wav_header
 from ..utils.tasks import get_task_manager
 
 logger = logging.getLogger(__name__)
@@ -321,7 +321,12 @@ async def stream_speech(
     db: Session = Depends(get_db),
 ):
     """Generate speech and stream the WAV audio directly without saving to disk."""
-    from ..backends import get_tts_backend_for_engine, ensure_model_cached_or_raise, load_engine_model, engine_needs_trim
+    from ..backends import (
+        engine_needs_trim,
+        ensure_model_cached_or_raise,
+        get_tts_backend_for_engine,
+        load_engine_model,
+    )
 
     profile = await profiles.get_profile(data.profile_id, db)
     if not profile:
@@ -344,13 +349,68 @@ async def stream_speech(
         engine=engine,
     )
 
-    from ..utils.chunked_tts import generate_chunked
+    from ..utils.chunked_tts import generate_chunked, generate_chunked_stream, split_text_into_chunks
 
     trim_fn = None
     if engine_needs_trim(engine):
         from ..utils.audio import trim_tts_output
 
         trim_fn = trim_tts_output
+
+    effects_chain_config = None
+    if data.effects_chain is not None:
+        effects_chain_config = [e.model_dump() for e in data.effects_chain]
+    elif profile.effects_chain:
+        import json as _json
+
+        try:
+            effects_chain_config = _json.loads(profile.effects_chain)
+        except Exception:
+            effects_chain_config = None
+
+    text_chunks = split_text_into_chunks(data.text, data.max_chunk_chars)
+    supports_live_stream = callable(getattr(tts_model, "generate_stream", None))
+    needs_buffer = (
+        data.normalize
+        or bool(effects_chain_config)
+        or trim_fn is not None
+        or (len(text_chunks) > 1 and data.crossfade_ms > 0)
+    )
+
+    if supports_live_stream and not needs_buffer:
+        async def _live_wav_stream():
+            header_sent = False
+            try:
+                async for chunk_audio, sample_rate in generate_chunked_stream(
+                    tts_model,
+                    data.text,
+                    voice_prompt,
+                    language=data.language,
+                    seed=data.seed,
+                    instruct=data.instruct,
+                    max_chunk_chars=data.max_chunk_chars,
+                    trim_fn=trim_fn,
+                ):
+                    if not header_sent:
+                        yield streaming_wav_header(sample_rate)
+                        header_sent = True
+                    yield audio_to_pcm16_bytes(chunk_audio)
+
+                if not header_sent:
+                    yield streaming_wav_header(24000)
+            except (BrokenPipeError, ConnectionResetError, asyncio.CancelledError):
+                logger.debug("Client disconnected during live audio stream")
+
+        return StreamingResponse(
+            _live_wav_stream(),
+            media_type="audio/wav",
+            headers={
+                "Content-Disposition": 'attachment; filename="speech.wav"',
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "X-Voicebox-Stream-Mode": "live",
+            },
+        )
 
     audio, sample_rate = await generate_chunked(
         tts_model,
@@ -363,17 +423,6 @@ async def stream_speech(
         crossfade_ms=data.crossfade_ms,
         trim_fn=trim_fn,
     )
-
-    effects_chain_config = None
-    if data.effects_chain is not None:
-        effects_chain_config = [e.model_dump() for e in data.effects_chain]
-    elif profile.effects_chain:
-        import json as _json
-
-        try:
-            effects_chain_config = _json.loads(profile.effects_chain)
-        except Exception:
-            effects_chain_config = None
 
     if effects_chain_config:
         from ..utils.effects import apply_effects
@@ -398,7 +447,10 @@ async def stream_speech(
     return StreamingResponse(
         _wav_stream(),
         media_type="audio/wav",
-        headers={"Content-Disposition": 'attachment; filename="speech.wav"'},
+        headers={
+            "Content-Disposition": 'attachment; filename="speech.wav"',
+            "X-Voicebox-Stream-Mode": "buffered",
+        },
     )
 
 

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -408,6 +408,7 @@ async def stream_speech(
                 "Content-Disposition": 'attachment; filename="speech.wav"',
                 "Cache-Control": "no-cache",
                 "X-Accel-Buffering": "no",
+                "X-Content-Type-Options": "nosniff",
                 "X-Voicebox-Stream-Mode": "live",
             },
         )
@@ -449,6 +450,7 @@ async def stream_speech(
         media_type="audio/wav",
         headers={
             "Content-Disposition": 'attachment; filename="speech.wav"',
+            "X-Content-Type-Options": "nosniff",
             "X-Voicebox-Stream-Mode": "buffered",
         },
     )

--- a/backend/tests/test_mlx_streaming_bridge.py
+++ b/backend/tests/test_mlx_streaming_bridge.py
@@ -1,0 +1,56 @@
+"""Unit tests for the MLX backend async streaming bridge."""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+if importlib.util.find_spec("torch") is None:
+    torch = types.ModuleType("torch")
+    torch.Tensor = object
+    torch.load = lambda *args, **kwargs: None
+    torch.save = lambda *args, **kwargs: None
+    sys.modules.setdefault("torch", torch)
+
+from backend.backends.mlx_backend import MLXTTSBackend
+
+
+class CountingMLXBackend(MLXTTSBackend):
+    def __init__(self, total_chunks=5000):
+        super().__init__()
+        self.generated_count = 0
+        self.total_chunks = total_chunks
+
+    async def load_model_async(self, model_size=None):
+        return None
+
+    def _iter_generate_sync(
+        self,
+        *,
+        text,
+        voice_prompt,
+        language="en",
+        seed=None,
+    ):
+        for _ in range(self.total_chunks):
+            self.generated_count += 1
+            yield np.array([0.0], dtype=np.float32), 24000
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_stops_worker_when_consumer_breaks_early():
+    backend = CountingMLXBackend()
+
+    async for _chunk, _sample_rate in backend.generate_stream("hello", {}):
+        break
+
+    await asyncio.sleep(0.05)
+
+    assert backend.generated_count < backend.total_chunks

--- a/backend/tests/test_streaming_audio.py
+++ b/backend/tests/test_streaming_audio.py
@@ -1,0 +1,92 @@
+"""Unit tests for live audio streaming helpers."""
+
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.audio import audio_to_pcm16_bytes, streaming_wav_header
+from utils.chunked_tts import generate_chunked_stream
+
+
+class StreamingBackend:
+    async def generate_stream(
+        self,
+        text,
+        voice_prompt,
+        language="en",
+        seed=None,
+        instruct=None,
+    ):
+        yield np.array([0.0, 0.5], dtype=np.float32), 24000
+        yield np.array([-0.5, 1.0], dtype=np.float32), 24000
+
+    async def generate(self, *args, **kwargs):
+        raise AssertionError("streaming backend should not use buffered generate")
+
+
+class BufferedBackend:
+    async def generate(
+        self,
+        text,
+        voice_prompt,
+        language="en",
+        seed=None,
+        instruct=None,
+    ):
+        return np.array([0.25, -0.25], dtype=np.float32), 22050
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_stream_uses_backend_stream():
+    chunks = []
+
+    async for audio, sample_rate in generate_chunked_stream(
+        StreamingBackend(),
+        "hello",
+        {},
+    ):
+        chunks.append((audio, sample_rate))
+
+    assert len(chunks) == 2
+    assert chunks[0][1] == 24000
+    assert np.allclose(chunks[0][0], [0.0, 0.5])
+    assert np.allclose(chunks[1][0], [-0.5, 1.0])
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_stream_falls_back_to_buffered_generate():
+    chunks = []
+
+    async for audio, sample_rate in generate_chunked_stream(
+        BufferedBackend(),
+        "hello",
+        {},
+    ):
+        chunks.append((audio, sample_rate))
+
+    assert len(chunks) == 1
+    assert chunks[0][1] == 22050
+    assert np.allclose(chunks[0][0], [0.25, -0.25])
+
+
+def test_streaming_wav_header_uses_unknown_lengths():
+    header = streaming_wav_header(24000)
+
+    assert header[:4] == b"RIFF"
+    assert header[8:12] == b"WAVE"
+    assert header[12:16] == b"fmt "
+    assert header[36:40] == b"data"
+    assert struct.unpack("<I", header[4:8])[0] == 0xFFFFFFFF
+    assert struct.unpack("<I", header[40:44])[0] == 0xFFFFFFFF
+    assert struct.unpack("<I", header[24:28])[0] == 24000
+
+
+def test_audio_to_pcm16_bytes_clips_and_packs_little_endian():
+    pcm = audio_to_pcm16_bytes(np.array([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=np.float32))
+
+    assert pcm == struct.pack("<hhhhh", -32767, -32767, 0, 32767, 32767)

--- a/backend/tests/test_streaming_audio.py
+++ b/backend/tests/test_streaming_audio.py
@@ -89,4 +89,4 @@ def test_streaming_wav_header_uses_unknown_lengths():
 def test_audio_to_pcm16_bytes_clips_and_packs_little_endian():
     pcm = audio_to_pcm16_bytes(np.array([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=np.float32))
 
-    assert pcm == struct.pack("<hhhhh", -32767, -32767, 0, 32767, 32767)
+    assert pcm == struct.pack("<hhhhh", -32768, -32768, 0, 32767, 32767)

--- a/backend/tests/test_streaming_route.py
+++ b/backend/tests/test_streaming_route.py
@@ -1,0 +1,121 @@
+"""Unit tests for the /generate/stream route behavior."""
+
+import importlib.util
+import struct
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+if importlib.util.find_spec("torch") is None:
+    torch = types.ModuleType("torch")
+    torch.Tensor = object
+    torch.load = lambda *args, **kwargs: None
+    torch.save = lambda *args, **kwargs: None
+    sys.modules.setdefault("torch", torch)
+
+from backend import backends, models
+from backend.routes import generations
+
+
+class LiveBackend:
+    def __init__(self):
+        self.generate_called = False
+        self.generate_stream_called = False
+
+    async def generate_stream(
+        self,
+        text,
+        voice_prompt,
+        language="en",
+        seed=None,
+        instruct=None,
+    ):
+        self.generate_stream_called = True
+        yield np.array([0.0, 0.5], dtype=np.float32), 24000
+        yield np.array([-1.0, 1.0], dtype=np.float32), 24000
+
+    async def generate(self, *args, **kwargs):
+        self.generate_called = True
+        return np.array([0.25, -0.25], dtype=np.float32), 24000
+
+
+async def _noop_async(*args, **kwargs):
+    return None
+
+
+async def _read_body(response) -> bytes:
+    return b"".join([chunk async for chunk in response.body_iterator])
+
+
+def _install_route_fakes(monkeypatch, backend, *, effects_chain=None):
+    profile = SimpleNamespace(
+        id="profile-1",
+        effects_chain=effects_chain,
+        default_engine="qwen",
+        preset_engine=None,
+    )
+
+    async def get_profile(profile_id, db):
+        return profile
+
+    async def create_voice_prompt_for_profile(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(generations.profiles, "get_profile", get_profile)
+    monkeypatch.setattr(generations.profiles, "create_voice_prompt_for_profile", create_voice_prompt_for_profile)
+    monkeypatch.setattr(generations.profiles, "validate_profile_engine", lambda *args, **kwargs: None)
+    monkeypatch.setattr(backends, "engine_needs_trim", lambda engine: False)
+    monkeypatch.setattr(backends, "ensure_model_cached_or_raise", _noop_async)
+    monkeypatch.setattr(backends, "load_engine_model", _noop_async)
+    monkeypatch.setattr(backends, "get_tts_backend_for_engine", lambda engine: backend)
+
+
+@pytest.mark.asyncio
+async def test_stream_speech_uses_live_mode_when_request_can_stream(monkeypatch):
+    backend = LiveBackend()
+    _install_route_fakes(monkeypatch, backend)
+    data = models.GenerationRequest(
+        profile_id="profile-1",
+        text="Hello.",
+        engine="qwen",
+        normalize=False,
+    )
+
+    response = await generations.stream_speech(data, db=object())
+    body = await _read_body(response)
+
+    assert response.headers["x-voicebox-stream-mode"] == "live"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert backend.generate_stream_called is True
+    assert backend.generate_called is False
+    assert body[:4] == b"RIFF"
+    assert body[36:40] == b"data"
+    assert body[44:] == struct.pack("<hhhh", 0, 16383, -32768, 32767)
+
+
+@pytest.mark.asyncio
+async def test_stream_speech_buffers_when_normalization_requires_whole_file(monkeypatch):
+    backend = LiveBackend()
+    _install_route_fakes(monkeypatch, backend)
+    data = models.GenerationRequest(
+        profile_id="profile-1",
+        text="Hello.",
+        engine="qwen",
+        normalize=True,
+    )
+
+    response = await generations.stream_speech(data, db=object())
+    body = await _read_body(response)
+
+    assert response.headers["x-voicebox-stream-mode"] == "buffered"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert backend.generate_stream_called is False
+    assert backend.generate_called is True
+    assert body[:4] == b"RIFF"

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -2,10 +2,12 @@
 Audio processing utilities.
 """
 
+import struct
+from typing import Optional, Tuple
+
+import librosa
 import numpy as np
 import soundfile as sf
-import librosa
-from typing import Tuple, Optional
 
 
 def normalize_audio(
@@ -84,8 +86,8 @@ def save_audio(
     Raises:
         OSError: If file cannot be written
     """
-    from pathlib import Path
     import os
+    from pathlib import Path
 
     temp_path = f"{path}.tmp"
     try:
@@ -108,6 +110,48 @@ def save_audio(
             pass  # Best effort cleanup
 
         raise OSError(f"Failed to save audio to {path}: {e}") from e
+
+
+def audio_to_pcm16_bytes(audio: np.ndarray) -> bytes:
+    """Convert float audio samples to little-endian signed PCM16 bytes."""
+    clipped = np.clip(np.asarray(audio, dtype=np.float32), -1.0, 1.0)
+    pcm = (clipped * 32767.0).astype("<i2", copy=False)
+    return pcm.tobytes()
+
+
+def streaming_wav_header(
+    sample_rate: int,
+    *,
+    channels: int = 1,
+    bits_per_sample: int = 16,
+) -> bytes:
+    """Return a PCM WAV header suitable for HTTP chunked streaming.
+
+    Standard WAV normally stores total file sizes in the RIFF and data
+    headers. A live stream does not know those sizes up front, so we use the
+    common all-ones sentinel to let clients start playback before generation
+    has finished.
+    """
+    byte_rate = sample_rate * channels * bits_per_sample // 8
+    block_align = channels * bits_per_sample // 8
+    unknown_size = 0xFFFFFFFF
+
+    return struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        unknown_size,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        channels,
+        sample_rate,
+        byte_rate,
+        block_align,
+        bits_per_sample,
+        b"data",
+        unknown_size,
+    )
 
 
 def trim_tts_output(

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -115,7 +115,8 @@ def save_audio(
 def audio_to_pcm16_bytes(audio: np.ndarray) -> bytes:
     """Convert float audio samples to little-endian signed PCM16 bytes."""
     clipped = np.clip(np.asarray(audio, dtype=np.float32), -1.0, 1.0)
-    pcm = (clipped * 32767.0).astype("<i2", copy=False)
+    scaled = np.where(clipped < 0, clipped * 32768.0, clipped * 32767.0)
+    pcm = scaled.astype("<i2", copy=False)
     return pcm.tobytes()
 
 

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -11,6 +11,7 @@ overhead.
 
 import logging
 import re
+from collections.abc import AsyncIterator
 from typing import List, Tuple
 
 import numpy as np
@@ -297,3 +298,62 @@ async def generate_chunked(
 
     audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=crossfade_ms)
     return audio, sample_rate
+
+
+async def generate_chunked_stream(
+    backend,
+    text: str,
+    voice_prompt: dict,
+    language: str = "en",
+    seed: int | None = None,
+    instruct: str | None = None,
+    max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    trim_fn=None,
+) -> AsyncIterator[Tuple[np.ndarray, int]]:
+    """Yield audio chunks as soon as a backend can produce them.
+
+    Backends that implement ``generate_stream()`` can expose true model-level
+    streaming for short utterances. Backends without that optional method still
+    work by yielding one completed text chunk at a time.
+
+    This intentionally does not crossfade between text chunks because a live
+    response cannot look ahead without buffering the next chunk. Callers that
+    need crossfade-equivalent output should use ``generate_chunked()``.
+    """
+    chunks = split_text_into_chunks(text, max_chunk_chars)
+    if not chunks:
+        return
+
+    stream_fn = getattr(backend, "generate_stream", None)
+
+    for i, chunk_text in enumerate(chunks):
+        logger.info(
+            "Streaming chunk %d/%d (%d chars)",
+            i + 1,
+            len(chunks),
+            len(chunk_text),
+        )
+        chunk_seed = (seed + i) if seed is not None else None
+
+        if callable(stream_fn) and trim_fn is None:
+            async for chunk_audio, chunk_sr in stream_fn(
+                chunk_text,
+                voice_prompt,
+                language,
+                chunk_seed,
+                instruct,
+            ):
+                yield np.asarray(chunk_audio, dtype=np.float32), chunk_sr
+            continue
+
+        chunk_audio, chunk_sr = await backend.generate(
+            chunk_text,
+            voice_prompt,
+            language,
+            chunk_seed,
+            instruct,
+        )
+        if trim_fn is not None:
+            chunk_audio = trim_fn(chunk_audio, chunk_sr)
+
+        yield np.asarray(chunk_audio, dtype=np.float32), chunk_sr

--- a/docs/content/docs/developer/tts-generation.mdx
+++ b/docs/content/docs/developer/tts-generation.mdx
@@ -196,7 +196,28 @@ The model management API (`/models/load`, `/models/unload`) lets users free VRAM
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | POST | `/generate` | Generate speech from text |
+| POST | `/generate/stream` | Stream generated speech bytes directly |
 | GET | `/audio/{generation_id}` | Serve generated audio file |
+
+### Streaming generation
+
+`POST /generate/stream` returns `audio/wav` without writing a generation row.
+When the selected backend can yield audio incrementally, Voicebox sends a WAV
+header followed by PCM16 chunks as soon as the model produces them. The response
+header `X-Voicebox-Stream-Mode` is `live` for this low-latency path and
+`buffered` when Voicebox has to preserve whole-file processing semantics.
+
+The live path currently requires all of these to be true:
+
+- the backend implements `generate_stream()` (Qwen on MLX does)
+- `normalize` is `false`
+- no effects chain is applied
+- the engine does not require trim post-processing
+- long-text chunking does not require crossfade across text chunks
+
+If any of those constraints are not met, `/generate/stream` keeps the existing
+compatibility behavior: it generates the full waveform first, applies requested
+post-processing, then streams the completed WAV bytes.
 
 ### Response schema
 


### PR DESCRIPTION
## Status

Draft/WIP. This has passed focused unit and syntax checks, but has **not** yet been tested against a real loaded MLX TTS model for time-to-first-audio or playback behavior. It should not be treated as ready for review until that real-model streaming test is done.

## Summary
- expose MLX model generation as an async chunk stream instead of collecting the full waveform first
- make `/generate/stream` emit a WAV header plus PCM16 chunks for live-compatible requests
- keep the existing buffered fallback when normalization, effects, trim, or crossfade require whole-file processing, and label responses with `X-Voicebox-Stream-Mode`
- document the live streaming contract and add focused unit tests for the streaming helpers

## Validation
- `uv run --with pytest --with pytest-asyncio --with soundfile --with librosa --with numpy python -m pytest tests/test_streaming_audio.py`
- `uvx ruff check --select F,I,RUF100 backends/mlx_backend.py utils/audio.py utils/chunked_tts.py routes/generations.py tests/test_streaming_audio.py`
- `python -m compileall backends/mlx_backend.py utils/audio.py utils/chunked_tts.py routes/generations.py`

## Still needed
- run against a real Voicebox profile/model locally
- measure time-to-first-audio on `/generate/stream` with `normalize: false`
- verify browser/client playback and lip-sync analyser behavior