### PR TITLE
fix(setup): stop preferring Python 3.13 for backend venv, fix version-warning off-by-one

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,8 +17,11 @@ pip := if os() == "windows" { venv_bin / "pip.exe" } else { venv_bin / "pip" }
 # Shell selection: use powershell on Windows, bash elsewhere
 set windows-shell := ["powershell", "-NoProfile", "-Command"]
 
-# Detect best python for venv creation (platform-aware)
-system_python := if os() == "windows" { "python" } else { `command -v python3.12 2>/dev/null || command -v python3.13 2>/dev/null || echo python3` }
+# Detect best python for venv creation (platform-aware).
+# Prefer 3.12/3.11 over 3.13+: numba (a required ML dependency) has no
+# wheel for Python 3.13 yet, so preferring it over a plain `python3`
+# fallback just trades one failure mode for a guaranteed one.
+system_python := if os() == "windows" { "python" } else { `command -v python3.12 2>/dev/null || command -v python3.11 2>/dev/null || command -v python3.13 2>/dev/null || echo python3` }
 
 # ─── Setup ────────────────────────────────────────────────────────────
 
@@ -35,9 +38,9 @@ setup-python:
     if [ ! -d "{{ venv }}" ]; then
         echo "Creating Python virtual environment..."
         PY_MINOR=$({{ system_python }} -c "import sys; print(sys.version_info[1])")
-        if [ "$PY_MINOR" -gt 13 ]; then
-            echo "Warning: Python 3.$PY_MINOR detected. ML packages may not be compatible."
-            echo "Recommended: brew install python@3.12"
+        if [ "$PY_MINOR" -ge 13 ]; then
+            echo "Warning: Python 3.$PY_MINOR detected. numba (a required ML dependency) has no wheel for Python 3.13+ yet, so this may fail installing requirements.txt."
+            echo "Recommended: install Python 3.12 (e.g. brew install python@3.12, or pyenv/uv) and re-run just setup."
         fi
         {{ system_python }} -m venv {{ venv }}
     fi
@@ -82,8 +85,9 @@ setup-python:
     if (-not (Test-Path "{{ venv }}")) { \
         Write-Host "Creating Python virtual environment..."; \
         $pyMinor = & {{ system_python }} -c "import sys; print(sys.version_info[1])"; \
-        if ([int]$pyMinor -gt 13) { \
-            Write-Host "Warning: Python 3.$pyMinor detected. ML packages may not be compatible."; \
+        if ([int]$pyMinor -ge 13) { \
+            Write-Host "Warning: Python 3.$pyMinor detected. numba (a required ML dependency) has no wheel for Python 3.13+ yet, so this may fail installing requirements.txt."; \
+            Write-Host "Recommended: install Python 3.12 and re-run just setup."; \
         }; \
         & {{ system_python }} -m venv {{ venv }}; \
     }


### PR DESCRIPTION
## Summary
- `just setup-python`'s `system_python` detection tried `python3.12` then fell straight to `python3.13`, which is worse than falling straight to the generic `python3` — on distros where 3.13 is already the system default (e.g. Debian 13), this guarantees hitting `numba 0.60`'s missing `cp313` wheel instead of just leaving it to chance.
- The version-compatibility warning also had an off-by-one: `-gt 13` never fires for Python 3.13 itself, only 3.14+, so the one version actually known to break stayed silent.

## Changes
- `system_python` now tries `python3.12` → `python3.11` → `python3.13` → `python3`, preferring known-good versions before falling back.
- Fixed the warning threshold to `-ge 13` (bash) / `-ge 13` (PowerShell) so it actually fires for Python 3.13, and made the message specific about the `numba` incompatibility with a concrete remediation step.
- Applied consistently to both the `[unix]` and `[windows]` `setup-python` recipes.

Fixes #793

## Test plan
- [x] `just --list` parses the justfile without errors after the change
- [x] Verified the bash version-check logic directly: warns for `PY_MINOR=13`, silent for `PY_MINOR=12`
- [x] Verified the `command -v` fallback chain resolves to `python3.12` first when available (confirmed on macOS with both 3.12 and 3.13 installed via Homebrew)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python version selection on non-Windows systems to prefer Python 3.12 or 3.11 before newer versions.
  * Updated setup warnings for newer Python releases on both Unix and Windows so they now appear for Python 3.13+ and recommend installing Python 3.12 before rerunning setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->