### PR TITLE
fix(audio): capture raw audio (disable AEC/NS/AGC) + share one stream with the waveform

### DIFF
--- a/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
+++ b/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
@@ -26,6 +26,13 @@ interface AudioSampleRecordingProps {
   file: File | null | undefined;
   isRecording: boolean;
   duration: number;
+  /**
+   * The live capture stream while recording, from useAudioRecording. When
+   * recording we visualize this exact stream rather than opening a second
+   * getUserMedia — two concurrent opens of one input device leave the
+   * visualizer silent on macOS (external interfaces especially).
+   */
+  recordingStream?: MediaStream | null;
   onStart: () => void;
   onStop: () => void;
   onCancel: () => void;
@@ -40,6 +47,7 @@ export function AudioSampleRecording({
   file,
   isRecording,
   duration,
+  recordingStream,
   onStart,
   onStop,
   onCancel,
@@ -50,33 +58,47 @@ export function AudioSampleRecording({
   showWaveform = true,
 }: AudioSampleRecordingProps) {
   const { t } = useTranslation();
-  const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
+  const [previewStream, setPreviewStream] = useState<MediaStream | null>(null);
 
-  // Request microphone access when component mounts
+  // Run a standalone preview capture only while idle. Once recording starts we
+  // switch to the actual recording stream (recordingStream) and tear this down,
+  // so the device is never opened twice at once.
   useEffect(() => {
-    if (!showWaveform) return;
+    if (!showWaveform || isRecording) return;
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
 
     let stream: MediaStream | null = null;
+    let cancelled = false;
 
     navigator.mediaDevices
       .getUserMedia({ audio: true, video: false })
       .then((s) => {
+        if (cancelled) {
+          s.getTracks().forEach((track) => {
+            track.stop();
+          });
+          return;
+        }
         stream = s;
-        setAudioStream(s);
+        setPreviewStream(s);
       })
       .catch((err) => {
         console.warn('Could not access microphone for visualization:', err);
       });
 
     return () => {
+      cancelled = true;
       if (stream) {
         stream.getTracks().forEach((track) => {
           track.stop();
         });
       }
+      setPreviewStream(null);
     };
-  }, [showWaveform]);
+  }, [showWaveform, isRecording]);
+
+  // While recording, visualize the real capture stream; otherwise the preview.
+  const audioStream = isRecording ? (recordingStream ?? null) : previewStream;
 
   return (
     <FormItem>

--- a/app/src/components/VoiceProfiles/ProfileForm.tsx
+++ b/app/src/components/VoiceProfiles/ProfileForm.tsx
@@ -226,11 +226,16 @@ export function ProfileForm() {
     isRecording,
     duration,
     error: recordingError,
+    stream: recordingStream,
     startRecording,
     stopRecording,
     cancelRecording,
   } = useAudioRecording({
     maxDurationSeconds: 29,
+    // Reference samples for cloning must be raw/high-fidelity — the browser
+    // voice DSP (AEC/NS/AGC) stutters and degrades quality with external
+    // audio interfaces such as the RodeCaster.
+    audioProcessing: false,
     onRecordingComplete: (blob, recordedDuration) => {
       const file = new File([blob], `recording-${Date.now()}.webm`, {
         type: blob.type || 'audio/webm',
@@ -1005,6 +1010,7 @@ export function ProfileForm() {
                                     file={selectedFile}
                                     isRecording={isRecording}
                                     duration={duration}
+                                    recordingStream={recordingStream}
                                     onStart={startRecording}
                                     onStop={stopRecording}
                                     onCancel={handleCancelRecording}

--- a/app/src/components/VoiceProfiles/SampleUpload.tsx
+++ b/app/src/components/VoiceProfiles/SampleUpload.tsx
@@ -70,11 +70,16 @@ export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProp
     isRecording,
     duration,
     error: recordingError,
+    stream: recordingStream,
     startRecording,
     stopRecording,
     cancelRecording,
   } = useAudioRecording({
     maxDurationSeconds: 29,
+    // Reference samples for cloning must be raw/high-fidelity — the browser
+    // voice DSP (AEC/NS/AGC) stutters and degrades quality with external
+    // audio interfaces such as the RodeCaster.
+    audioProcessing: false,
     onRecordingComplete: (blob, recordedDuration) => {
       // Convert blob to File object
       const file = new File([blob], `recording-${Date.now()}.webm`, {
@@ -278,6 +283,7 @@ export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProp
                       file={selectedFile}
                       isRecording={isRecording}
                       duration={duration}
+                      recordingStream={recordingStream}
                       onStart={startRecording}
                       onStop={stopRecording}
                       onCancel={handleCancelRecording}

--- a/app/src/lib/hooks/useAudioRecording.ts
+++ b/app/src/lib/hooks/useAudioRecording.ts
@@ -5,16 +5,32 @@ import { convertToWav } from '@/lib/utils/audio';
 interface UseAudioRecordingOptions {
   maxDurationSeconds?: number;
   onRecordingComplete?: (blob: Blob, duration?: number) => void;
+  /**
+   * Enable the browser's voice-processing DSP (echo cancellation, noise
+   * suppression, auto gain). Defaults to true, which is fine for dictation
+   * against a laptop's built-in mic. Pass false for high-fidelity capture
+   * (e.g. voice-clone reference samples) or when using an external audio
+   * interface: on macOS these flags route through the OS VoiceProcessingIO
+   * path, which is tuned for built-in mics and causes stutter/dropouts with
+   * pro interfaces (clock drift vs. the echo reference) plus quality loss
+   * from NS/AGC.
+   */
+  audioProcessing?: boolean;
 }
 
 export function useAudioRecording({
   maxDurationSeconds,
   onRecordingComplete,
+  audioProcessing = true,
 }: UseAudioRecordingOptions = {}) {
   const platform = usePlatform();
   const [isRecording, setIsRecording] = useState(false);
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  // Exposed so callers can drive a waveform visualizer from the SAME capture
+  // stream instead of opening a second getUserMedia — two concurrent opens of
+  // one input device leave the visualizer's stream silent on macOS.
+  const [stream, setStream] = useState<MediaStream | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
@@ -58,16 +74,20 @@ export function useAudioRecording({
         }
       }
 
-      // Request microphone access
+      // Request microphone access. For high-fidelity capture we disable the
+      // browser voice-processing DSP: on macOS those flags force the OS
+      // VoiceProcessingIO path, which stutters/drops with external interfaces
+      // (RodeCaster et al.) and degrades quality via NS/AGC.
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
+          echoCancellation: audioProcessing,
+          noiseSuppression: audioProcessing,
+          autoGainControl: audioProcessing,
         },
       });
 
       streamRef.current = stream;
+      setStream(stream);
 
       // Create MediaRecorder with preferred MIME type
       const options: MediaRecorderOptions = {
@@ -104,6 +124,7 @@ export function useAudioRecording({
           track.stop();
         });
         streamRef.current = null;
+        setStream(null);
 
         // Don't fire completion callback if the recording was cancelled
         if (wasCancelled) return;
@@ -162,7 +183,7 @@ export function useAudioRecording({
       setError(errorMessage);
       setIsRecording(false);
     }
-  }, [maxDurationSeconds, onRecordingComplete]);
+  }, [maxDurationSeconds, onRecordingComplete, audioProcessing]);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {
@@ -190,6 +211,7 @@ export function useAudioRecording({
       track.stop();
     });
     streamRef.current = null;
+    setStream(null);
 
     if (timerRef.current !== null) {
       clearInterval(timerRef.current);
@@ -213,6 +235,7 @@ export function useAudioRecording({
     isRecording,
     duration,
     error,
+    stream,
     startRecording,
     stopRecording,
     cancelRecording,

--- a/app/src/lib/hooks/useCaptureRecordingSession.ts
+++ b/app/src/lib/hooks/useCaptureRecordingSession.ts
@@ -250,6 +250,10 @@ export function useCaptureRecordingSession(
     stopRecording,
     error: recordError,
   } = useAudioRecording({
+    // Capture raw audio: the browser voice DSP (AEC/NS/AGC) stutters and drops
+    // with external audio interfaces on macOS, and Whisper handles clean input
+    // fine, so we disable it here too.
+    audioProcessing: false,
     onRecordingComplete: (blob, recordedDuration) => {
       // Trigger-happy tap — MediaRecorder hasn't emitted a usable chunk yet
       // so the blob is empty or unparseable. Surface it as a transient pill


### PR DESCRIPTION
### Problem
Voice-clone recording from external USB interfaces (RØDECaster Duo) was stuttery and low quality on macOS. Root cause: `useAudioRecording` forced `echoCancellation`/`noiseSuppression`/`autoGainControl` on, which on WKWebView routes capture through the OS VoiceProcessingIO path — clock-drift glitches vs. the echo reference (stutter) plus NS/AGC degradation. Reference recordings should be raw.

Separately, the waveform visualizer opened a **second** concurrent `getUserMedia`; on macOS the second open of the same device yields no audio, so the wave didn't react.

### Changes
- `useAudioRecording`: new `audioProcessing?: boolean` option (default `true`, backwards compatible) that gates the three constraints; hook now also exposes the live `stream`.
- Voice-clone recorders (`ProfileForm`, `SampleUpload`) and dictation (`useCaptureRecordingSession`) pass `audioProcessing: false` for clean capture. (Whisper handles clean input fine.)
- `AudioSampleRecording`: accepts `recordingStream` and visualizes it during recording; the standalone preview capture now runs only while idle and is torn down on record — so the input device is never opened twice at once.

### Verification
- Confirmed on hardware (RØDECaster Duo, macOS/Apple Silicon): recorded sample is clean, no stutter, and the waveform tracks input.
- `tsc --noEmit`, `biome lint`, and `vite build` all pass.

### Notes
- Kept `audioProcessing` configurable rather than hard-removing, so a future caller can re-enable browser AEC if recording against speakers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice sample recording with a live waveform preview that uses the active microphone stream while recording and a separate idle preview when available.
  * Audio capture now preserves more of the original recording quality for reference/cloning workflows.

* **Bug Fixes**
  * Reduced recording glitches and dropped audio when using external audio interfaces, especially on macOS.
  * Improved cleanup when starting, stopping, or canceling preview and recording sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->