### PR TITLE
fix: constrain model migration destinations

### DIFF
--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -2,19 +2,100 @@
 
 import asyncio
 import shutil
+from contextlib import suppress
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
-from sqlalchemy.orm import Session
 
-from .. import models
-from ..utils.platform_detect import get_backend_type
+from .. import config as backend_config, models
 from ..services.task_queue import create_background_task
 from ..utils.progress import get_progress_manager
 from ..utils.tasks import get_task_manager
 
 router = APIRouter()
+MODEL_CACHE_DIR_PREFIX = "models--"
+
+
+def _resolve_missing_leaf(path: Path) -> Path:
+    """Resolve a path whose final component may not exist yet."""
+    try:
+        return path.resolve(strict=True)
+    except FileNotFoundError:
+        try:
+            return path.parent.resolve(strict=True) / path.name
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Destination parent directory does not exist",
+            ) from exc
+
+
+def _resolve_migration_destination(raw_destination: str, source: Path) -> Path:
+    """Resolve and constrain a model migration destination.
+
+    The API is unauthenticated, so migration is only allowed into Voicebox's
+    app-owned model storage root or one direct child of that root.
+    """
+    if not raw_destination.strip():
+        raise HTTPException(status_code=400, detail="Destination is required")
+
+    owned_root_path = backend_config.get_models_dir()
+    if owned_root_path.is_symlink():
+        raise HTTPException(status_code=400, detail="Voicebox models directory cannot be a symlink")
+
+    owned_root = owned_root_path.resolve()
+    requested = Path(raw_destination).expanduser()
+    candidate = requested if requested.is_absolute() else owned_root / requested
+    if candidate.is_symlink():
+        raise HTTPException(status_code=400, detail="Destination cannot be a symlink")
+
+    destination = _resolve_missing_leaf(candidate)
+
+    try:
+        relative_destination = destination.relative_to(owned_root)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Destination must be inside the Voicebox-owned models directory",
+        ) from exc
+
+    if len(relative_destination.parts) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Destination must be the Voicebox models directory or one direct child",
+        )
+
+    source = source.resolve()
+    if source == destination:
+        raise HTTPException(status_code=400, detail="Source and destination are the same directory")
+
+    if destination.is_relative_to(source):
+        raise HTTPException(status_code=400, detail="Destination cannot be inside the current cache directory")
+
+    return destination
+
+
+def _model_cache_dirs(source: Path) -> list[Path]:
+    """Return top-level HuggingFace model cache directories eligible to migrate."""
+    return [
+        item
+        for item in source.iterdir()
+        if item.name.startswith(MODEL_CACHE_DIR_PREFIX) and item.is_dir() and not item.is_symlink()
+    ]
+
+
+def _validate_no_destination_collisions(model_dirs: list[Path], destination: Path) -> None:
+    """Prevent migration from deleting or overwriting destination model dirs."""
+    collisions = [
+        item.name for item in model_dirs if (destination / item.name).exists() or (destination / item.name).is_symlink()
+    ]
+    if collisions:
+        names = ", ".join(sorted(collisions))
+        raise HTTPException(
+            status_code=409,
+            detail=f"Destination already contains model cache directories: {names}",
+        )
 
 
 def _get_dir_size(path: Path) -> int:
@@ -123,32 +204,26 @@ async def migrate_models(request: models.ModelMigrateRequest):
     """Move all downloaded models to a new directory with byte-level progress via SSE."""
     from huggingface_hub import constants as hf_constants
 
-    source = Path(hf_constants.HF_HUB_CACHE)
-    destination = Path(request.destination)
+    source = Path(hf_constants.HF_HUB_CACHE).resolve()
 
     if not source.exists():
         raise HTTPException(status_code=404, detail="Current model cache directory not found")
 
-    if source.resolve() == destination.resolve():
-        raise HTTPException(status_code=400, detail="Source and destination are the same directory")
-
-    if destination.resolve().is_relative_to(source.resolve()):
-        raise HTTPException(status_code=400, detail="Destination cannot be inside the current cache directory")
+    destination = _resolve_migration_destination(request.destination, source)
 
     progress_manager = get_progress_manager()
-    model_dirs = [d for d in source.iterdir() if d.name.startswith("models--") and d.is_dir()]
+    model_dirs = _model_cache_dirs(source)
     if not model_dirs:
         progress_manager.update_progress("migration", 1, 1, status="complete")
         progress_manager.mark_complete("migration")
         return {"moved": 0, "errors": [], "source": str(source), "destination": str(destination)}
 
+    _validate_no_destination_collisions(model_dirs, destination)
     destination.mkdir(parents=True, exist_ok=True)
 
     same_fs = False
-    try:
+    with suppress(OSError):
         same_fs = source.stat().st_dev == destination.stat().st_dev
-    except OSError:
-        pass
 
     async def migrate_background():
         moved = 0
@@ -159,8 +234,6 @@ async def migrate_models(request: models.ModelMigrateRequest):
                 for i, item in enumerate(model_dirs):
                     dest_item = destination / item.name
                     try:
-                        if dest_item.exists():
-                            shutil.rmtree(dest_item)
                         shutil.move(str(item), str(dest_item))
                         moved += 1
                         progress_manager.update_progress(
@@ -171,7 +244,7 @@ async def migrate_models(request: models.ModelMigrateRequest):
                             status="downloading",
                         )
                     except Exception as e:
-                        errors.append(f"{item.name}: {str(e)}")
+                        errors.append(f"{item.name}: {e!s}")
             else:
                 total_bytes = sum(_get_dir_size(d) for d in model_dirs)
                 progress_manager.update_progress(
@@ -182,15 +255,13 @@ async def migrate_models(request: models.ModelMigrateRequest):
                 for item in model_dirs:
                     dest_item = destination / item.name
                     try:
-                        if dest_item.exists():
-                            shutil.rmtree(dest_item)
                         copied = await asyncio.to_thread(
                             _copy_with_progress, item, dest_item, progress_manager, copied, total_bytes
                         )
                         await asyncio.to_thread(shutil.rmtree, str(item))
                         moved += 1
                     except Exception as e:
-                        errors.append(f"{item.name}: {str(e)}")
+                        errors.append(f"{item.name}: {e!s}")
 
             progress_manager.update_progress("migration", 1, 1, status="complete")
             progress_manager.mark_complete("migration")
@@ -228,7 +299,6 @@ async def get_model_status():
     """Get status of all available models."""
     from huggingface_hub import constants as hf_constants
 
-    backend_type = get_backend_type()
     task_manager = get_task_manager()
 
     active_download_names = {task.model_name for task in task_manager.get_active_downloads()}
@@ -240,7 +310,7 @@ async def get_model_status():
     except ImportError:
         use_scan_cache = False
 
-    from ..backends import get_all_model_configs, check_model_loaded
+    from ..backends import check_model_loaded, get_all_model_configs
 
     registry_configs = get_all_model_configs()
     model_configs = [
@@ -445,6 +515,7 @@ async def cancel_model_download(request: models.ModelDownloadRequest):
 async def delete_model(model_name: str):
     """Delete a downloaded model from the HuggingFace cache."""
     from huggingface_hub import constants as hf_constants
+
     from ..backends import get_model_config, unload_model_by_config
 
     config = get_model_config(model_name)

--- a/backend/tests/test_model_migration_security.py
+++ b/backend/tests/test_model_migration_security.py
@@ -1,0 +1,116 @@
+"""Security tests for model cache migration path handling."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from backend import config
+from backend.routes import models as model_routes
+
+
+@pytest.fixture
+def owned_models_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(config, "_data_dir", tmp_path / "data")
+    return config.get_models_dir()
+
+
+def _source_cache(tmp_path: Path) -> Path:
+    source = tmp_path / "hf-cache"
+    source.mkdir()
+    return source
+
+
+def _assert_rejected(raw_destination: str, source: Path) -> HTTPException:
+    with pytest.raises(HTTPException) as exc_info:
+        model_routes._resolve_migration_destination(raw_destination, source)
+    assert exc_info.value.status_code == 400
+    return exc_info.value
+
+
+def test_migration_destination_allows_owned_root(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+
+    destination = model_routes._resolve_migration_destination(str(owned_models_root), source)
+
+    assert destination == owned_models_root.resolve()
+
+
+def test_migration_destination_allows_owned_direct_child(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+
+    destination = model_routes._resolve_migration_destination("local-cache", source)
+
+    assert destination == owned_models_root.resolve() / "local-cache"
+
+
+def test_migration_destination_rejects_absolute_outside_path(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+    outside = owned_models_root.parent / "outside"
+    outside.mkdir()
+
+    error = _assert_rejected(str(outside), source)
+
+    assert "inside the Voicebox-owned models directory" in error.detail
+
+
+def test_migration_destination_rejects_relative_traversal(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+
+    error = _assert_rejected("../outside", source)
+
+    assert "inside the Voicebox-owned models directory" in error.detail
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink support required")
+def test_migration_destination_rejects_symlink_escape(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = owned_models_root / "linked-cache"
+    link.symlink_to(outside, target_is_directory=True)
+
+    error = _assert_rejected(str(link), source)
+
+    assert "cannot be a symlink" in error.detail
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink support required")
+def test_migration_destination_rejects_symlink_owned_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (data_dir / "models").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(config, "_data_dir", data_dir)
+    source = _source_cache(tmp_path)
+
+    error = _assert_rejected("local-cache", source)
+
+    assert "models directory cannot be a symlink" in error.detail
+
+
+def test_migration_destination_rejects_source_contained_path(owned_models_root: Path) -> None:
+    source = owned_models_root
+
+    error = _assert_rejected("nested-cache", source)
+
+    assert "inside the current cache directory" in error.detail
+
+
+def test_migration_rejects_existing_destination_model_dir(owned_models_root: Path, tmp_path: Path) -> None:
+    source = _source_cache(tmp_path)
+    model_dir = source / "models--voicebox--example"
+    model_dir.mkdir()
+    destination = owned_models_root / "target-cache"
+    destination.mkdir()
+    (destination / model_dir.name).mkdir()
+
+    with pytest.raises(HTTPException) as exc_info:
+        model_routes._validate_no_destination_collisions([model_dir], destination)
+
+    assert exc_info.value.status_code == 409
+    assert model_dir.name in exc_info.value.detail


### PR DESCRIPTION
## Summary

Fixes #809 by constraining `/models/migrate` to Voicebox-owned model storage instead of accepting arbitrary filesystem destinations from an unauthenticated local API endpoint.

This change:

- resolves migration destinations under `config.get_models_dir()`
- allows only the Voicebox models root or one direct child of that root
- rejects absolute outside paths, relative traversal, symlink escapes, destinations inside the source cache, and symlinked model roots
- preflights destination model directory collisions instead of deleting/overwriting existing target dirs
- skips symlinked source cache dirs during migration

## Validation

- `/Users/timharris/Documents/voicebox/backend/venv/bin/ruff format --check backend/routes/models.py backend/tests/test_model_migration_security.py`
- `/Users/timharris/Documents/voicebox/backend/venv/bin/ruff check --select I,F backend/routes/models.py backend/tests/test_model_migration_security.py`
- `/Users/timharris/Documents/voicebox/backend/venv/bin/python -m pytest backend/tests/test_model_migration_security.py -v`
- `git diff --check`

## Notes

This intentionally narrows migration behavior. If Voicebox later wants arbitrary user-selected model destinations, that should be mediated by a trusted desktop UI capability or real authentication rather than this unauthenticated API route.

Fixes #809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened model migration path handling to prevent destinations outside the allowed models storage area.
  * Added protections against symlink-based destinations and migrations into invalid locations.
  * Improved collision checks so existing model folders are not overwritten during migration.
  * Updated migration behavior to better handle same-disk and cross-disk moves without unsafe deletions.
  * Refined model status handling with minor cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->