### PR TITLE
fix(backend): speak-in-character and compose honor the configured refinement model size

### DIFF
--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -10,7 +10,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import config, models
-from ..services import history, personality, profiles, tts
+from ..services import history, personality, profiles, settings as settings_service, tts
 from ..database import Generation as DBGeneration, VoiceProfile as DBVoiceProfile, get_db
 from ..services.generation import run_generation
 from ..services.task_queue import cancel_generation as cancel_generation_job, enqueue_generation
@@ -79,8 +79,16 @@ async def generate_speech(
     text = data.text
     source = "manual"
     if data.personality and getattr(profile, "personality", None):
+        # Speak-in-character shares the single refinement LLM configured in
+        # Settings → Model Management (capture_settings.llm_model) — without
+        # threading it through here, rewrite_as_profile() falls back to
+        # whatever the LLM backend singleton last happened to load, ignoring
+        # the user's selection.
+        refinement_model_size = settings_service.get_capture_settings(db).llm_model
         try:
-            llm_result = await personality.rewrite_as_profile(profile.personality, data.text)
+            llm_result = await personality.rewrite_as_profile(
+                profile.personality, data.text, model_size=refinement_model_size
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         text = llm_result.text.strip()

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from .. import config, models
 from ..app import safe_content_disposition
 from ..database import VoiceProfile as DBVoiceProfile, get_db
-from ..services import channels, export_import, personality, profiles
+from ..services import channels, export_import, personality, profiles, settings as settings_service
 from ..services.profiles import _profile_to_response
 
 logger = logging.getLogger(__name__)
@@ -384,7 +384,13 @@ async def compose_in_character(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     try:
-        result = await personality.compose_as_profile(profile.personality)
+        # See routes/generations.py's speak-in-character handling: the
+        # refinement model size must come from capture_settings.llm_model,
+        # not the LLM backend singleton's last-loaded size.
+        refinement_model_size = settings_service.get_capture_settings(db).llm_model
+        result = await personality.compose_as_profile(
+            profile.personality, model_size=refinement_model_size
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return models.PersonalityTextResponse(

--- a/backend/tests/test_personality_model_size.py
+++ b/backend/tests/test_personality_model_size.py
@@ -1,0 +1,155 @@
+"""
+Regression test for #711: speak-in-character generation (and the compose
+endpoint) must honor the refinement model size configured in Settings ->
+Model Management (``capture_settings.llm_model``) instead of silently
+falling back to whatever the LLM backend singleton last happened to load.
+
+Before the fix, ``routes/generations.py`` and ``routes/profiles.py`` called
+into ``personality.rewrite_as_profile`` / ``personality.compose_as_profile``
+without a ``model_size`` at all, so the user's selection in the UI had no
+effect on which model actually ran.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# Import the FastAPI app module first: routes/profiles.py and routes/app.py
+# have a circular import (routes -> app -> register_routers -> routes) that
+# only resolves cleanly when backend.app is imported before backend.routes.*
+# directly, which is what the real entrypoint (backend/main.py) always does.
+import backend.app  # noqa: F401
+from backend.database import Base
+from backend.models import GenerationRequest, VoiceProfileCreate
+from backend.services.profiles import create_profile
+from backend.services import settings as settings_service
+
+
+class _StopAfterCapture(Exception):
+    """Raised by the patched personality functions once their arguments are
+    recorded, so the test doesn't need to mock the rest of the (unrelated)
+    generation/composition pipeline."""
+
+
+@pytest.fixture
+def test_db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def mock_profiles_dir(monkeypatch, tmp_path):
+    from backend import config
+
+    monkeypatch.setattr(config, "get_profiles_dir", lambda: tmp_path)
+    return tmp_path
+
+
+async def _make_personality_profile(test_db):
+    data = VoiceProfileCreate(
+        name="Personality Test Profile",
+        description="",
+        language="en",
+        voice_type="preset",
+        preset_engine="kokoro",
+        preset_voice_id="af_heart",
+        default_engine="kokoro",
+        personality="A grumpy old pirate captain who only speaks in nautical metaphors.",
+    )
+    return await create_profile(data, test_db)
+
+
+@pytest.mark.asyncio
+async def test_generate_speak_in_character_uses_configured_refinement_model(
+    test_db, mock_profiles_dir, monkeypatch
+):
+    from backend.routes import generations as generations_route
+
+    settings_service.update_capture_settings(test_db, {"llm_model": "1.7B"})
+    profile = await _make_personality_profile(test_db)
+
+    captured = {}
+
+    async def fake_rewrite_as_profile(personality_text, user_text, model_size=None):
+        captured["model_size"] = model_size
+        raise _StopAfterCapture()
+
+    monkeypatch.setattr(generations_route.personality, "rewrite_as_profile", fake_rewrite_as_profile)
+
+    request = GenerationRequest(
+        profile_id=profile.id,
+        text="Install the dependencies before the deploy.",
+        language="en",
+        engine="kokoro",
+        personality=True,
+    )
+
+    with pytest.raises(_StopAfterCapture):
+        await generations_route.generate_speech(request, test_db)
+
+    assert captured["model_size"] == "1.7B"
+
+
+@pytest.mark.asyncio
+async def test_generate_speak_in_character_picks_up_changed_refinement_model(
+    test_db, mock_profiles_dir, monkeypatch
+):
+    """A different llm_model setting should reach the LLM call unchanged —
+    proves the value is read fresh per request, not cached."""
+    from backend.routes import generations as generations_route
+
+    settings_service.update_capture_settings(test_db, {"llm_model": "4B"})
+    profile = await _make_personality_profile(test_db)
+
+    captured = {}
+
+    async def fake_rewrite_as_profile(personality_text, user_text, model_size=None):
+        captured["model_size"] = model_size
+        raise _StopAfterCapture()
+
+    monkeypatch.setattr(generations_route.personality, "rewrite_as_profile", fake_rewrite_as_profile)
+
+    request = GenerationRequest(
+        profile_id=profile.id,
+        text="The build is broken, roll back to yesterday's version.",
+        language="en",
+        engine="kokoro",
+        personality=True,
+    )
+
+    with pytest.raises(_StopAfterCapture):
+        await generations_route.generate_speech(request, test_db)
+
+    assert captured["model_size"] == "4B"
+
+
+@pytest.mark.asyncio
+async def test_compose_in_character_uses_configured_refinement_model(
+    test_db, mock_profiles_dir, monkeypatch
+):
+    from backend.routes import profiles as profiles_route
+
+    settings_service.update_capture_settings(test_db, {"llm_model": "1.7B"})
+    profile = await _make_personality_profile(test_db)
+
+    captured = {}
+
+    async def fake_compose_as_profile(personality_text, model_size=None):
+        captured["model_size"] = model_size
+        raise _StopAfterCapture()
+
+    monkeypatch.setattr(profiles_route.personality, "compose_as_profile", fake_compose_as_profile)
+
+    with pytest.raises(_StopAfterCapture):
+        await profiles_route.compose_in_character(profile.id, test_db)
+
+    assert captured["model_size"] == "1.7B"


### PR DESCRIPTION
## Summary

`/generate` (speak-in-character, `personality=true`) and `/profiles/{id}/compose` call into `personality.rewrite_as_profile()` / `personality.compose_as_profile()` without ever passing `model_size`. Both functions fall back to `backend.model_size` when no size is given — the LLM backend singleton's cached attribute, which only reflects whatever model was most recently loaded by some *unrelated* request. The user's actual selection in **Settings → Model Management** (`capture_settings.llm_model`) is never consulted on this path, so speak-in-character silently ignores it and keeps using whatever loaded first (typically the 0.6B default) regardless of what's selected.

This matches #711 exactly: selecting 1.7B/4B as the refinement model, then triggering "Speak in character", still loads/uses 0.6B.

## Fix

Read `capture_settings.llm_model` and thread it through as `model_size` on both call sites — matching how `routes/captures.py`'s `/captures/{id}/refine` already resolves it correctly (`resolved_model = request.model_size or saved.llm_model`).

Worth noting: the repo's own `backend/tests/test_personality_samples.py` harness had already worked around this exact blind spot, with a comment reading *"Model size is set on the capture_settings singleton, not passed per-request to `/profiles/{id}/compose`. The harness swaps it between runs so we probe both sizes cleanly."* — independent, pre-existing confirmation of the same root cause.

## Test plan

- [x] Added `backend/tests/test_personality_model_size.py` — three tests using a real sqlite session and monkeypatched personality functions, asserting the configured `llm_model` reaches the LLM call for both `/generate` (`personality=true`) and `/compose`, and that it tracks a *changed* setting (proving it's read fresh, not cached).
- [x] Verified these tests **fail** against the pre-fix code (captured `model_size` is `None`, falling through to the backend's stale default) and **pass** against this fix.
- [x] Ran the full `backend/tests/` suite — 119 passed, 1 pre-existing unrelated failure (`test_hf_progress_tracker`, already failing on unmodified `main`), no new regressions.

Fixes #711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Speak in character” and “compose in character” now use the selected model size from your current capture settings, making character-based responses more consistent and predictable.
  * Added regression coverage to help prevent this setting from being ignored in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->