### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,8 @@ tauri/
 landing/
 docs/
 mlx-test/
-scripts/
+scripts/*
+!scripts/rocm-entrypoint.sh
 
 # Dependencies & build artifacts (rebuilt in Docker)
 node_modules/


### PR DESCRIPTION
whitelist ROCm entrypoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated packaging rules so most helper scripts are excluded from the build context, while the required entrypoint script remains included. This helps prevent missing runtime files and reduces unintended build contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->