### PR TITLE
refactor(i18n): localize startup splash messages

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { RouterProvider } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import voiceboxLogo from '@/assets/voicebox-logo.png';
 import { DictateWindow } from '@/components/DictateWindow/DictateWindow';
 import ShinyText from '@/components/ShinyText';
@@ -52,29 +53,6 @@ function isPortInUseError(error: unknown): boolean {
   );
 }
 
-const LOADING_MESSAGES = [
-  'Warming up tensors...',
-  'Calibrating synthesizer engine...',
-  'Initializing voice models...',
-  'Loading neural networks...',
-  'Preparing audio pipelines...',
-  'Optimizing waveform generators...',
-  'Tuning frequency analyzers...',
-  'Building voice embeddings...',
-  'Configuring text-to-speech cores...',
-  'Syncing audio buffers...',
-  'Establishing model connections...',
-  'Preprocessing training data...',
-  'Validating voice samples...',
-  'Compiling inference engines...',
-  'Mapping phoneme sequences...',
-  'Aligning prosody parameters...',
-  'Activating speech synthesis...',
-  'Fine-tuning acoustic models...',
-  'Preparing voice cloning matrices...',
-  'Initializing Qwen TTS framework...',
-];
-
 function App() {
   useThemeSync();
 
@@ -89,6 +67,8 @@ function App() {
 }
 
 function MainApp() {
+  const { t } = useTranslation();
+  const loadingMessages = t('startup.loadingMessages', { returnObjects: true }) as string[];
   const platform = usePlatform();
   const [serverReady, setServerReady] = useState(false);
   const [startupError, setStartupError] = useState<string | null>(null);
@@ -218,10 +198,7 @@ function MainApp() {
         setTimeout(() => {
           clearInterval(pollInterval);
           serverStartingRef.current = false;
-          setStartupError(
-            'Could not connect to a Voicebox server within 2 minutes. ' +
-              'Please check that the server is running and try again.',
-          );
+          setStartupError(t('startup.connectTimeout'));
         }, 120_000);
       });
 
@@ -242,7 +219,7 @@ function MainApp() {
     }
 
     const interval = setInterval(() => {
-      setLoadingMessageIndex((prev) => (prev + 1) % LOADING_MESSAGES.length);
+      setLoadingMessageIndex((prev) => (prev + 1) % loadingMessages.length);
     }, 3000);
 
     return () => clearInterval(interval);
@@ -271,7 +248,7 @@ function MainApp() {
           </div>
           {startupError ? (
             <div className="animate-fade-in-delayed max-w-md mx-auto space-y-3">
-              <p className="text-lg font-medium text-destructive">Server startup failed</p>
+              <p className="text-lg font-medium text-destructive">{t('startup.serverFailed')}</p>
               <p className="text-sm text-muted-foreground">{startupError}</p>
               <button
                 type="button"
@@ -283,13 +260,13 @@ function MainApp() {
                   window.location.reload();
                 }}
               >
-                Retry
+                {t('startup.retry')}
               </button>
             </div>
           ) : (
             <div className="animate-fade-in-delayed">
               <ShinyText
-                text={LOADING_MESSAGES[loadingMessageIndex]}
+                text={loadingMessages[loadingMessageIndex]}
                 className="text-lg font-medium text-muted-foreground"
                 speed={2}
                 color="hsl(var(--muted-foreground))"

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -11,6 +11,33 @@
     "unknown": "Unknown",
     "unknownError": "Unknown error"
   },
+  "startup": {
+    "serverFailed": "Server startup failed",
+    "retry": "Retry",
+    "connectTimeout": "Could not connect to a Voicebox server within 2 minutes. Please check that the server is running and try again.",
+    "loadingMessages": [
+      "Warming up tensors...",
+      "Calibrating synthesizer engine...",
+      "Initializing voice models...",
+      "Loading neural networks...",
+      "Preparing audio pipelines...",
+      "Optimizing waveform generators...",
+      "Tuning frequency analyzers...",
+      "Building voice embeddings...",
+      "Configuring text-to-speech cores...",
+      "Syncing audio buffers...",
+      "Establishing model connections...",
+      "Preprocessing training data...",
+      "Validating voice samples...",
+      "Compiling inference engines...",
+      "Mapping phoneme sequences...",
+      "Aligning prosody parameters...",
+      "Activating speech synthesis...",
+      "Fine-tuning acoustic models...",
+      "Preparing voice cloning matrices...",
+      "Initializing Qwen TTS framework..."
+    ]
+  },
   "nav": {
     "generate": "Generate",
     "stories": "Stories",

--- a/app/src/i18n/locales/pt-BR/translation.json
+++ b/app/src/i18n/locales/pt-BR/translation.json
@@ -11,6 +11,33 @@
     "unknown": "Desconhecido",
     "unknownError": "Erro desconhecido"
   },
+  "startup": {
+    "serverFailed": "Falha ao iniciar o servidor",
+    "retry": "Tentar de novo",
+    "connectTimeout": "Não foi possível conectar a um servidor Voicebox em 2 minutos. Verifique se o servidor está rodando e tente de novo.",
+    "loadingMessages": [
+      "Aquecendo os tensores...",
+      "Calibrando o motor de síntese...",
+      "Inicializando os modelos de voz...",
+      "Carregando as redes neurais...",
+      "Preparando os pipelines de áudio...",
+      "Otimizando os geradores de forma de onda...",
+      "Ajustando os analisadores de frequência...",
+      "Construindo os embeddings de voz...",
+      "Configurando os núcleos de fala...",
+      "Sincronizando os buffers de áudio...",
+      "Estabelecendo as conexões dos modelos...",
+      "Pré-processando os dados de treinamento...",
+      "Validando as amostras de voz...",
+      "Compilando os motores de inferência...",
+      "Mapeando as sequências de fonemas...",
+      "Alinhando os parâmetros de prosódia...",
+      "Ativando a síntese de fala...",
+      "Refinando os modelos acústicos...",
+      "Preparando as matrizes de clonagem de voz...",
+      "Inicializando o framework Qwen TTS..."
+    ]
+  },
   "nav": {
     "generate": "Gerar",
     "stories": "Histórias",


### PR DESCRIPTION
## What

The startup/loading splash currently renders in English for every locale: the rotating "Warming up tensors…" messages, plus the server-failure / retry / connect-timeout copy, were hardcoded in `App.tsx`.

This PR extracts those strings into the i18n resource files under a new `startup.*` namespace so the loading screen is localized like the rest of the UI.

## Changes

- **`en/translation.json`** — new `startup` section holding the original English strings (no copy changes).
- **`pt-BR/translation.json`** — Brazilian Portuguese translations for the same keys.
- **`App.tsx`** — removed the hardcoded `LOADING_MESSAGES` const; messages now come from `t('startup.loadingMessages', { returnObjects: true })`, and the error/retry/timeout text from `t()`.

## Notes

- Purely a localization refactor — no behavior change for `en` users (same strings, same rotation).
- Follows up on #810 (pt-BR locale), which only covered the React UI strings and missed this hardcoded array.
- Other locales (ja, zh-Hans, zh-Hant) fall back to `en` for the new keys until translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup and loading screens now support localized text in English and Portuguese.
  * Added translated startup status messages, including loading stages, connection timeout guidance, and server startup failure text.
* **Bug Fixes**
  * Loading messages now cycle correctly based on the available translated entries.
  * The startup failure screen now shows translated retry and error text instead of fixed wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->