### PR TITLE
feat: optionally keep capture transcript on clipboard

### DIFF
--- a/app/src/components/DictateWindow/DictateWindow.tsx
+++ b/app/src/components/DictateWindow/DictateWindow.tsx
@@ -42,25 +42,34 @@ export function DictateWindow() {
   const focusRef = useRef<FocusSnapshot | null>(null);
 
   const session = useCaptureRecordingSession({
-    onFinalText: async (text, _capture, allowAutoPaste) => {
+    onFinalText: async (text, _capture, allowAutoPaste, copyTranscriptToClipboard) => {
       const focus = focusRef.current;
       // Consume-once: a second chord before this fires would overwrite
       // focusRef, but nulling it here guards against the late-arriving
       // refine-result firing a paste after the user has moved on.
       focusRef.current = null;
-      if (!allowAutoPaste) return;
-      if (!focus || !text.trim()) return;
-      try {
-        await invoke('paste_final_text', { text, focus });
-      } catch (err) {
-        // Surface accessibility failures to the main window so it can prompt
-        // the user to grant permission. Other errors stay swallowed —
-        // the transcription still landed in the captures list.
-        const msg = err instanceof Error ? err.message : String(err);
-        if (/accessibility/i.test(msg)) {
-          emit('system:accessibility-missing').catch(() => {});
+      const finalText = text.trim();
+      if (!finalText) return;
+      if (allowAutoPaste && focus) {
+        try {
+          await invoke('paste_final_text', { text: finalText, focus });
+        } catch (err) {
+          // Surface accessibility failures to the main window so it can prompt
+          // the user to grant permission. Other errors stay swallowed —
+          // the transcription still landed in the captures list.
+          const msg = err instanceof Error ? err.message : String(err);
+          if (/accessibility/i.test(msg)) {
+            emit('system:accessibility-missing').catch(() => {});
+          }
+          console.warn('[dictate] paste_final_text failed:', err);
         }
-        console.warn('[dictate] paste_final_text failed:', err);
+      }
+      if (copyTranscriptToClipboard) {
+        try {
+          await invoke('copy_text_to_clipboard', { text: finalText });
+        } catch (err) {
+          console.warn('[dictate] copy_text_to_clipboard failed:', err);
+        }
       }
     },
   });
@@ -141,9 +150,7 @@ export function DictateWindow() {
     audio.onplaying = () => {
       emit('dictate:show').catch(() => {});
       setSpeaking((prev) =>
-        prev && prev.generationId === generationId
-          ? { ...prev, startedAt: Date.now() }
-          : prev,
+        prev && prev.generationId === generationId ? { ...prev, startedAt: Date.now() } : prev,
       );
       setSpeakElapsed(0);
     };

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -1,4 +1,13 @@
-import { Check, ChevronDown, FolderOpen, Info, Keyboard, Laptop, Lock, Volume2 } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  FolderOpen,
+  Info,
+  Keyboard,
+  Laptop,
+  Lock,
+  Volume2,
+} from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AccessibilityNotice } from '@/components/AccessibilityGate/AccessibilityGate';
@@ -37,7 +46,9 @@ import { SettingRow, SettingSection } from './SettingRow';
 function ChordPreview({ keys }: { keys: string[] }) {
   const { t } = useTranslation();
   if (keys.length === 0) {
-    return <span className="text-xs text-muted-foreground italic">{t('captures.chord.notSet')}</span>;
+    return (
+      <span className="text-xs text-muted-foreground italic">{t('captures.chord.notSet')}</span>
+    );
   }
   return (
     <div className="flex items-center gap-1">
@@ -61,8 +72,7 @@ function ChordPreview({ keys }: { keys: string[] }) {
   );
 }
 
-const isWindows =
-  typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
+const isWindows = typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
 
 const PILL_SEQUENCE: PillState[] = ['recording', 'transcribing', 'refining', 'rest'];
 const PILL_DURATIONS: Partial<Record<PillState, number>> = {
@@ -136,6 +146,7 @@ export function CapturesPage() {
   const selfCorrection = settings?.self_correction ?? true;
   const preserveTechnical = settings?.preserve_technical ?? true;
   const allowAutoPaste = settings?.allow_auto_paste ?? true;
+  const copyTranscriptToClipboard = settings?.copy_transcript_to_clipboard ?? false;
   const defaultVoiceId = settings?.default_playback_voice_id ?? null;
   const hotkeyEnabled = settings?.hotkey_enabled ?? false;
   const pushToTalkKeys = settings?.chord_push_to_talk_keys ?? defaultChordKeys('push');
@@ -149,9 +160,7 @@ export function CapturesPage() {
     fetch(`${serverUrl}/health/filesystem`)
       .then((res) => res.json())
       .then((data) => {
-        const dir = data.directories?.find((d: { path: string }) =>
-          d.path.includes('captures'),
-        );
+        const dir = data.directories?.find((d: { path: string }) => d.path.includes('captures'));
         if (dir?.path) setCapturesPath(dir.path);
       })
       .catch(() => {});
@@ -170,369 +179,415 @@ export function CapturesPage() {
   }, [platform, capturesPath]);
 
   const voices: VoiceProfileResponse[] = profiles ?? [];
-  const defaultVoice =
-    voices.find((v) => v.id === defaultVoiceId) ?? null;
+  const defaultVoice = voices.find((v) => v.id === defaultVoiceId) ?? null;
 
   return (
     <div className="flex gap-8 items-start max-w-5xl">
       <div className="flex-1 min-w-0 max-w-2xl space-y-10">
-      <SettingSection
-        title={t('settings.captures.dictation.title')}
-        description={t('settings.captures.dictation.description')}
-      >
-        <div>
-          <SettingRow
-            title={t('settings.captures.dictation.globalShortcut.title')}
-            description={t('settings.captures.dictation.globalShortcut.description')}
-            htmlFor="hotkeyEnabled"
-            action={
-              <Toggle
-                id="hotkeyEnabled"
-                checked={hotkeyEnabled}
-                onCheckedChange={(v) => {
-                  update({ hotkey_enabled: v });
-                  // Surface model-readiness blocks at the toggle. The
-                  // InputMonitoringNotice below already covers TCC, but
-                  // missing models would otherwise be invisible from this
-                  // page — the user toggles on, presses the chord, and
-                  // nothing happens because useChordSync gates on readiness.
-                  if (!v) return;
-                  const missingModels = readiness.missing.filter(
-                    (g) => g === 'stt' || g === 'llm',
-                  );
-                  if (missingModels.length === 0) return;
-                  const names = [
-                    missingModels.includes('stt') ? readiness.stt?.display_name : null,
-                    missingModels.includes('llm') ? readiness.llm?.display_name : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' and ');
-                  toast({
-                    title: t('captures.toast.shortcutNotArmed'),
-                    description: t('captures.toast.shortcutNotArmedDescription', {
-                      names,
-                      count: missingModels.length,
-                    }),
-                  });
-                }}
-              />
-            }
-          />
-          <InputMonitoringNotice enabled={hotkeyEnabled} />
-        </div>
-
-        <SettingRow
-          title={t('settings.captures.dictation.pushToTalk.title')}
-          description={t('settings.captures.dictation.pushToTalk.description')}
-          action={
-            <div className="flex items-center gap-2">
-              <ChordPreview keys={pushToTalkKeys} />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hotkeyEnabled}
-                onClick={() => setChordEditor('push')}
-              >
-                <Keyboard className="h-3.5 w-3.5 mr-1.5" />
-                {t('settings.captures.dictation.pushToTalk.change')}
-              </Button>
-            </div>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.dictation.toggle.title')}
-          description={t('settings.captures.dictation.toggle.description')}
-          action={
-            <div className="flex items-center gap-2">
-              <ChordPreview keys={toggleToTalkKeys} />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hotkeyEnabled}
-                onClick={() => setChordEditor('toggle')}
-              >
-                <Keyboard className="h-3.5 w-3.5 mr-1.5" />
-                {t('settings.captures.dictation.toggle.change')}
-              </Button>
-            </div>
-          }
-        />
-
-        <ChordPicker
-          open={chordEditor === 'push'}
-          title={t('settings.captures.dictation.chordPicker.pttTitle')}
-          description={t('settings.captures.dictation.chordPicker.pttDescription')}
-          initialKeys={pushToTalkKeys}
-          onCancel={() => setChordEditor(null)}
-          onSave={(keys) => {
-            update({ chord_push_to_talk_keys: keys });
-            setChordEditor(null);
-          }}
-        />
-
-        <ChordPicker
-          open={chordEditor === 'toggle'}
-          title={t('settings.captures.dictation.chordPicker.toggleTitle')}
-          description={t('settings.captures.dictation.chordPicker.toggleDescription')}
-          initialKeys={toggleToTalkKeys}
-          onCancel={() => setChordEditor(null)}
-          onSave={(keys) => {
-            update({ chord_toggle_to_talk_keys: keys });
-            setChordEditor(null);
-          }}
-        />
-
-        <SettingRow
-          title={t('settings.captures.dictation.preview.title')}
-          description={t('settings.captures.dictation.preview.description')}
+        <SettingSection
+          title={t('settings.captures.dictation.title')}
+          description={t('settings.captures.dictation.description')}
         >
-          <HotkeyPillPreview enabled={hotkeyEnabled} />
-        </SettingRow>
+          <div>
+            <SettingRow
+              title={t('settings.captures.dictation.globalShortcut.title')}
+              description={t('settings.captures.dictation.globalShortcut.description')}
+              htmlFor="hotkeyEnabled"
+              action={
+                <Toggle
+                  id="hotkeyEnabled"
+                  checked={hotkeyEnabled}
+                  onCheckedChange={(v) => {
+                    update({ hotkey_enabled: v });
+                    // Surface model-readiness blocks at the toggle. The
+                    // InputMonitoringNotice below already covers TCC, but
+                    // missing models would otherwise be invisible from this
+                    // page — the user toggles on, presses the chord, and
+                    // nothing happens because useChordSync gates on readiness.
+                    if (!v) return;
+                    const missingModels = readiness.missing.filter(
+                      (g) => g === 'stt' || g === 'llm',
+                    );
+                    if (missingModels.length === 0) return;
+                    const names = [
+                      missingModels.includes('stt') ? readiness.stt?.display_name : null,
+                      missingModels.includes('llm') ? readiness.llm?.display_name : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' and ');
+                    toast({
+                      title: t('captures.toast.shortcutNotArmed'),
+                      description: t('captures.toast.shortcutNotArmedDescription', {
+                        names,
+                        count: missingModels.length,
+                      }),
+                    });
+                  }}
+                />
+              }
+            />
+            <InputMonitoringNotice enabled={hotkeyEnabled} />
+          </div>
 
-        <div>
           <SettingRow
-            title={t('settings.captures.dictation.autoPaste.title')}
-            description={t('settings.captures.dictation.autoPaste.description')}
-            htmlFor="autoPaste"
+            title={t('settings.captures.dictation.pushToTalk.title')}
+            description={t('settings.captures.dictation.pushToTalk.description')}
             action={
-              <Toggle
-                id="autoPaste"
-                checked={allowAutoPaste}
-                onCheckedChange={(v) => update({ allow_auto_paste: v })}
-                disabled={!hotkeyEnabled}
-              />
-            }
-          />
-          <AccessibilityNotice />
-        </div>
-      </SettingSection>
-
-      <SettingSection
-        title={t('settings.captures.transcription.title')}
-        description={t('settings.captures.transcription.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.transcription.model.title')}
-          description={t('settings.captures.transcription.model.description')}
-          action={
-            <Select
-              value={sttModel}
-              onValueChange={(v) => update({ stt_model: v as WhisperModelSize })}
-            >
-              <SelectTrigger className="w-[300px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="base">
-                  {t('settings.captures.transcription.model.base', { tail: t('settings.captures.transcription.model.tail.fast') })}
-                </SelectItem>
-                <SelectItem value="small">
-                  {t('settings.captures.transcription.model.small', { tail: t('settings.captures.transcription.model.tail.balanced') })}
-                </SelectItem>
-                <SelectItem value="medium">
-                  {t('settings.captures.transcription.model.medium', { tail: t('settings.captures.transcription.model.tail.higher') })}
-                </SelectItem>
-                <SelectItem value="large">
-                  {t('settings.captures.transcription.model.large', { tail: t('settings.captures.transcription.model.tail.best') })}
-                </SelectItem>
-                <SelectItem value="turbo">
-                  {t('settings.captures.transcription.model.turbo', { tail: t('settings.captures.transcription.model.tail.nearBest') })}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.transcription.language.title')}
-          description={t('settings.captures.transcription.language.description')}
-          action={
-            <Select value={language} onValueChange={(v) => update({ language: v })}>
-              <SelectTrigger className="w-[180px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">{t('settings.captures.transcription.language.auto')}</SelectItem>
-                <SelectItem value="en">{t('settings.captures.transcription.language.en')}</SelectItem>
-                <SelectItem value="es">{t('settings.captures.transcription.language.es')}</SelectItem>
-                <SelectItem value="fr">{t('settings.captures.transcription.language.fr')}</SelectItem>
-                <SelectItem value="de">{t('settings.captures.transcription.language.de')}</SelectItem>
-                <SelectItem value="ja">{t('settings.captures.transcription.language.ja')}</SelectItem>
-                <SelectItem value="zh">{t('settings.captures.transcription.language.zh')}</SelectItem>
-                <SelectItem value="hi">{t('settings.captures.transcription.language.hi')}</SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-      </SettingSection>
-
-      <SettingSection
-        title={t('settings.captures.refinement.title')}
-        description={t('settings.captures.refinement.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.refinement.auto.title')}
-          description={t('settings.captures.refinement.auto.description')}
-          htmlFor="autoRefine"
-          action={
-            <Toggle
-              id="autoRefine"
-              checked={autoRefine}
-              onCheckedChange={(v) => update({ auto_refine: v })}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.model.title')}
-          description={t('settings.captures.refinement.model.description')}
-          action={
-            <Select
-              value={llmModel}
-              onValueChange={(v) => update({ llm_model: v as Qwen3ModelSize })}
-              disabled={!autoRefine}
-            >
-              <SelectTrigger className="w-[260px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="0.6B">
-                  {t('settings.captures.refinement.model.size06', { tail: t('settings.captures.refinement.model.tail.veryFast') })}
-                </SelectItem>
-                <SelectItem value="1.7B">
-                  {t('settings.captures.refinement.model.size17', { tail: t('settings.captures.refinement.model.tail.fast') })}
-                </SelectItem>
-                <SelectItem value="4B">
-                  {t('settings.captures.refinement.model.size40', { tail: t('settings.captures.refinement.model.tail.fullQuality') })}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.smartCleanup.title')}
-          description={t('settings.captures.refinement.smartCleanup.description')}
-          htmlFor="smartCleanup"
-          action={
-            <Toggle
-              id="smartCleanup"
-              checked={smartCleanup}
-              onCheckedChange={(v) => update({ smart_cleanup: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.selfCorrection.title')}
-          description={t('settings.captures.refinement.selfCorrection.description')}
-          htmlFor="selfCorrection"
-          action={
-            <Toggle
-              id="selfCorrection"
-              checked={selfCorrection}
-              onCheckedChange={(v) => update({ self_correction: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.preserveTechnical.title')}
-          description={t('settings.captures.refinement.preserveTechnical.description')}
-          htmlFor="preserveTechnical"
-          action={
-            <Toggle
-              id="preserveTechnical"
-              checked={preserveTechnical}
-              onCheckedChange={(v) => update({ preserve_technical: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-      </SettingSection>
-
-      <SettingSection
-        title={t('settings.captures.playback.title')}
-        description={t('settings.captures.playback.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.playback.defaultVoice.title')}
-          description={t('settings.captures.playback.defaultVoice.description')}
-          action={
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+              <div className="flex items-center gap-2">
+                <ChordPreview keys={pushToTalkKeys} />
                 <Button
                   variant="outline"
                   size="sm"
-                  className="gap-2 min-w-[220px] justify-between"
-                  disabled={voices.length === 0}
+                  disabled={!hotkeyEnabled}
+                  onClick={() => setChordEditor('push')}
                 >
-                  <div className="flex items-center gap-2 min-w-0">
-                    {defaultVoice ? (
-                      <span className="truncate">{defaultVoice.name}</span>
-                    ) : (
-                      <span className="truncate text-muted-foreground">
-                        {voices.length === 0
-                          ? t('settings.captures.playback.defaultVoice.noClonedVoices')
-                          : t('settings.captures.playback.defaultVoice.noneSelected')}
-                      </span>
-                    )}
-                  </div>
-                  <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
+                  <Keyboard className="h-3.5 w-3.5 mr-1.5" />
+                  {t('settings.captures.dictation.pushToTalk.change')}
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-64">
-                <DropdownMenuLabel className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                  {t('settings.captures.playback.defaultVoice.clonedVoices')}
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {voices.map((v) => (
-                  <DropdownMenuItem
-                    key={v.id}
-                    onClick={() => update({ default_playback_voice_id: v.id })}
-                    className="gap-2.5 py-2"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium truncate">{v.name}</div>
-                      {v.description ? (
-                        <div className="text-[11px] text-muted-foreground truncate">
-                          {v.description}
-                        </div>
-                      ) : null}
-                    </div>
-                    {v.id === defaultVoiceId && <Check className="h-3.5 w-3.5 text-accent shrink-0" />}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          }
-        />
-      </SettingSection>
+              </div>
+            }
+          />
 
-      <SettingSection
-        title={t('settings.captures.storage.title')}
-        description={t('settings.captures.storage.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.storage.folder.title')}
-          description={capturesPath ?? t('settings.captures.storage.folder.description')}
-          action={
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openCapturesFolder}
-              disabled={opening || !capturesPath}
-            >
-              <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
-              {t('settings.captures.storage.folder.open')}
-            </Button>
-          }
-        />
-      </SettingSection>
+          <SettingRow
+            title={t('settings.captures.dictation.toggle.title')}
+            description={t('settings.captures.dictation.toggle.description')}
+            action={
+              <div className="flex items-center gap-2">
+                <ChordPreview keys={toggleToTalkKeys} />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!hotkeyEnabled}
+                  onClick={() => setChordEditor('toggle')}
+                >
+                  <Keyboard className="h-3.5 w-3.5 mr-1.5" />
+                  {t('settings.captures.dictation.toggle.change')}
+                </Button>
+              </div>
+            }
+          />
+
+          <ChordPicker
+            open={chordEditor === 'push'}
+            title={t('settings.captures.dictation.chordPicker.pttTitle')}
+            description={t('settings.captures.dictation.chordPicker.pttDescription')}
+            initialKeys={pushToTalkKeys}
+            onCancel={() => setChordEditor(null)}
+            onSave={(keys) => {
+              update({ chord_push_to_talk_keys: keys });
+              setChordEditor(null);
+            }}
+          />
+
+          <ChordPicker
+            open={chordEditor === 'toggle'}
+            title={t('settings.captures.dictation.chordPicker.toggleTitle')}
+            description={t('settings.captures.dictation.chordPicker.toggleDescription')}
+            initialKeys={toggleToTalkKeys}
+            onCancel={() => setChordEditor(null)}
+            onSave={(keys) => {
+              update({ chord_toggle_to_talk_keys: keys });
+              setChordEditor(null);
+            }}
+          />
+
+          <SettingRow
+            title={t('settings.captures.dictation.preview.title')}
+            description={t('settings.captures.dictation.preview.description')}
+          >
+            <HotkeyPillPreview enabled={hotkeyEnabled} />
+          </SettingRow>
+
+          <div>
+            <SettingRow
+              title={t('settings.captures.dictation.copyToClipboard.title')}
+              description={t('settings.captures.dictation.copyToClipboard.description')}
+              htmlFor="copyTranscriptToClipboard"
+              action={
+                <Toggle
+                  id="copyTranscriptToClipboard"
+                  checked={copyTranscriptToClipboard}
+                  onCheckedChange={(v) => update({ copy_transcript_to_clipboard: v })}
+                  disabled={!hotkeyEnabled}
+                />
+              }
+            />
+
+            <SettingRow
+              title={t('settings.captures.dictation.autoPaste.title')}
+              description={t('settings.captures.dictation.autoPaste.description')}
+              htmlFor="autoPaste"
+              action={
+                <Toggle
+                  id="autoPaste"
+                  checked={allowAutoPaste}
+                  onCheckedChange={(v) => update({ allow_auto_paste: v })}
+                  disabled={!hotkeyEnabled}
+                />
+              }
+            />
+            <AccessibilityNotice />
+          </div>
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.transcription.title')}
+          description={t('settings.captures.transcription.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.transcription.model.title')}
+            description={t('settings.captures.transcription.model.description')}
+            action={
+              <Select
+                value={sttModel}
+                onValueChange={(v) => update({ stt_model: v as WhisperModelSize })}
+              >
+                <SelectTrigger className="w-[300px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="base">
+                    {t('settings.captures.transcription.model.base', {
+                      tail: t('settings.captures.transcription.model.tail.fast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="small">
+                    {t('settings.captures.transcription.model.small', {
+                      tail: t('settings.captures.transcription.model.tail.balanced'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="medium">
+                    {t('settings.captures.transcription.model.medium', {
+                      tail: t('settings.captures.transcription.model.tail.higher'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="large">
+                    {t('settings.captures.transcription.model.large', {
+                      tail: t('settings.captures.transcription.model.tail.best'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="turbo">
+                    {t('settings.captures.transcription.model.turbo', {
+                      tail: t('settings.captures.transcription.model.tail.nearBest'),
+                    })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.transcription.language.title')}
+            description={t('settings.captures.transcription.language.description')}
+            action={
+              <Select value={language} onValueChange={(v) => update({ language: v })}>
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">
+                    {t('settings.captures.transcription.language.auto')}
+                  </SelectItem>
+                  <SelectItem value="en">
+                    {t('settings.captures.transcription.language.en')}
+                  </SelectItem>
+                  <SelectItem value="es">
+                    {t('settings.captures.transcription.language.es')}
+                  </SelectItem>
+                  <SelectItem value="fr">
+                    {t('settings.captures.transcription.language.fr')}
+                  </SelectItem>
+                  <SelectItem value="de">
+                    {t('settings.captures.transcription.language.de')}
+                  </SelectItem>
+                  <SelectItem value="ja">
+                    {t('settings.captures.transcription.language.ja')}
+                  </SelectItem>
+                  <SelectItem value="zh">
+                    {t('settings.captures.transcription.language.zh')}
+                  </SelectItem>
+                  <SelectItem value="hi">
+                    {t('settings.captures.transcription.language.hi')}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.refinement.title')}
+          description={t('settings.captures.refinement.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.refinement.auto.title')}
+            description={t('settings.captures.refinement.auto.description')}
+            htmlFor="autoRefine"
+            action={
+              <Toggle
+                id="autoRefine"
+                checked={autoRefine}
+                onCheckedChange={(v) => update({ auto_refine: v })}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.model.title')}
+            description={t('settings.captures.refinement.model.description')}
+            action={
+              <Select
+                value={llmModel}
+                onValueChange={(v) => update({ llm_model: v as Qwen3ModelSize })}
+                disabled={!autoRefine}
+              >
+                <SelectTrigger className="w-[260px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="0.6B">
+                    {t('settings.captures.refinement.model.size06', {
+                      tail: t('settings.captures.refinement.model.tail.veryFast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="1.7B">
+                    {t('settings.captures.refinement.model.size17', {
+                      tail: t('settings.captures.refinement.model.tail.fast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="4B">
+                    {t('settings.captures.refinement.model.size40', {
+                      tail: t('settings.captures.refinement.model.tail.fullQuality'),
+                    })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.smartCleanup.title')}
+            description={t('settings.captures.refinement.smartCleanup.description')}
+            htmlFor="smartCleanup"
+            action={
+              <Toggle
+                id="smartCleanup"
+                checked={smartCleanup}
+                onCheckedChange={(v) => update({ smart_cleanup: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.selfCorrection.title')}
+            description={t('settings.captures.refinement.selfCorrection.description')}
+            htmlFor="selfCorrection"
+            action={
+              <Toggle
+                id="selfCorrection"
+                checked={selfCorrection}
+                onCheckedChange={(v) => update({ self_correction: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.preserveTechnical.title')}
+            description={t('settings.captures.refinement.preserveTechnical.description')}
+            htmlFor="preserveTechnical"
+            action={
+              <Toggle
+                id="preserveTechnical"
+                checked={preserveTechnical}
+                onCheckedChange={(v) => update({ preserve_technical: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.playback.title')}
+          description={t('settings.captures.playback.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.playback.defaultVoice.title')}
+            description={t('settings.captures.playback.defaultVoice.description')}
+            action={
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-2 min-w-[220px] justify-between"
+                    disabled={voices.length === 0}
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      {defaultVoice ? (
+                        <span className="truncate">{defaultVoice.name}</span>
+                      ) : (
+                        <span className="truncate text-muted-foreground">
+                          {voices.length === 0
+                            ? t('settings.captures.playback.defaultVoice.noClonedVoices')
+                            : t('settings.captures.playback.defaultVoice.noneSelected')}
+                        </span>
+                      )}
+                    </div>
+                    <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuLabel className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                    {t('settings.captures.playback.defaultVoice.clonedVoices')}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {voices.map((v) => (
+                    <DropdownMenuItem
+                      key={v.id}
+                      onClick={() => update({ default_playback_voice_id: v.id })}
+                      className="gap-2.5 py-2"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">{v.name}</div>
+                        {v.description ? (
+                          <div className="text-[11px] text-muted-foreground truncate">
+                            {v.description}
+                          </div>
+                        ) : null}
+                      </div>
+                      {v.id === defaultVoiceId && (
+                        <Check className="h-3.5 w-3.5 text-accent shrink-0" />
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.storage.title')}
+          description={t('settings.captures.storage.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.storage.folder.title')}
+            description={capturesPath ?? t('settings.captures.storage.folder.description')}
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openCapturesFolder}
+                disabled={opening || !capturesPath}
+              >
+                <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
+                {t('settings.captures.storage.folder.open')}
+              </Button>
+            }
+          />
+        </SettingSection>
       </div>
 
       <aside className="hidden lg:block w-[280px] shrink-0 space-y-6 sticky top-0">
@@ -544,12 +599,16 @@ export function CapturesPage() {
         </div>
 
         <div className="space-y-3">
-          <h3 className="text-sm font-semibold">{t('settings.captures.sidebar.differencesTitle')}</h3>
+          <h3 className="text-sm font-semibold">
+            {t('settings.captures.sidebar.differencesTitle')}
+          </h3>
           <ul className="space-y-3 text-sm text-muted-foreground">
             <li className="flex gap-2.5">
               <Lock className="h-4 w-4 shrink-0 mt-0.5 text-accent" />
               <span className="leading-relaxed">
-                <span className="text-foreground font-medium">{t('settings.captures.sidebar.local.title')}</span>{' '}
+                <span className="text-foreground font-medium">
+                  {t('settings.captures.sidebar.local.title')}
+                </span>{' '}
                 {t('settings.captures.sidebar.local.body')}
               </span>
             </li>

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -179,15 +179,15 @@ export interface CaptureListResponse {
 }
 
 /**
- * Response of ``POST /captures``. Adds ``auto_refine`` and ``allow_auto_paste``
- * — the server's current settings captured at request time — so the client
- * can decide whether to chain a refine call and whether to fire the
- * synthetic-paste pipeline without relying on its own (possibly stale) copy
- * of capture_settings.
+ * Response of ``POST /captures``. Adds delivery settings captured at request
+ * time so the client can decide whether to chain a refine call, fire the
+ * synthetic-paste pipeline, and/or keep the transcript on the clipboard
+ * without relying on its own (possibly stale) copy of capture_settings.
  */
 export interface CaptureCreateResponse extends CaptureResponse {
   auto_refine: boolean;
   allow_auto_paste: boolean;
+  copy_transcript_to_clipboard: boolean;
 }
 
 export interface CaptureRefineRequest {
@@ -209,6 +209,7 @@ export interface CaptureSettings {
   self_correction: boolean;
   preserve_technical: boolean;
   allow_auto_paste: boolean;
+  copy_transcript_to_clipboard: boolean;
   default_playback_voice_id: string | null;
   /** Whether the global keyboard hotkey is armed. Off by default — turning
    *  this on triggers the macOS Input Monitoring TCC prompt. */

--- a/app/src/lib/hooks/useCaptureRecordingSession.ts
+++ b/app/src/lib/hooks/useCaptureRecordingSession.ts
@@ -3,11 +3,7 @@ import { emit as tauriEmit } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PillState } from '@/components/CapturePill/CapturePill';
 import { apiClient } from '@/lib/api/client';
-import type {
-  CaptureListResponse,
-  CaptureResponse,
-  CaptureSource,
-} from '@/lib/api/types';
+import type { CaptureListResponse, CaptureResponse, CaptureSource } from '@/lib/api/types';
 import { useAudioRecording } from '@/lib/hooks/useAudioRecording';
 
 /**
@@ -64,14 +60,15 @@ export interface UseCaptureRecordingSessionOptions {
    * for this capture, raw transcript otherwise. Used by the floating
    * dictate window to hand the text off to the Rust auto-paste pipeline.
    *
-   * ``allowAutoPaste`` snapshots the setting at chord-start so a refine that
-   * lands after the user flips the toggle still uses the value the capture
-   * was created under.
+   * ``allowAutoPaste`` and ``copyTranscriptToClipboard`` snapshot the
+   * delivery settings at chord-start so a refine that lands after the user
+   * flips a toggle still uses the values the capture was created under.
    */
   onFinalText?: (
     text: string,
     capture: CaptureResponse,
     allowAutoPaste: boolean,
+    copyTranscriptToClipboard: boolean,
   ) => void;
 }
 
@@ -127,6 +124,7 @@ export function useCaptureRecordingSession(
   // held so the refine onSuccess (which only sees the plain CaptureResponse)
   // can still pass the original setting through to onFinalText.
   const allowAutoPasteRef = useRef<boolean>(true);
+  const copyTranscriptToClipboardRef = useRef<boolean>(false);
 
   const clearRestTimer = useCallback(() => {
     if (restTimerRef.current !== null) {
@@ -194,7 +192,12 @@ export function useCaptureRecordingSession(
       if (pillStateRef.current === 'refining') scheduleHidePill();
       const finalText = data.transcript_refined ?? data.transcript_raw;
       if (finalText) {
-        onFinalTextRef.current?.(finalText, data, allowAutoPasteRef.current);
+        onFinalTextRef.current?.(
+          finalText,
+          data,
+          allowAutoPasteRef.current,
+          copyTranscriptToClipboardRef.current,
+        );
       }
     },
     onError: (err: Error) => {
@@ -215,6 +218,7 @@ export function useCaptureRecordingSession(
       broadcastCreated(capture);
       onCaptureCreatedRef.current?.(capture);
       allowAutoPasteRef.current = capture.allow_auto_paste;
+      copyTranscriptToClipboardRef.current = capture.copy_transcript_to_clipboard;
       if (capture.auto_refine) {
         setPillState('refining');
         refineMutation.mutate(capture.id);
@@ -225,6 +229,7 @@ export function useCaptureRecordingSession(
             capture.transcript_raw,
             capture,
             capture.allow_auto_paste,
+            capture.copy_transcript_to_clipboard,
           );
         }
       }
@@ -308,8 +313,7 @@ export function useCaptureRecordingSession(
     [refineMutation],
   );
 
-  const pillElapsedMs =
-    pillState === 'recording' ? Math.round(duration * 1000) : frozenElapsedMs;
+  const pillElapsedMs = pillState === 'recording' ? Math.round(duration * 1000) : frozenElapsedMs;
 
   return {
     pillState,

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -48,6 +48,7 @@ def run_migrations(engine) -> None:
 
 # -- helpers ---------------------------------------------------------------
 
+
 def _get_columns(inspector, table: str) -> set[str]:
     return {col["name"] for col in inspector.get_columns(table)}
 
@@ -62,6 +63,7 @@ def _add_column(engine, table: str, column_sql: str, label: str) -> None:
 
 # -- per-table migrations --------------------------------------------------
 
+
 def _migrate_story_items(engine, inspector, tables: set[str]) -> None:
     if "story_items" not in tables:
         return
@@ -73,15 +75,15 @@ def _migrate_story_items(engine, inspector, tables: set[str]) -> None:
         logger.info("Migrating story_items: removing position column, using start_time_ms")
         with engine.connect() as conn:
             if "start_time_ms" not in columns:
-                conn.execute(text(
-                    "ALTER TABLE story_items ADD COLUMN start_time_ms INTEGER DEFAULT 0"
-                ))
-                result = conn.execute(text("""
+                conn.execute(text("ALTER TABLE story_items ADD COLUMN start_time_ms INTEGER DEFAULT 0"))
+                result = conn.execute(
+                    text("""
                     SELECT si.id, si.story_id, si.position, g.duration
                     FROM story_items si
                     JOIN generations g ON si.generation_id = g.id
                     ORDER BY si.story_id, si.position
-                """))
+                """)
+                )
                 current_story_id = None
                 current_time_ms = 0
                 for item_id, story_id, _position, duration in result.fetchall():
@@ -96,7 +98,8 @@ def _migrate_story_items(engine, inspector, tables: set[str]) -> None:
                 conn.commit()
 
             # Recreate table without the position column (SQLite lacks DROP COLUMN)
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE story_items_new (
                     id VARCHAR PRIMARY KEY,
                     story_id VARCHAR NOT NULL,
@@ -110,13 +113,16 @@ def _migrate_story_items(engine, inspector, tables: set[str]) -> None:
                     FOREIGN KEY (story_id) REFERENCES stories(id),
                     FOREIGN KEY (generation_id) REFERENCES generations(id)
                 )
-            """))
-            conn.execute(text("""
+            """)
+            )
+            conn.execute(
+                text("""
                 INSERT INTO story_items_new (id, story_id, generation_id, start_time_ms, track, trim_start_ms, trim_end_ms, version_id, created_at)
                 SELECT id, story_id, generation_id, start_time_ms,
                     COALESCE(track, 0), COALESCE(trim_start_ms, 0), COALESCE(trim_end_ms, 0), version_id, created_at
                 FROM story_items
-            """))
+            """)
+            )
             conn.execute(text("DROP TABLE story_items"))
             conn.execute(text("ALTER TABLE story_items_new RENAME TO story_items"))
             conn.commit()
@@ -215,6 +221,13 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "allow_auto_paste BOOLEAN NOT NULL DEFAULT 1",
             "allow_auto_paste",
         )
+    if "copy_transcript_to_clipboard" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "copy_transcript_to_clipboard BOOLEAN NOT NULL DEFAULT 0",
+            "copy_transcript_to_clipboard",
+        )
     if "default_playback_voice_id" not in columns:
         _add_column(
             engine,
@@ -312,9 +325,7 @@ def _normalize_storage_paths(engine, tables: set[str]) -> None:
         for table, column in path_columns:
             if table not in tables:
                 continue
-            rows = conn.execute(
-                text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")
-            ).fetchall()
+            rows = conn.execute(text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")).fetchall()
             for row_id, path_val in rows:
                 if not path_val:
                     continue

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -34,10 +34,10 @@ class VoiceProfile(Base):
 
     # Voice type system — added v0.3.x
     voice_type = Column(String, default="cloned")  # "cloned" | "preset" | "designed"
-    preset_engine = Column(String, nullable=True)   # e.g. "kokoro" — only for preset
+    preset_engine = Column(String, nullable=True)  # e.g. "kokoro" — only for preset
     preset_voice_id = Column(String, nullable=True)  # e.g. "am_adam" — only for preset
-    design_prompt = Column(Text, nullable=True)      # text description — only for designed
-    default_engine = Column(String, nullable=True)   # auto-selected engine, locked for preset
+    design_prompt = Column(Text, nullable=True)  # text description — only for designed
+    default_engine = Column(String, nullable=True)  # auto-selected engine, locked for preset
     # Free-form character prompt used by the compose button and the
     # personality-rewrite path on /generate. Describes *what* this voice
     # says and how, orthogonal to how it sounds (handled by the preset /
@@ -203,6 +203,7 @@ class CaptureSettings(Base):
     self_correction = Column(Boolean, nullable=False, default=True)
     preserve_technical = Column(Boolean, nullable=False, default=True)
     allow_auto_paste = Column(Boolean, nullable=False, default=True)
+    copy_transcript_to_clipboard = Column(Boolean, nullable=False, default=False)
     default_playback_voice_id = Column(String, nullable=True)
     # Default OFF — opting in is what triggers the macOS Input Monitoring TCC
     # prompt. We deliberately don't spawn the global keyboard tap until the
@@ -212,12 +213,8 @@ class CaptureSettings(Base):
     hotkey_enabled = Column(Boolean, nullable=False, default=False)
     # Lists of keytap key names (e.g. "MetaRight", "ControlRight"). Right-hand
     # modifiers by default so they don't collide with left-hand shortcuts.
-    chord_push_to_talk_keys = Column(
-        JSON, nullable=False, default=default_push_to_talk_chord
-    )
-    chord_toggle_to_talk_keys = Column(
-        JSON, nullable=False, default=default_toggle_to_talk_chord
-    )
+    chord_push_to_talk_keys = Column(JSON, nullable=False, default=default_push_to_talk_chord)
+    chord_toggle_to_talk_keys = Column(JSON, nullable=False, default=default_toggle_to_talk_chord)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -81,11 +81,15 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$")
+    language: str = Field(
+        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+    )
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(
+        default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$"
+    )
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -220,15 +224,16 @@ class CaptureCreateResponse(CaptureResponse):
     """
     Response model for ``POST /captures``.
 
-    Adds ``auto_refine`` and ``allow_auto_paste`` — the server-side settings
-    captured at the moment the capture was created. The client reads these to
-    decide whether to chain a refinement request and whether to fire the
-    synthetic-paste pipeline, so it doesn't need a synced local copy of the
-    capture_settings table across sibling Tauri webviews.
+    Adds capture-delivery settings captured at the moment the capture was
+    created. The client reads these to decide whether to chain a refinement
+    request, fire the synthetic-paste pipeline, and/or leave the final
+    transcript on the clipboard, so it doesn't need a synced local copy of
+    the capture_settings table across sibling Tauri webviews.
     """
 
     auto_refine: bool
     allow_auto_paste: bool
+    copy_transcript_to_clipboard: bool
 
 
 class CaptureRefineRequest(BaseModel):
@@ -256,14 +261,11 @@ class CaptureSettingsResponse(BaseModel):
     self_correction: bool = True
     preserve_technical: bool = True
     allow_auto_paste: bool = True
+    copy_transcript_to_clipboard: bool = False
     default_playback_voice_id: Optional[str] = None
     hotkey_enabled: bool = False
-    chord_push_to_talk_keys: List[str] = Field(
-        default_factory=default_push_to_talk_chord
-    )
-    chord_toggle_to_talk_keys: List[str] = Field(
-        default_factory=default_toggle_to_talk_chord
-    )
+    chord_push_to_talk_keys: List[str] = Field(default_factory=default_push_to_talk_chord)
+    chord_toggle_to_talk_keys: List[str] = Field(default_factory=default_toggle_to_talk_chord)
 
     class Config:
         from_attributes = True
@@ -280,6 +282,7 @@ class CaptureSettingsUpdate(BaseModel):
     self_correction: Optional[bool] = None
     preserve_technical: Optional[bool] = None
     allow_auto_paste: Optional[bool] = None
+    copy_transcript_to_clipboard: Optional[bool] = None
     default_playback_voice_id: Optional[str] = None
     hotkey_enabled: Optional[bool] = None
     chord_push_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)

--- a/backend/routes/captures.py
+++ b/backend/routes/captures.py
@@ -64,6 +64,7 @@ async def create_capture_endpoint(
         **capture.model_dump(),
         auto_refine=bool(saved.auto_refine),
         allow_auto_paste=bool(saved.allow_auto_paste),
+        copy_transcript_to_clipboard=bool(saved.copy_transcript_to_clipboard),
     )
 
 

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1101,6 +1101,17 @@ async fn paste_final_text(
     Ok(true)
 }
 
+/// Leave the final transcript on the system clipboard.
+///
+/// This is intentionally separate from `paste_final_text`: auto-paste keeps
+/// using save/write/paste/restore so it does not clobber existing clipboard
+/// contents unless the user opts into this explicit SuperWhisper-style mode.
+#[command]
+fn copy_text_to_clipboard(text: String) -> Result<(), String> {
+    clipboard::write_text(&text)?;
+    Ok(())
+}
+
 /// Inspect the currently focused UI element. Returns the owning app's PID,
 /// bundle id, and AX role. Useful for sanity-checking the focus pipeline
 /// before committing to a paste.
@@ -1372,6 +1383,7 @@ pub fn run() {
             open_accessibility_settings,
             open_input_monitoring_settings,
             paste_final_text,
+            copy_text_to_clipboard,
             enable_hotkey,
             disable_hotkey,
             update_chord_bindings


### PR DESCRIPTION
## Summary

Adds a separate **Copy transcript to clipboard** capture setting so users can keep the final dictated text on the clipboard after capture, while preserving the current safe auto-paste behavior by default.

This wires up the already-present `settings.captures.dictation.copyToClipboard` UI text to actual behavior:

- adds `capture_settings.copy_transcript_to_clipboard` with migration/defaults
- includes the setting in capture settings API models and `POST /captures` responses
- snapshots the setting through the capture/refine lifecycle
- adds a Tauri `copy_text_to_clipboard` command
- calls it after the final transcript is available when the setting is enabled
- keeps `paste_final_text` unchanged, so auto-paste still saves/restores clipboard unless the user explicitly enables this new mode

## Why

Some users expect SuperWhisper-style behavior where the dictated transcript remains available for `Cmd+V` after recording. Today auto-paste stages the transcript temporarily and restores the prior clipboard, which is safer but means the user cannot paste the transcript afterward.

Related issues:

- #762
- #144

## Validation

- `git diff --check`
- `python3 -m py_compile backend/models.py backend/routes/captures.py backend/database/models.py backend/database/migrations.py`

Not fully validated locally:

- TypeScript check did not complete because the clone had no installed app deps and `bunx tsc -p app/tsconfig.json --noEmit` stopped on missing `vite/client` plus an existing TS 7 `baseUrl` deprecation.
- Rust/Tauri compile was not run because `cargo` was not available on this machine.

Opening as draft for maintainer review and proper CI/build validation.
