### PR TITLE
fix(linux): guard pill click-through against tao unrealized-window panic

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1273,6 +1273,10 @@ pub fn run() {
                 let handle_for_hide = app.handle().clone();
                 app.handle().listen("dictate:hide", move |_event| {
                     if let Some(window) = handle_for_hide.get_webview_window(DICTATE_WINDOW_LABEL) {
+                        // Skip on Linux: when the GDK window isn't realized,
+                        // set_ignore_cursor_events(true) panics in tao (unwrap on None).
+                        // This click-through park is a macOS-only workaround anyway.
+                        #[cfg(not(target_os = "linux"))]
                         let _ = window.set_ignore_cursor_events(true);
                         let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
                         let _ = window.hide();


### PR DESCRIPTION
## Problem

The app crashes on **every launch on Linux** with:

```
tao-0.34.5/src/platform_impl/linux/event_loop.rs:449:18:
called `Option::unwrap()` on a `None` value
panic in a function that cannot unwind -> abort
```

### Root cause

The dictate pill window is built hidden at startup (`visible(false)`). The pill component initializes in the `hidden` state, so on mount it immediately `emit('dictate:hide')` (`app/src/components/DictateWindow/DictateWindow.tsx`). The Rust `dictate:hide` handler then calls `set_ignore_cursor_events(true)`.

On Linux/GTK a window that has never been shown has no realized GDK window, so deep inside tao `window.window()` is `None` and `.unwrap()` aborts the process. macOS/Windows don't hit this because their windows realize differently.

## Fix

The click-through park is a macOS NSWindow workaround anyway (per the existing comment); on Linux plain `hide()` + off-screen park is sufficient. Gate the `set_ignore_cursor_events(true)` call off on Linux.

It's the only `set_ignore_cursor_events(true)` call in the tree; the `(false)` calls take tao's safe branch and don't panic.

## Testing

`just dev` on Pop!_OS 24.04 (Wayland, NVIDIA): app now launches cleanly and stays running, no panic, GPU detected as CUDA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window behavior when hiding dictation on Linux by avoiding a crash related to cursor-event handling.
  * Non-Linux platforms continue to use the click-through behavior as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->