### PR TITLE
fix(setup): install mlx-lm/mlx-audio in `just setup` and pin mlx<0.31 on Apple Silicon

### DIFF
--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -1,7 +1,13 @@
 # MLX-specific dependencies (Apple Silicon only)
 # These should only be installed on aarch64-apple-darwin platforms
 
-mlx>=0.30.0
+# Pin below 0.31: mlx 0.31.x made GPU streams thread-local, which breaks
+# mlx-lm / mlx-audio inference run from a worker thread (the backend calls
+# them via asyncio.to_thread) with:
+#   RuntimeError: There is no Stream(gpu, N) in current thread.
+# Models load fine but generation/transcription 500s. 0.30.4 is the floor
+# required by mlx-lm 0.31.1; 0.30.6 is the current 0.30.x tip and works.
+mlx>=0.30.4,<0.31
 
 # miniaudio is a runtime dep of mlx-audio's STT path (mlx_audio.stt).
 # mlx-audio itself is installed --no-deps (see comment below), so we

--- a/justfile
+++ b/justfile
@@ -72,6 +72,13 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        # mlx-lm / mlx-audio declare transformers>=5.x, which conflicts with the
+        # transformers<=4.57.6 cap in requirements.txt, so install them --no-deps
+        # (matches .github/workflows/release.yml). Without these, MLX engines
+        # (Qwen TTS, Whisper STT, personality LLM) fail at call time with
+        # "No module named 'mlx_audio'".
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q


### PR DESCRIPTION
## Problem

On a fresh Apple Silicon dev environment, `just setup` completes but every MLX-backed engine fails at call time:

- **`No module named 'mlx_audio'`** — Qwen TTS, Whisper STT, and the personality/refinement LLM all break. Models can't download or load.
- After installing the missing packages, MLX inference still 500s with:
  ```
  RuntimeError: There is no Stream(gpu, N) in current thread.
  ```
  Models load, but generation/transcription fail.

## Root cause

**1. `just setup` doesn't install `mlx-lm` / `mlx-audio`.**
The `setup-python` recipe installs `requirements-mlx.txt`, but the actual `mlx-lm` / `mlx-audio` packages are only installed in CI (`.github/workflows/release.yml`), not in the local setup path. They're intentionally `--no-deps` (they declare `transformers>=5.x`, conflicting with the `transformers<=4.57.6` cap), so a fresh dev checkout never gets them.

**2. `requirements-mlx.txt` pins only `mlx>=0.30.0`.**
A fresh install therefore resolves **mlx 0.31.x**, which made GPU streams *thread-local*. The backend runs MLX inference on a worker thread (`asyncio.to_thread`), while `mlx-lm` creates its `generation_stream` on the import/main thread — so inference on the worker thread raises `There is no Stream(gpu, N) in current thread.` mlx 0.30.6 (the current 0.30.x tip) does not have this behavior.

## Fix

- **`justfile`** — install `mlx-lm==0.31.1` and `mlx-audio==0.4.1` `--no-deps` in the Apple Silicon block, mirroring `release.yml` exactly.
- **`backend/requirements-mlx.txt`** — pin `mlx>=0.30.4,<0.31` (0.30.4 is `mlx-lm` 0.31.1's floor; `<0.31` avoids the thread-local-stream regression). Comment explains why.

## Test plan

Verified on an M1 (macOS, 8GB):

- [x] `just setup` from clean → `import mlx_audio.tts, mlx_audio.stt, mlx_lm` all succeed
- [x] `mlx` resolves to 0.30.6 (was 0.31.2 before the pin)
- [x] `POST /models/download` for `whisper-turbo` and `qwen3-0.6b`/`qwen3-1.7b` complete
- [x] `POST /transcribe` (Whisper Turbo) transcribes correctly
- [x] `POST /llm/generate` (Qwen3 0.6B and 1.7B) returns text — no `Stream(gpu, N)` error
- [x] Kokoro TTS generation + persona `compose` work end-to-end

## Notes

The `--no-deps` installs still emit the expected pip warnings about `transformers>=5.0.0` / `huggingface_hub>=1.0`; these are the same conflicts already accepted in `release.yml` and documented in `requirements-mlx.txt`. The runtime API surface used (`mlx_audio.tts.load`, `mlx_audio.stt.load`, `mlx_lm.generate`) works on transformers 4.57.x in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple Silicon setup by installing the required MLX-related packages more reliably.
  * Updated the supported MLX version range to avoid known runtime failures during inference or transcription.
  * Reduced the chance of import and threading-related errors when running tasks in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->