### PR TITLE
fix: ROCm setup for Linux AMD GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Changelog
 
+## [Unreleased]
+
+### Linux
+
+- **ROCm setup works on Linux AMD systems.** Docker ROCm builds now keep PyTorch
+  on the ROCm wheel index during dependency installation, so later installs do
+  not replace it with CUDA wheels. The ROCm compose overlay no longer assumes
+  Ubuntu render/video group IDs; the container joins the groups that own the GPU
+  device nodes at startup. Native Linux setup now picks ROCm wheels for AMD GPUs
+  and CUDA wheels for NVIDIA GPUs before installing backend dependencies.
+
 ## [0.5.0] - 2026-04-22
 
 **The Capture release.** Voicebox stops being just a voice-cloning studio and becomes a full AI voice studio. Hold a key anywhere on your machine, speak, release — the transcript lands in the focused text field. Flip the primitive around and any MCP-aware agent — Claude Code, Cursor, Spacebot — speaks back through an on-screen pill in one of your cloned voices. A local LLM sits between the two, so transcripts come out clean and voice profiles can carry a personality that reshapes what the agent says before it gets spoken.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ ARG ROCM_VERSION=6.3
 # For ROCm, make the PyTorch ROCm index primary so every install below resolves
 # torch to ROCm wheels instead of the default CUDA build.
 RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      pip install --no-cache-dir --prefix=/install \
+        --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
+        torch torchaudio && \
       printf '[global]\nindex-url = https://download.pytorch.org/whl/rocm%s\nextra-index-url = https://pypi.org/simple\n' "$ROCM_VERSION" > /etc/pip.conf; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,18 +45,13 @@ RUN pip install --no-cache-dir --upgrade pip
 
 COPY backend/requirements.txt .
 
-# ROCm version to pull PyTorch wheels for. Default is 6.3 (supports RDNA1/2/3).
-# Set ROCM_VERSION=7.2 for RDNA 4 (RX 9000 series) support.
+# ROCm wheel index. Default 6.3 (RDNA1/2/3); set ROCM_VERSION=7.2 for RDNA4.
 ARG ROCM_VERSION=6.3
 
-# When building the ROCm variant, install the ROCm-enabled PyTorch wheels
-# first so that the subsequent requirements.txt install sees them as already
-# satisfying the torch/torchaudio constraints and leaves them in place.
-# The CPU path skips this step and installs torch from PyPI as before.
+# For ROCm, make the PyTorch ROCm index primary so every install below resolves
+# torch to ROCm wheels instead of the default CUDA build.
 RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
-      pip install --no-cache-dir --prefix=/install \
-        torch torchaudio \
-        --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}"; \
+      printf '[global]\nindex-url = https://download.pytorch.org/whl/rocm%s\nextra-index-url = https://pypi.org/simple\n' "$ROCM_VERSION" > /etc/pip.conf; \
     fi
 
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
@@ -69,37 +64,17 @@ RUN pip install --no-cache-dir --prefix=/install \
 # === Stage 3: Runtime ===
 FROM python:3.11-slim
 
-# Re-declare ARG inside the stage (Docker scoping requirement).
-ARG PYTORCH_VARIANT=cpu
-
-# ROCm device access requires the container user to belong to the render
-# and video groups. GIDs are parameterised to match the host; Ubuntu 22.04+
-# defaults are used here. Override via env vars (docker-compose.rocm.yml
-# passes them through automatically):
-#   export RENDER_GID=$(getent group render | cut -d: -f3)
-#   export VIDEO_GID=$(getent group video  | cut -d: -f3)
-ARG RENDER_GID=992
-ARG VIDEO_GID=44
-RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
-      groupadd -f -g ${RENDER_GID} render && \
-      groupadd -f -g ${VIDEO_GID}  video; \
-    fi
-
-# Create non-root user for security
+# Create non-root user; the entrypoint joins GPU device groups at runtime.
 RUN groupadd -r voicebox && \
     useradd -r -g voicebox -m -s /bin/bash voicebox
 
-# ROCm: add voicebox user to render+video so it can open /dev/kfd and /dev/dri.
-RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
-      usermod -aG render,video voicebox; \
-    fi
-
 WORKDIR /app
 
-# Install only runtime system dependencies
+# Install only runtime system dependencies (gosu drops root in the entrypoint)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed Python packages from builder stage
@@ -115,9 +90,6 @@ COPY --from=frontend --chown=voicebox:voicebox /build/web/dist /app/frontend/
 RUN mkdir -p /app/data/generations /app/data/profiles /app/data/cache \
     && chown -R voicebox:voicebox /app/data
 
-# Switch to non-root user
-USER voicebox
-
 # Expose the API port
 EXPOSE 17493
 
@@ -125,5 +97,7 @@ EXPOSE 17493
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
     CMD curl -f http://localhost:17493/health || exit 1
 
-# Start the FastAPI server
+# Entrypoint joins GPU groups then drops to the voicebox user
+COPY --chmod=755 scripts/rocm-entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "17493"]

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -1,24 +1,11 @@
+---
 # ROCm (AMD GPU) overlay for Voicebox
 #
-# Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
 #
-# Prerequisites on the host:
-#   1. ROCm drivers installed — https://rocm.docs.amd.com/projects/install-on-linux
-#   2. Current user in the 'render' and 'video' groups:
-#        sudo usermod -aG render,video $USER   (then log out/in)
-#
-# If the render/video GIDs on your host differ from the Ubuntu 22.04 defaults
-# (render=992, video=44), export them before running compose so the build arg
-# and group_add values both stay in sync automatically:
-#   export RENDER_GID=$(getent group render | cut -d: -f3)
-#   export VIDEO_GID=$(getent group video  | cut -d: -f3)
-#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
-#
-# ROCm version (ROCM_VERSION):
-#   Default is 6.3 (supports RDNA1/2/3). For RDNA 4 (RX 9000 series) use 7.2:
-#   export ROCM_VERSION=7.2
-#   docker compose -f docker-compose.yml -f docker-compose.rocm.yml up --build
+# Requires ROCm drivers on the host:
+# https://rocm.docs.amd.com/projects/install-on-linux
+# RDNA4 (RX 9000): export ROCM_VERSION=7.2 (default 6.3 covers RDNA1-3).
 
 services:
   voicebox:
@@ -26,39 +13,24 @@ services:
       context: .
       args:
         PYTORCH_VARIANT: rocm
-        # These build args read from env vars so a single export covers both the
-        # Dockerfile group creation and the runtime group_add below.
-        RENDER_GID: ${RENDER_GID:-992}
-        VIDEO_GID: ${VIDEO_GID:-44}
         ROCM_VERSION: ${ROCM_VERSION:-6.3}
 
-    # Pass the AMD GPU device nodes into the container.
-    # /dev/kfd  — ROCm compute interface (required for GPU inference)
-    # /dev/dri  — DRM render nodes (required for display/memory access)
     devices:
       - /dev/kfd
       - /dev/dri
-
-    # Grant access to the render and video groups so the non-root user
-    # inside the container can open the GPU device nodes.
-    # These reference the same env vars used in build.args above so a
-    # single export keeps Dockerfile groups and runtime group_add in sync.
-    group_add:
-      - "${RENDER_GID:-992}"   # render
-      - "${VIDEO_GID:-44}"     # video
 
     environment:
       # HSA_OVERRIDE_GFX_VERSION forces the ROCm runtime to treat the GPU as a
       # specific GFX version when auto-detection fails or the GPU is newer than
       # the ROCm release. app.py sets 10.3.0 (RDNA2) by default; override here
       # for your GPU family:
-      #   RDNA4 / RX 9000 series:              12.0.0  (requires ROCM_VERSION=7.2)
+      #   RDNA4 / RX 9000 series:              12.0.0
+      #                                           (requires ROCM_VERSION=7.2)
       #   RDNA3 / RX 7000 series / Strix Halo: 11.0.0
       #   RDNA2 / RX 6000 series:              10.3.0
       #   RDNA1 / RX 5000 series:              10.1.0
       #   Vega / GCN5:                          9.0.0
-      - HSA_OVERRIDE_GFX_VERSION=11.0.0
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}
 
-      # Tune the ROCm memory allocator to reduce fragmentation during
-      # multi-engine inference (TTS + STT + LLM running concurrently).
+      # Tune the ROCm memory allocator
       - PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.8,max_split_size_mb:512

--- a/justfile
+++ b/justfile
@@ -45,7 +45,10 @@ setup-python:
     {{ pip }} install --upgrade pip -q
     if [ "$(uname)" = "Linux" ]; then
         torch_index=""
-        if [ -e /dev/kfd ] || [ -d /sys/module/amdgpu ]; then
+        if [ -e /proc/driver/nvidia/version ] || [ -d /sys/module/nvidia ]; then
+            echo "Detected NVIDIA GPU — installing CUDA PyTorch..."
+            torch_index="https://download.pytorch.org/whl/cu128"
+        elif [ -e /dev/kfd ]; then
             if [ -n "${VOICEBOX_ROCM_VERSION:-}" ]; then
                 rocm_ver="$VOICEBOX_ROCM_VERSION"
             elif lspci 2>/dev/null | grep -qi "Navi 4"; then
@@ -55,9 +58,6 @@ setup-python:
             fi
             echo "Detected AMD GPU — installing ROCm PyTorch (rocm${rocm_ver})..."
             torch_index="https://download.pytorch.org/whl/rocm${rocm_ver}"
-        elif [ -e /proc/driver/nvidia/version ] || [ -d /sys/module/nvidia ]; then
-            echo "Detected NVIDIA GPU — installing CUDA PyTorch..."
-            torch_index="https://download.pytorch.org/whl/cu128"
         fi
         if [ -n "$torch_index" ]; then
             {{ pip }} install torch torchaudio --index-url "$torch_index"

--- a/justfile
+++ b/justfile
@@ -43,6 +43,26 @@ setup-python:
     fi
     echo "Installing Python dependencies..."
     {{ pip }} install --upgrade pip -q
+    if [ "$(uname)" = "Linux" ]; then
+        torch_index=""
+        if [ -e /dev/kfd ] || [ -d /sys/module/amdgpu ]; then
+            if [ -n "${VOICEBOX_ROCM_VERSION:-}" ]; then
+                rocm_ver="$VOICEBOX_ROCM_VERSION"
+            elif lspci 2>/dev/null | grep -qi "Navi 4"; then
+                rocm_ver=7.2
+            else
+                rocm_ver=6.3
+            fi
+            echo "Detected AMD GPU — installing ROCm PyTorch (rocm${rocm_ver})..."
+            torch_index="https://download.pytorch.org/whl/rocm${rocm_ver}"
+        elif [ -e /proc/driver/nvidia/version ] || [ -d /sys/module/nvidia ]; then
+            echo "Detected NVIDIA GPU — installing CUDA PyTorch..."
+            torch_index="https://download.pytorch.org/whl/cu128"
+        fi
+        if [ -n "$torch_index" ]; then
+            {{ pip }} install torch torchaudio --index-url "$torch_index"
+        fi
+    fi
     {{ pip }} install -r {{ backend_dir }}/requirements.txt
     # Chatterbox pins numpy<1.26 / torch==2.6 which break on Python 3.12+
     {{ pip }} install --no-deps chatterbox-tts

--- a/scripts/rocm-entrypoint.sh
+++ b/scripts/rocm-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+# Join whatever groups own the mounted GPU nodes so /dev/kfd and /dev/dri work
+# on any host (no RENDER_GID/VIDEO_GID needed), then drop to the app user.
+for dev in /dev/kfd /dev/dri/render*; do
+    [ -e "$dev" ] || continue
+    gid=$(stat -c %g "$dev")
+    grp=$(getent group "$gid" | cut -d: -f1)
+    [ -n "$grp" ] || {
+        grp="gpu$gid"
+        groupadd -g "$gid" "$grp"
+    }
+    usermod -aG "$grp" voicebox
+done
+exec gosu voicebox "$@"


### PR DESCRIPTION
## Why

Fixes two Linux AMD setup paths that currently fall back to CPU or install the wrong PyTorch build:

- Docker ROCm builds now keep PyTorch on the ROCm wheel index instead of letting later depedency installs replace it with CUDA wheels.
- The ROCm compose overlay no longer assumes Ubuntu render/video group IDs. The container joins the groups that own `/dev/kfd` and `/dev/dri` at startup.
- Native Linux setup now picks a GPU PyTorch index before installing backend dependencies: ROCm for AMD, CUDA for NVIDIA, and the default path otherwise.

Keeps Mac & Windows setups unchanged.

## Test rig

- Arch Linux, kernel 7.0.14-zen, AMD Ryzen 9 5950X, 64 GB RAM
- 3× AMD Radeon AI PRO R9700 - **gfx1201 (RDNA4)**, 96 GB total VRAM
- ROCm 7.2.4 at `/opt/rocm`; `render` GID **989**, `video` GID **985**
- Bun, Rust (x86_64-unknown-linux-gnu), `just`, Docker 29.6.1, Python 3.12

## Root cause

On my first install the Docker ROCm image installed `torch` and `torchaudio` from the ROCm index first, but later dependency installs could still resolve PyTorch packages from th default index. On my AMD test box this left the running container with a CUDA torch build, no HIP runtime, and `gpu_available: false`.

The compose overlay also required users to pass the host `render` and `video` GIDs manually. That works on **_Ubuntu_** defaults, but it is easy to miss on other distros. (sad face). On Arch, my host uses `render=989` and `video=985`, so the default values did not grant the app user access to the GPU devices. Boom now it's using my CPU 👎

Native Linux setup had a separa te problem: the Unix recipe installed plain `torch`, which gives Linux users a CUDA build by default. AMD users then had to replace it by hand with ROCm wheels after setup.

## Fix

- Set the ROCm PyTorch index as the pip index during Docker ROCm dependency installation, with PyPI as an extra index for normal packages.
- Add a small runtime entrypoint that reads the group IDs from mounted GPU device nodes, creates missing groups if needed, adds `voicebox` to them, then drops privileges with `gosu`.
- Leave `HSA_OVERRIDE_GFX_VERSION` unset by default in the ROCm compose overlay. Users can still set it when they need an override for older cards.
- Add Linux GPU detection to `just setup-python`:
  - AMD via `/dev/kfd` or the `amdgpu` module uses ROCm wheels.
  - Navi 4 defaults to ROCm 7.2. Other AMD GPUs default to ROCm 6.3.
  - NVIDIA uses the CUDA 12.8 PyTorch index.

## Security

This PR does not change remote access, authentication, or signing behavior. The Docker container still drops to the `voicebox` user before starting the server. The entrypoint only runs as root long enough to join the GPU device groups that Docker mounted into the container.

No secrets, API keys, or signing keys are included.

## Tested

- [x] `shfmt -d -i 4 scripts/rocm-entrypoint.sh`
- [x] `shellcheck scripts/rocm-entrypoint.sh`
- [x] `yamllint docker-compose.rocm.yml`
- [x] `git diff --check`
- [x] Native ROCm torch install verified on Arch Linux with ROCm 7.2.4 and
  gfx1201. `torch.version.hip` was set, `torch.cuda.is_available()` was true,
  and all 3 AMD GPUs were visible.
- [x] End-to-end TTS generation verified on the same AMD machine after launching
  the backend with ROCm.
- [ x] Rebuild Docker ROCm image and confirm `/health` reports GPU available.

Related to #618, #630, and #560.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GPU support during setup and container startup for AMD/ROCm and NVIDIA/CUDA environments.
  * Added automatic GPU device permission handling at container launch (joins required device groups dynamically).

* **Bug Fixes**
  * Fixed ROCm dependency installation to retain the ROCm PyTorch wheel source during image builds.
  * Made ROCm container configuration more environment-driven (optional graphics override instead of a fixed default).

* **Chores**
  * Updated setup behavior to install the correct PyTorch/torchaudio wheels based on detected GPU type.
  * Refreshed Linux/ROCm guidance in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->