### PR TITLE
fix(macos): fullscreen dictation, correct text injection, and MLX backend crash

### DIFF
--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -292,8 +292,12 @@ class MLXSTTBackend:
         if self.model is not None and self.model_size == model_size:
             return
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Load on the dedicated MLX thread (see services/mlx_thread.py) so the
+        # model's GPU stream stays affine to the same thread that later runs
+        # transcription.
+        from ..services.mlx_thread import run_mlx
+
+        await run_mlx(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -363,5 +367,9 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        # Run transcription on the dedicated MLX thread (see
+        # services/mlx_thread.py) — same thread as the model load, so MLX's
+        # thread-local GPU streams resolve.
+        from ..services.mlx_thread import run_mlx
+
+        return await run_mlx(_transcribe_sync)

--- a/backend/backends/qwen_llm_backend.py
+++ b/backend/backends/qwen_llm_backend.py
@@ -212,7 +212,9 @@ class MLXQwenLLMBackend:
         if self.model is not None and self._current_model_size != model_size:
             self.unload_model()
 
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        from ..services.mlx_thread import run_mlx
+
+        await run_mlx(self._load_model_sync, model_size)
 
     def _load_model_sync(self, model_size: str) -> None:
         from mlx_lm import load as mlx_load
@@ -255,7 +257,9 @@ class MLXQwenLLMBackend:
         examples: Optional[list[tuple[str, str]]] = None,
     ) -> str:
         await self.load_model(model_size)
-        return await asyncio.to_thread(
+        from ..services.mlx_thread import run_mlx
+
+        return await run_mlx(
             self._generate_sync, prompt, system, max_tokens, temperature, examples
         )
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -27,6 +27,40 @@ if not _is_writable(sys.stdout):
 if not _is_writable(sys.stderr):
     sys.stderr = open(os.devnull, 'w')
 
+
+class _PipeSafeStream:
+    """Wrap a stream so writes never raise after the reader goes away.
+
+    The Tauri host only drains the sidecar's stdout/stderr until the
+    "Uvicorn running" startup line, then drops the receiver — closing the
+    pipe. Any later print/log/tqdm write then raises BrokenPipeError
+    (``[Errno 32] Broken pipe``), which surfaces as a 500 from whatever
+    endpoint happened to log (observed on /transcribe during Whisper model
+    load). Swallow pipe errors so logging can never break request handling.
+    """
+
+    def __init__(self, base):
+        self._base = base
+
+    def write(self, data):
+        try:
+            return self._base.write(data)
+        except (BrokenPipeError, OSError):
+            return len(data)
+
+    def flush(self):
+        try:
+            self._base.flush()
+        except (BrokenPipeError, OSError):
+            pass
+
+    def __getattr__(self, name):
+        return getattr(self._base, name)
+
+
+sys.stdout = _PipeSafeStream(sys.stdout)
+sys.stderr = _PipeSafeStream(sys.stderr)
+
 # PyInstaller + multiprocessing: child processes re-execute the frozen binary
 # with internal arguments. freeze_support() handles this and exits early.
 import multiprocessing

--- a/backend/services/mlx_thread.py
+++ b/backend/services/mlx_thread.py
@@ -1,0 +1,33 @@
+"""Single dedicated worker thread for all MLX model operations.
+
+MLX GPU streams are thread-local, and some MLX libraries bind a stream to
+the thread that first imports them — most notably ``mlx_lm.generate``, which
+runs ``generation_stream = mx.new_stream(...)`` at module import. In a
+threaded ASGI server the default ``asyncio.to_thread`` pool hands successive
+model calls to *different* worker threads, so a stream created on one thread
+is missing on another. That surfaces as ``There is no Stream(gpu, N) in
+current thread`` and, under worse timing, a hard SIGABRT inside
+``mlx::core::metal::get_command_encoder``.
+
+Routing every MLX load / inference / unload through ONE worker thread keeps
+stream affinity intact and serializes Metal command encoding (MLX is not
+safe under concurrent GPU eval from multiple threads). Import-time streams
+are created on this thread the first time a model loads, and every later
+call runs on the same thread, so they always resolve.
+"""
+
+import asyncio
+import functools
+from concurrent.futures import ThreadPoolExecutor
+
+# max_workers=1 is load-bearing: it is what guarantees a single, stable OS
+# thread for all MLX work.
+_MLX_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
+
+
+async def run_mlx(fn, *args, **kwargs):
+    """Await ``fn(*args, **kwargs)`` on the dedicated MLX thread."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _MLX_EXECUTOR, functools.partial(fn, *args, **kwargs)
+    )

--- a/tauri/src-tauri/src/focus_capture.rs
+++ b/tauri/src-tauri/src/focus_capture.rs
@@ -198,6 +198,17 @@ pub fn capture_focus() -> Result<FocusSnapshot, String> {
             &mut focused as *mut _,
         );
         if err != AX_ERROR_SUCCESS || focused.is_null() {
+            // Some apps (terminals, some Electron windows) expose no
+            // system-wide focused element. Rather than drop the dictation,
+            // fall back to the frontmost app so the transcript still injects
+            // there via activate + ⌘V.
+            if let Some(fp) = frontmost_pid() {
+                return Ok(FocusSnapshot {
+                    pid: fp,
+                    bundle_id: bundle_id_for_pid(fp),
+                    role: None,
+                });
+            }
             return Err(format!(
                 "No focused element (AXError {}). Verify Accessibility permission is granted and a focused text field exists.",
                 err
@@ -211,6 +222,26 @@ pub fn capture_focus() -> Result<FocusSnapshot, String> {
         let err = AXUIElementGetPid(focused_elem, &mut pid);
         if err != AX_ERROR_SUCCESS {
             return Err(format!("AXUIElementGetPid failed (AXError {})", err));
+        }
+
+        // If the focused element belongs to our OWN process, the dictate pill
+        // has transiently taken key focus for its WebKit mic capture — the
+        // system-wide AXFocusedUIElement then resolves to the pill instead of
+        // the user's real target, which would make us paste into ourselves (a
+        // no-op) or drop the text entirely. The pill is a non-activating panel
+        // so it never becomes the frontmost application; remap to the
+        // frontmost app, which is always the real dictation target.
+        let our_pid = std::process::id() as Pid;
+        if pid == our_pid {
+            if let Some(fp) = frontmost_pid() {
+                if fp != our_pid {
+                    return Ok(FocusSnapshot {
+                        pid: fp,
+                        bundle_id: bundle_id_for_pid(fp),
+                        role: None,
+                    });
+                }
+            }
         }
 
         let role = {
@@ -298,6 +329,28 @@ pub fn activate_pid(pid: i32) -> Result<(), String> {
             ));
         }
         Ok(())
+    }
+}
+
+/// PID of the app the user is currently in (NSWorkspace frontmost). Used to
+/// skip re-activation when the paste target never lost frontmost status —
+/// activating an already-frontmost app is a no-op at best, and on
+/// fullscreen Spaces macOS 26's cooperative activation returns NO for it,
+/// which previously aborted the whole paste.
+#[cfg(target_os = "macos")]
+pub fn frontmost_pid() -> Option<i32> {
+    unsafe {
+        let _pool = AutoreleasePool::new();
+        let ws: Id = msg_send![class!(NSWorkspace), sharedWorkspace];
+        if ws.is_null() {
+            return None;
+        }
+        let app: Id = msg_send![ws, frontmostApplication];
+        if app.is_null() {
+            return None;
+        }
+        let pid: i32 = msg_send![app, processIdentifier];
+        Some(pid)
     }
 }
 

--- a/tauri/src-tauri/src/hotkey_monitor.rs
+++ b/tauri/src-tauri/src/hotkey_monitor.rs
@@ -269,6 +269,10 @@ fn apply_effect(app: &AppHandle, effect: Effect) {
                 // it out of whatever app the user was typing in, which is
                 // the opposite of what a dictation overlay should do.
                 let _ = window.show();
+                // Order the pill into the currently-active Space (incl. a
+                // foreign app's fullscreen Space) — see main.rs.
+                #[cfg(target_os = "macos")]
+                crate::force_order_front(&window);
                 let payload = serde_json::json!({ "focus": focus });
                 let _ = window.emit("dictate:start", payload);
             }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -57,7 +57,135 @@ fn build_dictate_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewW
         window.set_position(PhysicalPosition::new(x, y))?;
     }
 
+    // Make the pill able to float over other apps' native fullscreen Spaces.
+    #[cfg(target_os = "macos")]
+    apply_fullscreen_overlay_behavior(&window);
+
     Ok(window)
+}
+
+/// `object_setClass` — reclass a live object. Not re-exported by `objc`.
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn object_setClass(
+        obj: *mut objc::runtime::Object,
+        cls: *const objc::runtime::Class,
+    ) -> *const objc::runtime::Class;
+}
+
+/// `canBecomeKeyWindow` override for the pill panel. Borderless NSPanels
+/// refuse key status by default, and WebKit rejects `getUserMedia` from a
+/// document whose window can never become key — so recording silently fails.
+/// Returning YES restores capture; the panel stays non-activating, so showing
+/// it never steals focus from the app being dictated into.
+#[cfg(target_os = "macos")]
+extern "C" fn pill_panel_can_become_key(
+    _this: &objc::runtime::Object,
+    _sel: objc::runtime::Sel,
+) -> objc::runtime::BOOL {
+    objc::runtime::YES
+}
+
+/// Lazily-registered NSPanel subclass for the dictate pill: key-capable (for
+/// WebKit media capture) while remaining a panel (for fullscreen-Space join).
+#[cfg(target_os = "macos")]
+fn pill_panel_class() -> &'static objc::runtime::Class {
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel, BOOL};
+    use objc::{class, sel, sel_impl};
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let superclass = class!(NSPanel);
+        let mut decl =
+            ClassDecl::new("VoiceboxPillPanel", superclass).expect("register VoiceboxPillPanel");
+        unsafe {
+            decl.add_method(
+                sel!(canBecomeKeyWindow),
+                pill_panel_can_become_key as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+        }
+        decl.register();
+    });
+    Class::get("VoiceboxPillPanel").expect("VoiceboxPillPanel registered")
+}
+
+/// Convert the dictate pill's NSWindow into a key-capable NSPanel and set the
+/// collection behavior + window level required to appear over another app's
+/// native macOS fullscreen Space.
+///
+/// A regular (Dock-icon) app's plain NSWindow is never admitted to a foreign
+/// fullscreen Space regardless of collection-behavior flags or window level;
+/// an NSPanel with the same flags is. NSPanel adds no instance variables over
+/// NSWindow, so re-classing the live object is safe (the tauri-nspanel plugin
+/// uses the same technique). Idempotent via an `isKindOfClass` guard. Runs on
+/// the main thread because AppKit window mutation is main-thread-only.
+#[cfg(target_os = "macos")]
+pub fn apply_fullscreen_overlay_behavior(window: &tauri::WebviewWindow) {
+    let w = window.clone();
+    let dispatched = window.run_on_main_thread(move || {
+        use objc::runtime::{Object, NO, YES};
+        use objc::{class, msg_send, sel, sel_impl};
+
+        // NSWindowCollectionBehavior bit flags.
+        const CAN_JOIN_ALL_SPACES: u64 = 1 << 0;
+        const STATIONARY: u64 = 1 << 4;
+        const FULL_SCREEN_AUXILIARY: u64 = 1 << 8; // the flag stock Tauri never sets
+        const NONACTIVATING_PANEL: u64 = 1 << 7; // NSWindowStyleMaskNonactivatingPanel
+        // NSScreenSaverWindowLevel — floats above fullscreen app content.
+        const OVERLAY_WINDOW_LEVEL: i64 = 1000;
+
+        let ns_window = match w.ns_window() {
+            Ok(ptr) => ptr as *mut Object,
+            Err(e) => {
+                eprintln!("apply_fullscreen_overlay_behavior: ns_window() failed: {e}");
+                return;
+            }
+        };
+        if ns_window.is_null() {
+            return;
+        }
+        // SAFETY: ns_window is a valid, non-null NSWindow* owned by Tauri for
+        // the lifetime of the webview window; all selectors are standard AppKit
+        // calls and we are on the main thread.
+        unsafe {
+            let is_panel: objc::runtime::BOOL =
+                msg_send![ns_window, isKindOfClass: class!(NSPanel)];
+            if is_panel == NO {
+                object_setClass(ns_window, pill_panel_class());
+                let style: u64 = msg_send![ns_window, styleMask];
+                let _: () = msg_send![ns_window, setStyleMask: style | NONACTIVATING_PANEL];
+                let _: () = msg_send![ns_window, setHidesOnDeactivate: NO];
+                let _: () = msg_send![ns_window, setBecomesKeyOnlyIfNeeded: YES];
+                let _: () = msg_send![ns_window, setFloatingPanel: YES];
+            }
+            let behavior = CAN_JOIN_ALL_SPACES | FULL_SCREEN_AUXILIARY | STATIONARY;
+            let _: () = msg_send![ns_window, setCollectionBehavior: behavior];
+            let _: () = msg_send![ns_window, setLevel: OVERLAY_WINDOW_LEVEL];
+        }
+    });
+    if let Err(e) = dispatched {
+        eprintln!("apply_fullscreen_overlay_behavior: main-thread dispatch failed: {e}");
+    }
+}
+
+/// Order the pill front over whatever Space is active. `orderFrontRegardless`
+/// works even though the app is inactive (it always is mid-dictation — the
+/// user is typing in some other app). Called right after `window.show()`.
+#[cfg(target_os = "macos")]
+pub fn force_order_front(window: &tauri::WebviewWindow) {
+    let w = window.clone();
+    let _ = window.run_on_main_thread(move || {
+        use objc::runtime::Object;
+        use objc::{msg_send, sel, sel_impl};
+        if let Ok(ptr) = w.ns_window() {
+            let ns_window = ptr as *mut Object;
+            if !ns_window.is_null() {
+                unsafe {
+                    let _: () = msg_send![ns_window, orderFrontRegardless];
+                }
+            }
+        }
+    });
 }
 
 /// Position, undo click-through, and show the dictate pill window.
@@ -114,6 +242,8 @@ pub fn show_dictate_window(app: &tauri::AppHandle) {
     }
     let _ = window.set_ignore_cursor_events(false);
     let _ = window.show();
+    #[cfg(target_os = "macos")]
+    force_order_front(&window);
 }
 
 const LEGACY_PORT: u16 = 8000;
@@ -1210,6 +1340,7 @@ fn open_input_monitoring_settings(app: tauri::AppHandle) -> Result<(), String> {
 /// Returns `true` when the paste sequence completed end-to-end.
 #[command]
 async fn paste_final_text(
+    app: tauri::AppHandle,
     text: String,
     focus: focus_capture::FocusSnapshot,
 ) -> Result<bool, String> {
@@ -1223,14 +1354,45 @@ async fn paste_final_text(
         );
     }
 
-    focus_capture::activate_pid(focus.pid)?;
-    tokio::time::sleep(std::time::Duration::from_millis(POST_ACTIVATE_SETTLE_MS)).await;
+    // Only re-activate the target when the user actually left it. When it is
+    // still frontmost (the common case — the dictate pill is non-activating,
+    // and in a fullscreen Space the target never loses frontmost), activation
+    // is a no-op; on macOS 26 fullscreen Spaces `activate` returns NO for an
+    // already-frontmost app, which would otherwise abort the paste entirely.
+    #[cfg(target_os = "macos")]
+    let already_front = focus_capture::frontmost_pid() == Some(focus.pid);
+    #[cfg(not(target_os = "macos"))]
+    let already_front = false;
+
+    if !already_front {
+        focus_capture::activate_pid(focus.pid)?;
+        tokio::time::sleep(std::time::Duration::from_millis(POST_ACTIVATE_SETTLE_MS)).await;
+    }
 
     let snapshot = clipboard::save_clipboard()?;
     let after_write = clipboard::write_text(&text)?;
 
+    // Order the pill out for the synthetic ⌘V. The pill is a key-capable
+    // panel (WebKit needs that for getUserMedia), and over a fullscreen Space
+    // it holds key focus Spotlight-style — the keystroke would land in the
+    // pill instead of the target app. Hidden it can't swallow keys; restored
+    // immediately after so the webview never suspends between dictations.
+    #[cfg(target_os = "macos")]
+    let pill = app.get_webview_window(DICTATE_WINDOW_LABEL);
+    #[cfg(target_os = "macos")]
+    if let Some(ref w) = pill {
+        let _ = w.hide();
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    }
+
     let paste_result = synthetic_keys::send_paste();
     tokio::time::sleep(std::time::Duration::from_millis(PASTE_CONSUME_MS)).await;
+
+    #[cfg(target_os = "macos")]
+    if let Some(ref w) = pill {
+        let _ = w.show();
+        force_order_front(w);
+    }
 
     let safe_to_restore = matches!(
         clipboard::current_change_count(),


### PR DESCRIPTION
## Summary

Three independent bug fixes for macOS push-to-talk dictation, found while using
VoiceBox daily on an M4 / macOS 26. Each is a separate commit.

### 1. Dictation now works in native fullscreen apps — `fix(macos)`
The dictation pill was an ordinary `NSWindow`, which macOS never places on
another app's native fullscreen Space. In fullscreen the pill therefore never
appeared, its `WKWebView` stayed occluded, and `getUserMedia()` never resolved —
so recording only began after leaving fullscreen. The pill is now a **key‑capable
`NSPanel`** (the window class fullscreen Spaces admit; key‑capable so WebKit still
grants mic capture) with a `CanJoinAllSpaces | FullScreenAuxiliary` collection
behavior, ordered front via `orderFrontRegardless`.

### 2. Correct text injection & keyboard focus — `fix(macos)`
`capture_focus()` read the *system‑wide* focused element, which resolved to the
pill itself while it briefly held key focus. Two consequences:
- the transcript was dropped (the paste‑into‑self guard fired), so text was
  recorded but never injected — reproducible in terminals and some Electron apps;
- the pill kept keyboard focus, so the next Enter went to the pill instead of the
  user's field.

Focus now targets the **frontmost application** (always the real dictation target,
since the pill is a non‑activating panel), falls back to it for apps that expose
no accessibility focus, and the pill is restored after paste **without** re‑taking
key focus so the target keeps keyboard focus.

### 3. MLX backend crash & refinement failure — `fix(mlx)` + `fix(backend)`
- **Thread‑affinity crash:** `mlx_lm` binds a module‑level GPU stream
  (`mlx_lm/generate.py`) to whichever thread first imports it, but the server
  dispatches inference through an `asyncio.to_thread` pool. Successive calls on
  different workers hit `There is no Stream(gpu, N) in current thread` (LLM
  refinement) or, under worse timing, a hard `SIGABRT` inside
  `mlx::core::metal::get_command_encoder` that takes down the backend. All MLX
  Whisper (STT) and Qwen (LLM) load/inference now runs on a single dedicated
  worker thread, preserving stream affinity and serializing Metal.
- **Broken pipe:** the desktop host stops draining the sidecar's stdout/stderr
  after startup, closing the pipe; later writes raised `BrokenPipeError` and
  surfaced as a 500 (`[Errno 32] Broken pipe`) during transcription. The frozen
  entry point's streams now swallow pipe errors.

## Testing
- Fullscreen dictation verified end‑to‑end in Chrome and WhatsApp: pill appears
  over the fullscreen app, records, transcribes, and pastes.
- Text injection verified into desktop apps including terminals; Enter after paste
  no longer requires re‑focusing the field.
- MLX fix verified by hammering the running backend with concurrent
  prewarm/transcribe/refine — previously failed on refinement and eventually
  crashed (macOS crash report: `SIGABRT` in `get_command_encoder`); now stable
  across many rounds with no stream errors and no new crash reports.
- `cargo check` and Python syntax pass on a clean upstream checkout.

## Platform notes
Changes 1 and 2 are macOS‑only (`#[cfg(target_os = "macos")]`). Change 3 helps any
Apple‑Silicon user (the MLX crash) and every platform (the broken pipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS dictation window behavior so it appears more reliably and works better with fullscreen apps.
  * Enhanced focus detection to better choose the correct target app when starting dictation or pasting text.

* **Bug Fixes**
  * Reduced paste failures on macOS by handling app activation more carefully.
  * Prevented logging crashes when output pipes are no longer available.
  * Improved stability for AI model loading and transcription/generation by keeping related work on a consistent execution thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->