### PR TITLE
fix: harden API/Tauri security and fix MCP tool naming

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -71,12 +71,21 @@ def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     from .mcp_server.server import build_mcp_server, compose_lifespan
     from .mcp_server.context import ClientIdMiddleware
+    from starlette.middleware import Middleware
+    from starlette.middleware.trustedhost import TrustedHostMiddleware
 
     # Build the MCP app up-front so we can wire its lifespan into FastAPI's —
     # FastMCP's Streamable HTTP transport only works if its session manager
     # runs inside the parent ASGI lifespan.
     mcp = build_mcp_server()
-    mcp_app = mcp.http_app(path="/", transport="http")
+    mcp_app = mcp.http_app(
+        path="/", 
+        transport="http",
+        middleware=[Middleware(
+            TrustedHostMiddleware, 
+            allowed_hosts=["127.0.0.1", "localhost", "127.0.0.1:17493", "localhost:17493"]
+        )],
+    )
 
     @asynccontextmanager
     async def voicebox_lifespan(app: FastAPI):
@@ -106,6 +115,10 @@ def create_app() -> FastAPI:
 
     _configure_cors(application)
     application.add_middleware(ClientIdMiddleware)
+    application.add_middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=["127.0.0.1", "localhost", "127.0.0.1:17493", "localhost:17493"]
+    )
     register_routers(application)
     application.mount("/mcp", mcp_app)
     logger.info("MCP: mounted at /mcp")

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -36,7 +36,7 @@ def register_tools(mcp: FastMCP) -> None:
     """Attach all Voicebox tools to the given FastMCP instance."""
 
     @mcp.tool(
-        name="voicebox.speak",
+        name="voicebox_speak",
         description=(
             "Speak text in a Voicebox voice profile. Returns a generation id "
             "the caller can poll at /generate/{id}/status. Audio plays on the "
@@ -105,7 +105,7 @@ def register_tools(mcp: FastMCP) -> None:
             db.close()
 
     @mcp.tool(
-        name="voicebox.transcribe",
+        name="voicebox_transcribe",
         description=(
             "Transcribe an audio clip to text using Voicebox's local Whisper. "
             "Pass exactly one of `audio_base64` (bytes as base64) or "
@@ -163,7 +163,7 @@ def register_tools(mcp: FastMCP) -> None:
             tmp_path.unlink(missing_ok=True)
 
     @mcp.tool(
-        name="voicebox.list_captures",
+        name="voicebox_list_captures",
         description=(
             "List recent voice captures (dictations, recordings, uploads) "
             "with their transcripts. Most-recent first."
@@ -191,7 +191,7 @@ def register_tools(mcp: FastMCP) -> None:
             db.close()
 
     @mcp.tool(
-        name="voicebox.list_profiles",
+        name="voicebox_list_profiles",
         description=(
             "List available voice profiles (both cloned voices and presets). "
             "Use the returned `name` with voicebox.speak(profile=...)."

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -5,7 +5,7 @@
   "platforms": ["linux", "macOS", "windows"],
   "windows": ["main", "dictate"],
   "remote": {
-    "urls": ["http://localhost:*"]
+    "urls": ["http://127.0.0.1:17493", "http://localhost:5173", "http://127.0.0.1:5173"]
   },
   "permissions": [
     "core:default",
@@ -14,15 +14,11 @@
     "core:webview:default",
     "core:webview:allow-internal-toggle-devtools",
     "shell:allow-open",
-    "shell:allow-execute",
-    "shell:allow-spawn",
     "updater:default",
     "process:default",
     "dialog:default",
     "dialog:allow-save",
     "dialog:allow-open",
-    "fs:default",
-    "fs:read-all",
-    "fs:write-all"
+    "fs:default"
   ]
 }

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   "app": {
     "macOSPrivateApi": true,
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:17493 http://localhost:17493 ws://localhost:5173 ws://127.0.0.1:5173 http://localhost:5173 http://127.0.0.1:5173; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "capabilities": ["default"]
     },
     "windows": [
@@ -57,7 +57,7 @@
   },
   "plugins": {
     "shell": {
-      "open": ".*"
+      "open": "^x-apple\\.systempreferences:.*"
     },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUxRENBQkRBQjdBNTM1OTIKUldTU05hVzMycXZjNGJGcUxmcVVocll2QjdSaTJNdlFxR2M3VDJsMnVvbDdyZGRPMmRlOW9aWTcK",


### PR DESCRIPTION
Fixes #778 and Fixes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened host, network, and app security settings to better restrict allowed connections and browser/app resource access.
  * Limited opening external links to a specific system settings scheme.
* **Changes**
  * Updated tool names used by the app’s voice features.
  * Reduced default app permissions in the desktop build, removing some broad system and file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->