### PR TITLE
fix: gate macOS-only keyboard_layout symbols behind cfg

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,6 @@
         "react-dom": "^18.3.0",
         "react-hook-form": "^7.53.0",
         "react-i18next": "^17.0.4",
-        "react-qr-code": "^2.0.18",
         "react-sound-visualizer": "^1.4.0",
         "tailwind-merge": "^2.5.4",
         "wavesurfer.js": "^7.0.0",
@@ -1006,8 +1005,6 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qr.js": ["qr.js@0.0.0", "", {}, "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
@@ -1021,8 +1018,6 @@
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-loaders": ["react-loaders@3.0.1", "", { "dependencies": { "classnames": "^2.2.3" }, "peerDependencies": { "prop-types": ">=15.6.0", "react": ">=15" } }, "sha512-4igMNqs9Fb3d4Z+0UHIGQNJsw/37gX0nUO8QxupnEKRn1dtyYC1LGwk5GuaoDciMQCQc/MmPwb4Fn6ZfdoX1FQ=="],
-
-    "react-qr-code": ["react-qr-code@2.0.18", "", { "dependencies": { "prop-types": "^15.8.1", "qr.js": "0.0.0" }, "peerDependencies": { "react": "*" } }, "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 

--- a/tauri/src-tauri/src/keyboard_layout.rs
+++ b/tauri/src-tauri/src/keyboard_layout.rs
@@ -19,19 +19,23 @@
 //! regardless of the active layout — most Windows apps treat that as
 //! Ctrl+V. AutoHotkey relies on the same behaviour.
 
+#[cfg(target_os = "macos")]
 use std::sync::atomic::{AtomicU16, Ordering};
 
 /// `kVK_ANSI_V` — the keycode for the physical V key on a US QWERTY
 /// layout. Used as the fallback whenever live resolution can't produce a
 /// better answer (no Unicode key layout data, lookup failure, non-macOS).
+#[cfg(target_os = "macos")]
 const FALLBACK_V_KEYCODE: u16 = 9;
 
+#[cfg(target_os = "macos")]
 static V_KEYCODE: AtomicU16 = AtomicU16::new(FALLBACK_V_KEYCODE);
 
 /// Returns the keycode whose current-layout translation is `'v'`. Falls
 /// back to `kVK_ANSI_V` when resolution hasn't run, the active input
 /// source carries no Unicode key layout data, or no keycode in the layout
 /// produces `v`.
+#[cfg(target_os = "macos")]
 pub fn paste_keycode_v() -> u16 {
     V_KEYCODE.load(Ordering::Relaxed)
 }


### PR DESCRIPTION
## Description

This PR fixes `dead_code` compiler warnings in `keyboard_layout.rs` by properly gating all macOS-specific symbols behind `#[cfg(target_os = "macos")]`.

### Problem

The following symbols were defined at module level and compiled on all platforms, but only used on macOS:

- `FALLBACK_V_KEYCODE` — the `kVK_ANSI_V` keycode constant
- `V_KEYCODE` — an `AtomicU16` holding the resolved keycode
- `paste_keycode_v()` — the public accessor for the resolved keycode
- `AtomicU16` and `Ordering` imports — only needed by the above

On Windows/Linux, these generated 3 warnings:
warning: constant FALLBACK_V_KEYCODE is never used warning: static V_KEYCODE is never used warning: function paste_keycode_v is never used


### Solution

Moved all four items behind `#[cfg(target_os = "macos")]`. The `mod macos` (already cfg-gated) uses them via `use super::*`, so macOS builds are unaffected.

### Files changed

- `tauri/src-tauri/src/keyboard_layout.rs` — added `#[cfg(target_os = "macos")]` on the import, constant, static, and public function
- `tauri/src-tauri/Cargo.toml`, `tauri/src-tauri/gen/schemas/desktop-schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling so paste-related key detection is only compiled and used on macOS, matching platform behavior more reliably.
  * Reduced the chance of unexpected behavior on non-macOS platforms by avoiding macOS-specific keycode handling there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->