### PR TITLE
feat(stt): transcribe long audio via overlapping Whisper chunks

### DIFF
--- a/VOICEBOX_DEV_GUIDE.md
+++ b/VOICEBOX_DEV_GUIDE.md
@@ -1,0 +1,134 @@
+# Voicebox Developer Guide
+
+Local development environment for [Voicebox](https://github.com/jamiepine/voicebox) on this machine.
+
+## Environment Summary
+
+| Item | Value |
+|------|--------|
+| **Machine** | ASUS TUF A15 (Windows) |
+| **RAM** | 16 GB |
+| **GPU** | NVIDIA GeForce RTX 3060 Laptop GPU (6 GB VRAM) |
+| **Repo path** | `F:\VoiceBox\voicebox-src` |
+| **Python venv** | `backend\venv` |
+| **Backend URL** | `http://127.0.0.1:17493` |
+| **PyTorch** | CUDA 12.8 (`cu128`) — Ampere-compatible |
+| **Package manager** | Bun (JS), pip (Python), Cargo (Rust/Tauri) |
+
+### What `just setup` installs
+
+- Python virtual environment and FastAPI backend dependencies
+- CUDA-enabled PyTorch when an NVIDIA GPU is detected
+- TTS engines (Qwen3-TTS, Kokoro, Chatterbox, LuxTTS, TADA, etc.)
+- Bun workspaces for `app/`, `tauri/`, and `web/`
+- Tauri dev sidecar placeholders (`bun run setup:dev`)
+
+### Useful commands
+
+```powershell
+just --list          # all recipes
+just dev-backend     # API only
+just dev-frontend    # Tauri only (backend must be running)
+just kill            # stop dev processes
+just test-models --only kokoro   # smoke-test Kokoro engine
+```
+
+---
+
+## How to Start
+
+Open PowerShell, then from the repo root:
+
+```powershell
+cd F:\VoiceBox\voicebox-src
+just dev
+```
+
+This starts the Python backend on port **17493** and launches the Tauri desktop app.
+
+**Two-terminal alternative:**
+
+```powershell
+# Terminal 1 — backend
+cd F:\VoiceBox\voicebox-src
+.\backend\venv\Scripts\Activate.ps1
+python -m uvicorn backend.main:app --reload --port 17493
+
+# Terminal 2 — desktop UI
+cd F:\VoiceBox\voicebox-src\tauri
+bun run tauri dev
+```
+
+**Verify the backend:**
+
+```powershell
+curl http://127.0.0.1:17493/health
+```
+
+API docs: http://127.0.0.1:17493/docs
+
+### Optional VRAM helper (recommended before `just dev`)
+
+```powershell
+$env:PYTORCH_CUDA_ALLOC_CONF = "expandable_segments:True"
+```
+
+---
+
+## VRAM Survival Guide (RTX 3060 — 6 GB)
+
+Six gigabytes is enough for daily dev work if you pick the right engines. The app **defaults to Qwen3-TTS 1.7B**, which needs ~6 GB VRAM and will OOM on this GPU.
+
+### Engine cheat sheet
+
+| Engine | VRAM | Safe on 6 GB? |
+|--------|------|----------------|
+| **Kokoro 82M** | ~150 MB | Yes — **use this as your default** |
+| LuxTTS | ~1 GB | Yes |
+| Chatterbox Turbo | ~1.5 GB | Yes |
+| Qwen3-TTS **0.6B** | ~2 GB | Yes (for cloning) |
+| Chatterbox Multilingual | ~3 GB | Usually OK (unload others first) |
+| Qwen3-TTS **1.7B** | ~6 GB | **No — will OOM** |
+| TADA 1B / 3B | ~4–8 GB | Avoid |
+
+### Do this immediately after launch
+
+1. **Switch the TTS engine to Kokoro**
+   - In the generate box, open the **engine dropdown**
+   - Select **Kokoro 82M** (not Qwen3-TTS 1.7B)
+   - For preset voices: **Profiles → + New Profile → Kokoro** → pick a voice
+
+2. **Never load Qwen 1.7B for TTS on this GPU**
+   - If you need Qwen cloning, choose **Qwen3-TTS 0.6B** in the engine/model selector
+   - Do not select 1.7B or Qwen CustomVoice 1.7B
+
+3. **Unload unused models when switching engines**
+   - **Settings → Models**
+   - Click **Unload** on any engine you are not actively using
+   - Only one generation runs at a time, but **loaded models stay in VRAM** until unloaded
+
+4. **Keep Whisper small for dictation**
+   - Use **Whisper Base** or **Small** in transcription settings
+   - Unload TTS models before heavy dictation sessions
+
+5. **Close other GPU apps** (games, browsers with hardware acceleration) before generating
+
+### If you still hit OOM
+
+- Unload all models in Settings → Models, then restart the app
+- Use Kokoro or LuxTTS only
+- Lower **Settings → Generation → chunk limit** for long scripts
+- Check VRAM: `nvidia-smi` in a separate terminal
+
+---
+
+## Notes from initial setup
+
+- **`just setup` on this machine:** The first run failed building `pyopenjtalk` (needs MSVC `nmake`). Setup was completed with CUDA PyTorch (`torch 2.11.0+cu128`) and `misaki[en]` (English Kokoro — no Japanese `pyopenjtalk` build required).
+- **`just dev` (Tauri desktop):** Requires **Visual Studio C++ Build Tools** with `link.exe` on PATH. If `just dev` fails with `linker link.exe not found`, open **"Developer PowerShell for VS 2022"** or install [Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with **Desktop development with C++**, then retry.
+- **Until Tauri builds:** Use `just dev-web` for the browser UI (backend + Vite on port 5173).
+- **GPU detection in automated shells:** If `just setup` skips CUDA PyTorch, install manually:
+  ```powershell
+  .\backend\venv\Scripts\pip.exe install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+  ```
+- **`just` binary:** Also available at `F:\VoiceBox\tools\just.exe` if winget PATH is stale.

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -21,6 +21,7 @@ from .base import (
 )
 from ..utils.cache import get_cache_key, get_cached_voice_prompt, cache_voice_prompt
 from ..utils.audio import load_audio
+from ..utils.whisper_stt import transcribe_whisper_pytorch
 
 
 class PyTorchTTSBackend:
@@ -335,44 +336,17 @@ class PyTorchSTTBackend:
 
         def _transcribe_sync():
             """Run synchronous transcription in thread pool."""
-            # Load audio
             audio, _sr = load_audio(audio_path, sample_rate=16000)
 
-            # Inference runs with the process's default HF_HUB_OFFLINE
-            # state — forcing offline here (issue #462) broke online users
-            # whose `get_decoder_prompt_ids` / tokenizer calls issue
-            # legitimate metadata lookups.
-            # Process audio
-            inputs = self.processor(
+            # Whisper accepts ~30 s per forward pass. Longer captures are
+            # windowed with overlap so Captures / dictation get the full file.
+            return transcribe_whisper_pytorch(
                 audio,
-                sampling_rate=16000,
-                return_tensors="pt",
+                processor=self.processor,
+                model=self.model,
+                device=self.device,
+                language=language,
             )
-            inputs = inputs.to(self.device)
-
-            # Generate transcription
-            # If language is provided, force it; otherwise let Whisper auto-detect
-            generate_kwargs = {}
-            if language:
-                forced_decoder_ids = self.processor.get_decoder_prompt_ids(
-                    language=language,
-                    task="transcribe",
-                )
-                generate_kwargs["forced_decoder_ids"] = forced_decoder_ids
-
-            with torch.no_grad():
-                predicted_ids = self.model.generate(
-                    inputs["input_features"],
-                    **generate_kwargs,
-                )
-
-            # Decode
-            transcription = self.processor.batch_decode(
-                predicted_ids,
-                skip_special_tokens=True,
-            )[0]
-
-            return transcription.strip()
 
         # Run blocking transcription in thread pool
         return await asyncio.to_thread(_transcribe_sync)

--- a/backend/requirements-win-setup.txt
+++ b/backend/requirements-win-setup.txt
@@ -1,0 +1,72 @@
+# FastAPI and server
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+pydantic>=2.5.0
+
+# Database
+sqlalchemy>=2.0.0
+alembic>=1.13.0
+
+# ML models
+torch>=2.2.0
+transformers>=4.36.0,<=4.57.6
+accelerate>=0.26.0
+huggingface_hub>=0.20.0
+qwen-tts>=0.0.5
+
+# LuxTTS (voice cloning engine)
+# piper-phonemize needs custom index (no PyPI wheels)
+--find-links https://k2-fsa.github.io/icefall/piper_phonemize.html
+# linacodec is a git-only dep of Zipvoice (uv-only source, pip can't resolve it)
+linacodec @ git+https://github.com/ysharma3501/LinaCodec.git
+Zipvoice @ git+https://github.com/ysharma3501/LuxTTS.git
+
+# Chatterbox TTS sub-dependencies (chatterbox-tts itself is installed
+# --no-deps in the setup script because it pins numpy<1.26 / torch==2.6
+# which are incompatible with Python 3.12+)
+conformer>=0.3.2
+diffusers>=0.29.0
+omegaconf
+pykakasi
+resemble-perth>=1.0.1
+s3tokenizer
+spacy-pkuseg
+pyloudnorm
+
+# HumeAI TADA sub-dependencies (hume-tada itself is installed
+# --no-deps in the setup script because it pins torch>=2.7,<2.8.
+# descript-audio-codec is NOT installed — it pulls onnx/tensorboard
+# via descript-audiotools.  A lightweight shim in utils/dac_shim.py
+# provides the only class TADA uses: Snake1d.)
+torchaudio
+
+# Kokoro TTS (lightweight 82M-param engine)
+kokoro>=0.9.4
+misaki[en]>=0.9.4
+# spacy model for misaki English G2P — must be pre-installed or misaki
+# tries spacy.cli.download() at runtime which crashes frozen builds
+en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+# fugashi (pulled in by misaki[ja]) needs a MeCab dictionary on disk.
+# unidic-lite ships one inside the wheel (~50MB); the full `unidic` package
+# requires `python -m unidic download` (~526MB) which breaks frozen builds
+# for the same reason en_core_web_sm does.
+unidic-lite>=1.0.8
+
+# Audio processing
+librosa>=0.10.0
+soundfile>=0.12.0
+numpy>=1.24.0,<2.0
+numba>=0.60.0,<0.61.0
+pedalboard>=0.9.0
+
+# HTTP client (for CUDA backend download)
+httpx>=0.27.0
+
+# MCP server (Model Context Protocol) — lets local AI agents call
+# voicebox.speak / .transcribe / .list_captures / .list_profiles
+fastmcp>=3.0,<4.0
+sse-starlette>=2.0
+
+# Utilities
+python-multipart>=0.0.6
+Pillow>=10.0.0

--- a/backend/tests/test_whisper_stt_chunks.py
+++ b/backend/tests/test_whisper_stt_chunks.py
@@ -1,0 +1,31 @@
+"""Tests for long-form Whisper chunking."""
+
+import numpy as np
+
+from backend.utils.whisper_stt import (
+    WHISPER_CHUNK_SAMPLES,
+    WHISPER_STRIDE_SAMPLES,
+    iter_whisper_chunks,
+    join_whisper_chunk_texts,
+)
+
+
+def test_iter_whisper_chunks_short_audio_single_window():
+    audio = np.zeros(16000 * 10, dtype=np.float32)
+    chunks = list(iter_whisper_chunks(audio))
+    assert len(chunks) == 1
+    assert len(chunks[0]) == len(audio)
+
+
+def test_iter_whisper_chunks_long_audio_multiple_windows():
+    audio = np.zeros(16000 * 65, dtype=np.float32)
+    chunks = list(iter_whisper_chunks(audio))
+    assert len(chunks) == 3
+    assert all(len(c) <= WHISPER_CHUNK_SAMPLES for c in chunks)
+    assert len(chunks[0]) == WHISPER_CHUNK_SAMPLES
+    # Last chunk covers the tail after overlapping windows.
+    assert sum(len(c) for c in chunks) > len(audio)
+
+
+def test_join_whisper_chunk_texts_skips_empty():
+    assert join_whisper_chunk_texts(["hello", "", "  ", "world"]) == "hello world"

--- a/backend/utils/whisper_stt.py
+++ b/backend/utils/whisper_stt.py
@@ -1,0 +1,94 @@
+"""
+Long-form Whisper STT helpers.
+
+Whisper models accept ~30 seconds of audio per forward pass. Callers must
+chunk longer inputs and stitch the text back together.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+import numpy as np
+
+WHISPER_SAMPLE_RATE = 16_000
+WHISPER_CHUNK_SECONDS = 30
+WHISPER_STRIDE_SECONDS = 5
+WHISPER_CHUNK_SAMPLES = WHISPER_CHUNK_SECONDS * WHISPER_SAMPLE_RATE
+WHISPER_STRIDE_SAMPLES = WHISPER_STRIDE_SECONDS * WHISPER_SAMPLE_RATE
+# Ignore trailing fragments shorter than half a second.
+MIN_CHUNK_SAMPLES = WHISPER_SAMPLE_RATE // 2
+
+
+def iter_whisper_chunks(audio: np.ndarray) -> Iterator[np.ndarray]:
+    """
+    Yield 30-second windows with 5-second overlap for audio longer than one chunk.
+
+    Short audio (<= 30 s) is yielded as a single chunk unchanged.
+    """
+    audio = np.asarray(audio, dtype=np.float32)
+    n = len(audio)
+    if n <= WHISPER_CHUNK_SAMPLES:
+        yield audio
+        return
+
+    step = WHISPER_CHUNK_SAMPLES - WHISPER_STRIDE_SAMPLES
+    start = 0
+    while start < n:
+        end = min(start + WHISPER_CHUNK_SAMPLES, n)
+        chunk = audio[start:end]
+        if len(chunk) < MIN_CHUNK_SAMPLES and start > 0:
+            break
+        yield chunk
+        if end >= n:
+            break
+        start += step
+
+
+def join_whisper_chunk_texts(texts: list[str]) -> str:
+    """Join per-chunk transcripts with a single space."""
+    return " ".join(t.strip() for t in texts if t and t.strip())
+
+
+def transcribe_whisper_pytorch(
+    audio: np.ndarray,
+    *,
+    processor,
+    model,
+    device: str,
+    language: Optional[str] = None,
+) -> str:
+    """Run PyTorch Whisper on arbitrary-length audio via overlapping chunks."""
+    import torch
+
+    texts: list[str] = []
+    for chunk in iter_whisper_chunks(audio):
+        inputs = processor(
+            chunk,
+            sampling_rate=WHISPER_SAMPLE_RATE,
+            return_tensors="pt",
+        )
+        inputs = inputs.to(device)
+
+        generate_kwargs = {}
+        if language:
+            forced_decoder_ids = processor.get_decoder_prompt_ids(
+                language=language,
+                task="transcribe",
+            )
+            generate_kwargs["forced_decoder_ids"] = forced_decoder_ids
+
+        with torch.no_grad():
+            predicted_ids = model.generate(
+                inputs["input_features"],
+                **generate_kwargs,
+            )
+
+        text = processor.batch_decode(
+            predicted_ids,
+            skip_special_tokens=True,
+        )[0]
+        if text:
+            texts.append(text.strip())
+
+    return join_whisper_chunk_texts(texts)


### PR DESCRIPTION
## Summary

- Adds `backend/utils/whisper_stt.py` to window audio longer than Whisper'\''s ~30s limit into overlapping 30s chunks (5s stride)
- Wires `PyTorchSTTBackend.transcribe()` through the shared helper so Captures, `/transcribe`, and dictation get full-file transcripts on PyTorch backends (Windows CUDA, Linux, etc.)
- Includes unit tests for chunking and text joining

## Motivation

Whisper only accepts ~30 seconds of audio per forward pass. Without chunking, longer captures (videos, podcasts, meeting recordings) were truncated or incomplete.

## Test plan

- [x] `pytest backend/tests/test_whisper_stt_chunks.py` (3 tests pass)
- [ ] Manual: upload a >60s capture in Captures tab and verify full transcript
- [ ] Manual: `POST /transcribe` with a long audio file

## Notes

- MLX (Apple Silicon) path unchanged — MLX Whisper already accepts file paths directly
- Chunk overlap may produce minor duplicate words at window boundaries; acceptable tradeoff for full coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added longer-audio speech recognition support with overlapping chunks for more reliable transcription.
  * Improved PyTorch-based transcription handling for better end-to-end voice input support.

* **Documentation**
  * Added a developer setup guide with local installation, startup steps, troubleshooting tips, and GPU/VRAM guidance.

* **Tests**
  * Added coverage for audio chunking and transcript merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->