### PR TITLE
fix(backend): make HF download progress tracking safe under concurrent downloads

### DIFF
--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -4,6 +4,7 @@ Test script to debug model download progress tracking.
 
 import asyncio
 import json
+import threading
 import time
 from typing import List, Dict
 import logging
@@ -163,6 +164,83 @@ def test_hf_progress_tracker():
             return None
 
 
+def test_concurrent_downloads_dont_cross_contaminate():
+    """Test 5: Two simultaneous downloads (two threads) must not corrupt
+    each other's progress. Regression test for the tqdm monkey-patch race
+    where the tracker most recently patched onto the global tqdm class
+    silently absorbed every other in-flight download's updates."""
+    print("\n" + "=" * 60)
+    print("Test 5: Concurrent HFProgressTracker Downloads Stay Isolated")
+    print("=" * 60)
+
+    import tqdm as tqdm_module
+
+    original_tqdm_class = tqdm_module.tqdm
+
+    results_a: List[tuple] = []
+    results_b: List[tuple] = []
+
+    tracker_a = HFProgressTracker(lambda d, t, f: results_a.append((d, t, f)))
+    tracker_b = HFProgressTracker(lambda d, t, f: results_b.append((d, t, f)))
+
+    start_barrier = threading.Barrier(2)
+    errors: List[Exception] = []
+
+    def run_download(tracker, filename, size, chunk):
+        start_barrier.wait()  # force real overlap between the two threads
+        try:
+            with tracker.patch_download():
+                # Import (and thus resolve the currently-patched class) only
+                # after the patch is installed — importing earlier would bind
+                # to the pre-patch tqdm and silently skip tracking.
+                from tqdm import tqdm
+
+                with tqdm(total=size, desc=filename, unit="B") as pbar:
+                    for _ in range(0, size, chunk):
+                        pbar.update(chunk)
+                        time.sleep(0.005)
+        except Exception as e:  # pragma: no cover - surfaced via `errors`
+            errors.append(e)
+
+    # HFProgressTracker only reports progress once a file's total crosses
+    # MIN_TOTAL_BYTES (1MB) — use real-sized files so this test exercises
+    # the same path a real download does.
+    SIZE_A = 2_000_000
+    SIZE_B = 3_000_000
+    thread_a = threading.Thread(target=run_download, args=(tracker_a, "model-a.safetensors", SIZE_A, 200_000))
+    thread_b = threading.Thread(target=run_download, args=(tracker_b, "model-b.safetensors", SIZE_B, 200_000))
+
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=10)
+    thread_b.join(timeout=10)
+
+    assert not errors, f"Concurrent downloads raised: {errors}"
+    assert results_a, "Tracker A should have captured progress"
+    assert results_b, "Tracker B should have captured progress"
+
+    # Every update tracker A saw must be for A's file/size, never B's, and vice versa.
+    for downloaded, total, filename in results_a:
+        assert filename == "model-a.safetensors", f"Tracker A leaked filename: {filename}"
+        assert total == SIZE_A, f"Tracker A leaked total from tracker B: {total}"
+    for downloaded, total, filename in results_b:
+        assert filename == "model-b.safetensors", f"Tracker B leaked filename: {filename}"
+        assert total == SIZE_B, f"Tracker B leaked total from tracker A: {total}"
+
+    # Final byte counts should match each tracker's own file size exactly.
+    assert results_a[-1][0] == SIZE_A, "Tracker A should finish at its own file size"
+    assert results_b[-1][0] == SIZE_B, "Tracker B should finish at its own file size"
+
+    # The monkey-patch must be fully torn down once both downloads finish,
+    # not just when whichever one finished first exits.
+    assert tqdm_module.tqdm is original_tqdm_class, "tqdm patch should be restored once both downloads finish"
+    assert HFProgressTracker._refcount == 0
+
+    print(f"  Tracker A: {len(results_a)} updates, tracker B: {len(results_b)} updates — no cross-talk")
+    print("✓ Test 5 PASSED\n")
+    return True
+
+
 async def test_full_integration():
     """Test 4: Full integration test."""
     print("\n" + "=" * 60)
@@ -284,6 +362,13 @@ async def main():
     except Exception as e:
         print(f"✗ Test 4 FAILED: {e}\n")
         results.append(("Full Integration", False))
+
+    # Test 5: Concurrent downloads stay isolated
+    try:
+        results.append(("Concurrent Downloads", test_concurrent_downloads_dont_cross_contaminate()))
+    except Exception as e:
+        print(f"✗ Test 5 FAILED: {e}\n")
+        results.append(("Concurrent Downloads", False))
 
     # Summary
     print("\n" + "=" * 60)

--- a/backend/utils/hf_progress.py
+++ b/backend/utils/hf_progress.py
@@ -12,12 +12,31 @@ logger = logging.getLogger(__name__)
 
 
 class HFProgressTracker:
-    """Tracks HuggingFace Hub download progress by intercepting tqdm."""
+    """Tracks HuggingFace Hub download progress by intercepting tqdm.
+
+    ``patch_download()`` monkey-patches the process-wide ``tqdm`` class, which
+    every concurrent download shares. To support multiple downloads running
+    at once (e.g. two models downloading in parallel), the monkey-patch
+    itself is installed at most once per process (refcounted so the last
+    download to finish is the one that tears it down), and dispatch to the
+    *correct* tracker instance happens via a thread-local — each download
+    runs its blocking HF calls on its own thread, so the tqdm bars it creates
+    always resolve back to that thread's tracker, never another thread's.
+    """
+
+    _install_lock = threading.Lock()
+    _refcount = 0
+    _local = threading.local()
+
+    _original_tqdm_class = None
+    _original_tqdm_auto = None
+    _patched_modules: dict = {}
+    _hf_tqdm_original_update = None
+    _tracked_tqdm_class = None
 
     def __init__(self, progress_callback: Optional[Callable] = None, filter_non_downloads: bool = False):
         self.progress_callback = progress_callback
         self.filter_non_downloads = filter_non_downloads  # Only filter if True
-        self._original_tqdm_class = None
         self._lock = threading.Lock()
         self._total_downloaded = 0
         self._total_size = 0
@@ -25,15 +44,21 @@ class HFProgressTracker:
         self._file_downloaded = {}  # Track downloaded bytes per file
         self._current_filename = ""
         self._active_tqdms = {}  # Track active tqdm instances
-        self._hf_tqdm_original_update = None  # For monkey-patching hf's tqdm
+        self._prev_local_tracker = None  # Saved for nested patch_download() on the same thread
 
-    def _create_tracked_tqdm_class(self):
-        """Create a tqdm subclass that tracks progress."""
-        tracker = self
-        original_tqdm = self._original_tqdm_class
+    @classmethod
+    def _current(cls) -> Optional["HFProgressTracker"]:
+        """The tracker bound to the calling thread, if any."""
+        return getattr(cls._local, "tracker", None)
+
+    @classmethod
+    def _create_tracked_tqdm_class(cls):
+        """Create a tqdm subclass that reports progress to whichever tracker
+        is bound to the thread that's currently driving it."""
+        original_tqdm = cls._original_tqdm_class
 
         class TrackedTqdm(original_tqdm):
-            """A tqdm subclass that reports progress to our tracker."""
+            """A tqdm subclass that reports progress to the calling thread's tracker."""
 
             def __init__(self, *args, **kwargs):
                 # Extract filename from desc before passing to parent
@@ -106,6 +131,9 @@ class HFProgressTracker:
 
                 self._tracker_filename = filename or "unknown"
 
+                tracker = HFProgressTracker._current()
+                if tracker is None:
+                    return
                 with tracker._lock:
                     if filename:
                         tracker._current_filename = filename
@@ -115,6 +143,10 @@ class HFProgressTracker:
 
             def update(self, n=1):
                 result = super().update(n)
+
+                tracker = HFProgressTracker._current()
+                if tracker is None:
+                    return result
 
                 # Report progress
                 with tracker._lock:
@@ -206,47 +238,37 @@ class HFProgressTracker:
                 return has_extension and not has_skip_pattern
 
             def close(self):
-                with tracker._lock:
-                    if id(self) in tracker._active_tqdms:
-                        del tracker._active_tqdms[id(self)]
+                tracker = HFProgressTracker._current()
+                if tracker is not None:
+                    with tracker._lock:
+                        if id(self) in tracker._active_tqdms:
+                            del tracker._active_tqdms[id(self)]
                 return super().close()
 
         return TrackedTqdm
 
-    @contextmanager
-    def patch_download(self):
-        """Context manager to patch tqdm for progress tracking."""
+    @classmethod
+    def _install_patch(cls):
+        """Install the process-wide tqdm monkey-patch. Idempotent — safe to
+        call once per concurrent download; only does work the first time."""
         try:
             import tqdm as tqdm_module
 
-            # Store original tqdm class
-            self._original_tqdm_class = tqdm_module.tqdm
+            cls._original_tqdm_class = tqdm_module.tqdm
+            cls._tracked_tqdm_class = cls._create_tracked_tqdm_class()
+            tracked_tqdm = cls._tracked_tqdm_class
 
-            # Reset totals
-            with self._lock:
-                self._total_downloaded = 0
-                self._total_size = 0
-                self._file_sizes = {}
-                self._file_downloaded = {}
-                self._current_filename = ""
-                self._active_tqdms = {}
-
-            # Create our tracked tqdm class
-            tracked_tqdm = self._create_tracked_tqdm_class()
-
-            # Patch tqdm.tqdm
             tqdm_module.tqdm = tracked_tqdm
 
-            # Also patch tqdm.auto.tqdm if it exists (used by huggingface_hub)
-            self._original_tqdm_auto = None
+            cls._original_tqdm_auto = None
             if hasattr(tqdm_module, "auto") and hasattr(tqdm_module.auto, "tqdm"):
-                self._original_tqdm_auto = tqdm_module.auto.tqdm
+                cls._original_tqdm_auto = tqdm_module.auto.tqdm
                 tqdm_module.auto.tqdm = tracked_tqdm
 
             # Patch in sys.modules to catch already-imported references
             # huggingface_hub uses: from tqdm.auto import tqdm as base_tqdm
             # So we need to patch both 'tqdm' and 'base_tqdm' attributes
-            self._patched_modules = {}
+            cls._patched_modules = {}
             tqdm_attr_names = ["tqdm", "base_tqdm", "old_tqdm"]  # Various names used
 
             patched_count = 0
@@ -259,8 +281,8 @@ class HFProgressTracker:
                                 attr = getattr(module, attr_name)
                                 # Only patch if it's a tqdm class (not already patched)
                                 is_tqdm_class = (
-                                    attr is self._original_tqdm_class
-                                    or (self._original_tqdm_auto and attr is self._original_tqdm_auto)
+                                    attr is cls._original_tqdm_class
+                                    or (cls._original_tqdm_auto and attr is cls._original_tqdm_auto)
                                     or (
                                         hasattr(attr, "__name__")
                                         and attr.__name__ == "tqdm"
@@ -269,7 +291,7 @@ class HFProgressTracker:
                                 )
                                 if is_tqdm_class:
                                     key = f"{module_name}.{attr_name}"
-                                    self._patched_modules[key] = (module, attr_name, attr)
+                                    cls._patched_modules[key] = (module, attr_name, attr)
                                     setattr(module, attr_name, tracked_tqdm)
                                     patched_count += 1
                     except (AttributeError, TypeError):
@@ -277,21 +299,21 @@ class HFProgressTracker:
 
             # ALSO monkey-patch the update method on huggingface_hub's tqdm class
             # This is needed because the class was already defined at import time
-            self._hf_tqdm_original_update = None
+            cls._hf_tqdm_original_update = None
             try:
                 from huggingface_hub.utils import tqdm as hf_tqdm_module
 
                 if hasattr(hf_tqdm_module, "tqdm"):
                     hf_tqdm_class = hf_tqdm_module.tqdm
-                    self._hf_tqdm_original_update = hf_tqdm_class.update
-
-                    # Create a wrapper that calls our tracking
-                    tracker = self  # Reference to HFProgressTracker instance
+                    cls._hf_tqdm_original_update = hf_tqdm_class.update
 
                     def patched_update(tqdm_self, n=1):
-                        result = tracker._hf_tqdm_original_update(tqdm_self, n)
+                        result = cls._hf_tqdm_original_update(tqdm_self, n)
 
-                        # Track this progress
+                        tracker = cls._current()
+                        if tracker is None:
+                            return result
+
                         with tracker._lock:
                             desc = getattr(tqdm_self, "desc", "") or ""
                             current = getattr(tqdm_self, "n", 0)
@@ -321,45 +343,84 @@ class HFProgressTracker:
                 logger.warning("Could not monkey-patch hf_tqdm: %s", e)
 
             logger.debug("Patched %d tqdm references", patched_count)
-
-            yield
-
         except ImportError:
-            # If tqdm not available, just yield without patching
-            yield
-        finally:
-            # Restore original tqdm
-            if self._original_tqdm_class:
+            pass  # tqdm not available — nothing to patch
+
+    @classmethod
+    def _uninstall_patch(cls):
+        """Reverse `_install_patch()`. Only called once refcount drops to 0."""
+        if cls._original_tqdm_class is None:
+            return
+        try:
+            import tqdm as tqdm_module
+
+            tqdm_module.tqdm = cls._original_tqdm_class
+
+            if cls._original_tqdm_auto:
+                tqdm_module.auto.tqdm = cls._original_tqdm_auto
+
+            for key, (module, attr_name, original) in cls._patched_modules.items():
                 try:
-                    import tqdm as tqdm_module
+                    if module and original:
+                        setattr(module, attr_name, original)
+                except (AttributeError, TypeError):
+                    pass
+            cls._patched_modules = {}
 
-                    tqdm_module.tqdm = self._original_tqdm_class
+            if cls._hf_tqdm_original_update:
+                try:
+                    from huggingface_hub.utils import tqdm as hf_tqdm_module
 
-                    if self._original_tqdm_auto:
-                        tqdm_module.auto.tqdm = self._original_tqdm_auto
-
-                    # Restore patched modules
-                    for key, (module, attr_name, original) in self._patched_modules.items():
-                        try:
-                            if module and original:
-                                setattr(module, attr_name, original)
-                        except (AttributeError, TypeError):
-                            pass
-                    self._patched_modules = {}
-
-                    # Restore hf_tqdm's original update method
-                    if self._hf_tqdm_original_update:
-                        try:
-                            from huggingface_hub.utils import tqdm as hf_tqdm_module
-
-                            if hasattr(hf_tqdm_module, "tqdm"):
-                                hf_tqdm_module.tqdm.update = self._hf_tqdm_original_update
-                        except (ImportError, AttributeError):
-                            pass
-                        self._hf_tqdm_original_update = None
-
+                    if hasattr(hf_tqdm_module, "tqdm"):
+                        hf_tqdm_module.tqdm.update = cls._hf_tqdm_original_update
                 except (ImportError, AttributeError):
                     pass
+                cls._hf_tqdm_original_update = None
+        except ImportError:
+            pass
+        finally:
+            cls._original_tqdm_class = None
+            cls._tracked_tqdm_class = None
+
+    @contextmanager
+    def patch_download(self):
+        """Context manager to patch tqdm for progress tracking.
+
+        Safe to have multiple `HFProgressTracker` instances active at once
+        (e.g. two models downloading concurrently on different threads): the
+        process-wide monkey-patch is installed once (refcounted) and each
+        thread's tqdm updates dispatch to that thread's own tracker via a
+        thread-local, so concurrent downloads no longer share or clobber
+        each other's progress state.
+        """
+        # Reset this tracker's own state
+        with self._lock:
+            self._total_downloaded = 0
+            self._total_size = 0
+            self._file_sizes = {}
+            self._file_downloaded = {}
+            self._current_filename = ""
+            self._active_tqdms = {}
+
+        with HFProgressTracker._install_lock:
+            if HFProgressTracker._refcount == 0:
+                HFProgressTracker._install_patch()
+            HFProgressTracker._refcount += 1
+
+        self._prev_local_tracker = HFProgressTracker._current()
+        HFProgressTracker._local.tracker = self
+
+        try:
+            yield self
+        finally:
+            HFProgressTracker._local.tracker = self._prev_local_tracker
+            self._prev_local_tracker = None
+
+            with HFProgressTracker._install_lock:
+                HFProgressTracker._refcount -= 1
+                if HFProgressTracker._refcount <= 0:
+                    HFProgressTracker._refcount = 0
+                    HFProgressTracker._uninstall_patch()
 
 
 def create_hf_progress_callback(model_name: str, progress_manager):


### PR DESCRIPTION
## Summary

`HFProgressTracker.patch_download()` monkey-patches the process-wide `tqdm` class every time it's called, binding the tracker instance into a closure. When two models download at the same time (each running its blocking HF call on its own thread), the second call's `patch_download()` silently overwrites the first call's patched class — both downloads' tqdm updates end up dispatching to whichever tracker patched most recently, so:

- Progress bars for two simultaneous downloads sync up / show each other's numbers (#784).
- Whichever download finishes first runs its `finally` block and tears down the monkey-patch globally, killing progress tracking for the other download that's still in flight.

## Fix

- The tqdm monkey-patch is now installed **at most once per process**, refcounted across concurrent `patch_download()` calls — only the first concurrent download installs it, only the last one to finish tears it down.
- Dispatch now goes through a `threading.local()` "current tracker for this thread" instead of a closure variable, so each thread's tqdm updates always resolve to *its own* tracker. Each download already runs its blocking HF call on a dedicated thread, so this cleanly isolates concurrent downloads without needing per-download class patching.
- Per-tracker state (`_file_sizes`, `_active_tqdms`, etc.) is unchanged — it was already correctly scoped to the tracker instance; the bug was purely in how tqdm dispatched *to* the right instance.

## Test plan

- [x] Added `test_concurrent_downloads_dont_cross_contaminate` to `backend/tests/test_progress.py`: runs two `HFProgressTracker`s on two threads with a `threading.Barrier` to force real overlap, and asserts each tracker only ever sees its own filename/total, both finish at their own file size, and the patch is fully restored once both are done.
- [x] Verified this new test **fails** against the pre-fix code (tracker A observed tracker B's filename) and **passes** against this fix.
- [x] Ran the full `backend/tests/test_progress.py` suite — all tests pass except `test_hf_progress_tracker`, which is a pre-existing failure on `main` unrelated to this change (its dummy file size of 1000 bytes never crosses the tracker's existing 1MB `MIN_TOTAL_BYTES` reporting threshold — confirmed by running it against unmodified `main`). Left it out of scope here to keep this PR focused on the concurrency fix.

Fixes #784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress tracking now works correctly for multiple downloads happening at the same time.

* **Bug Fixes**
  * Fixed progress updates from different downloads overwriting or mixing with each other.
  * Improved reliability when starting and finishing overlapping downloads, including nested progress handling.
  * Added coverage for concurrent download scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->