### PR TITLE
Fix: Linux startup panic from unrealized dictate window (#680)

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -46,7 +46,15 @@ fn build_dictate_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewW
     .skip_taskbar(true)
     .resizable(false)
     .shadow(false)
-    .visible(false)
+    // On Linux (GTK3 + tao 0.34.5), building the transparent dictate pill with
+    // `.visible(false)` leaves its GDK window unrealized. The first
+    // `set_ignore_cursor_events()` dispatched over the glib main-context channel
+    // then unwraps a `None` GDK window and aborts the whole app with a
+    // non-unwinding panic at tao event_loop.rs:449 (see #680). Build the window
+    // visible so GTK realizes the GDK backing, then immediately park it
+    // off-screen and hide it (below). Net user-visible effect is unchanged — the
+    // pill stays hidden until a speak — but the window now actually exists.
+    .visible(true)
     .build()?;
 
     if let Some(monitor) = window.current_monitor()? {
@@ -56,6 +64,11 @@ fn build_dictate_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewW
         let y = (monitor_size.height as f64 * 0.04) as i32;
         window.set_position(PhysicalPosition::new(x, y))?;
     }
+
+    // Force GDK realization to complete, then get the window off-screen and
+    // hidden before anything can toggle cursor-ignore on it.
+    let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
+    let _ = window.hide();
 
     Ok(window)
 }


### PR DESCRIPTION
## Summary

Fixes a startup crash on Linux where the app opens the main window and then immediately aborts with a non-unwinding panic from `tao`:

```
thread 'main' panicked at tao-0.34.5/src/platform_impl/linux/event_loop.rs:449:18:
called `Option::unwrap()` on a `None` value
...
panic in a function that cannot unwind
```

This is the crash reported in #680.

## Root cause

`build_dictate_window` (in `tauri/src-tauri/src/main.rs`) constructs the transparent "dictate pill" overlay with `.visible(false)`. On the Linux GTK3 backend, a window that is never shown never has its underlying **GDK window realized**. Shortly after startup, the first `set_ignore_cursor_events()` toggle is dispatched over the glib main-context channel and reaches into that unrealized window — `tao` calls `.unwrap()` on the `None` GDK window (`event_loop.rs:449`) and, because it happens in a non-unwinding context, the panic takes the whole process down before the UI is usable.

## Fix

Build the pill **visible** so GTK realizes the GDK backing, then immediately move it off-screen (`-10000, -10000`) and `hide()` it. The pill is still not visible to the user until a speak, so behaviour is unchanged — but the window now actually exists when cursor-ignore is first toggled, so there is no `None` to unwrap.

The change is confined to `build_dictate_window`; no public API or other call sites are touched.

## Testing

- Environment: Ubuntu 24.04, x86_64, X11 / GTK3 (WebKitGTK), tao 0.34.5 / tauri 2.9.5 — the same stack as #680.
- Before: app aborted on every launch at `event_loop.rs:449`.
- After: app launches and stays up. Verified with `xwininfo` that both the main window (1200x800) and the dictate pill are realized, with the pill parked off-screen and hidden as intended.
- `cargo check --no-default-features` passes on current `main` (only pre-existing `keyboard_layout.rs` dead-code warnings).

Happy to add a `CHANGELOG.md` entry in whatever format you prefer.

Fixes #680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux window handling so the dictate window initializes reliably without crashing when cursor-related events are toggled.
  * Kept the window hidden and off-screen until it is ready to be shown, preventing unintended interaction during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->