### PR TITLE
Fix voice sample validation on Python 3.13 (fixes #852)

### DIFF
--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -330,6 +330,9 @@ def build_server(cuda=False, rocm=False):
         ]
     )
 
+    if sys.version_info >= (3, 13):
+        args.extend(["--hidden-import", "audioop"])
+
     # Add CUDA/ROCm-specific hidden imports
     if cuda or rocm:
         variant = "ROCm" if rocm else "CUDA"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -53,6 +53,7 @@ en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_
 unidic-lite>=1.0.8
 
 # Audio processing
+audioop-lts>=0.2.1; python_version >= "3.13"
 librosa>=0.10.0
 soundfile>=0.12.0
 numpy>=1.24.0,<2.0

--- a/backend/tests/test_audioop_python313.py
+++ b/backend/tests/test_audioop_python313.py
@@ -41,7 +41,6 @@ class TestAudioopRuntime:
     def test_validate_reference_wav_does_not_fail_on_missing_audioop(self, tmp_path):
         import numpy as np
         import soundfile as sf
-
         from utils.audio import validate_and_load_reference_audio
 
         sr = 24000

--- a/backend/tests/test_audioop_python313.py
+++ b/backend/tests/test_audioop_python313.py
@@ -1,0 +1,124 @@
+"""
+Regression tests for issue #852: audioop removed from Python 3.13 stdlib.
+
+Voice sample validation imports audioop transitively (librosa → audioread).
+The audioop-lts backport must be declared in requirements and bundled in
+PyInstaller builds on 3.13+.
+"""
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from build_binary import build_server
+
+
+@pytest.fixture
+def backend_dir():
+    return Path(__file__).parent.parent
+
+
+class TestAudioopRequirements:
+    def test_requirements_declare_audioop_lts_for_python_313(self, backend_dir):
+        content = (backend_dir / "requirements.txt").read_text()
+        assert re.search(
+            r"^audioop-lts.*python_version\s*>=\s*['\"]3\.13['\"]",
+            content,
+            re.MULTILINE,
+        ), "requirements.txt must pin audioop-lts for Python 3.13+"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="Python 3.13+ only")
+class TestAudioopRuntime:
+    def test_audioop_importable(self):
+        import audioop  # noqa: F401
+
+    def test_validate_reference_wav_does_not_fail_on_missing_audioop(self, tmp_path):
+        import numpy as np
+        import soundfile as sf
+
+        from utils.audio import validate_and_load_reference_audio
+
+        sr = 24000
+        t = np.arange(int(sr * 3), dtype=np.float32) / sr
+        audio = (0.3 * np.sin(2 * np.pi * 220 * t)).astype(np.float32)
+        path = tmp_path / "reference.wav"
+        sf.write(str(path), audio, sr)
+
+        ok, err, out_audio, out_sr = validate_and_load_reference_audio(str(path))
+
+        assert ok, err
+        assert out_audio is not None
+        assert out_sr == sr
+        assert "audioop" not in (err or "").lower()
+
+
+class TestAudioopBuildArgs:
+    @staticmethod
+    def _hidden_imports(args):
+        imports = []
+        for i, arg in enumerate(args):
+            if arg == "--hidden-import" and i + 1 < len(args):
+                imports.append(args[i + 1])
+        return imports
+
+    def test_pyinstaller_includes_audioop_on_python_313(self):
+        class FakeVersionInfo(tuple):
+            @property
+            def major(self):
+                return self[0]
+
+            @property
+            def minor(self):
+                return self[1]
+
+            @property
+            def micro(self):
+                return self[2]
+
+        fake_313 = FakeVersionInfo((3, 13, 0, "final", 0))
+
+        with (
+            patch("build_binary.PyInstaller.__main__.run") as mock_run,
+            patch("build_binary.platform.system", return_value="Linux"),
+            patch("build_binary.is_apple_silicon", return_value=False),
+            patch("build_binary.os.chdir"),
+            patch("build_binary.sys.version_info", fake_313),
+        ):
+            build_server()
+            args = mock_run.call_args[0][0]
+
+        assert "audioop" in self._hidden_imports(args)
+
+    def test_pyinstaller_omits_audioop_on_python_312(self):
+        class FakeVersionInfo(tuple):
+            @property
+            def major(self):
+                return self[0]
+
+            @property
+            def minor(self):
+                return self[1]
+
+            @property
+            def micro(self):
+                return self[2]
+
+        fake_312 = FakeVersionInfo((3, 12, 0, "final", 0))
+
+        with (
+            patch("build_binary.PyInstaller.__main__.run") as mock_run,
+            patch("build_binary.platform.system", return_value="Linux"),
+            patch("build_binary.is_apple_silicon", return_value=False),
+            patch("build_binary.os.chdir"),
+            patch("build_binary.sys.version_info", fake_312),
+        ):
+            build_server()
+            args = mock_run.call_args[0][0]
+
+        assert "audioop" not in self._hidden_imports(args)


### PR DESCRIPTION
## Summary

Fixes #852. Python 3.13 dropped `audioop` from the standard library, but reference audio validation still needs it through librosa and audioread. Uploading a voice sample then fails with `No module named 'audioop'`.

This adds the `audioop-lts` backport for Python 3.13 and above, and tells PyInstaller to bundle `audioop` when building on those versions.

## Test plan

- [x] Reproduced the failure on Python 3.13.14 without `audioop-lts`: validation returns `Error validating audio: No module named 'audioop'`
- [x] Confirmed the fix: validation passes after installing `audioop-lts`
- [x] `pytest backend/tests/test_audioop_python313.py -v` on Python 3.13 (5 passed)
- [x] `pytest backend/tests/test_audio_preprocess.py -v` on Python 3.13 (9 passed)
- [x] Build arg tests pass on Python 3.12 (3 passed, 2 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Python 3.13+ by switching audio processing to `audioop-lts` when the standard `audioop` module is unavailable.
  * Updated the build output so the required audio module is bundled correctly on Python 3.13+ (including hidden-import handling).
  * Added regression coverage to ensure audio validation and packaging behave correctly on Python 3.12 vs 3.13+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->