### PR TITLE
fix(docker): exempt rocm-entrypoint.sh from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ landing/
 docs/
 mlx-test/
 scripts/
+!scripts/rocm-entrypoint.sh
 
 # Dependencies & build artifacts (rebuilt in Docker)
 node_modules/

--- a/backend/app.py
+++ b/backend/app.py
@@ -38,6 +38,13 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# An empty HSA_OVERRIDE_GFX_VERSION poisons the ROCm HSA runtime — it's
+# treated as "force-empty" and no GPU is detected, even natively supported
+# ones (e.g. gfx1201 / RX 9070 on ROCm 7.2). docker-compose can't
+# conditionally omit an env var, so we clean it up here before torch loads.
+if not os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
+    os.environ.pop("HSA_OVERRIDE_GFX_VERSION", None)
+
 # AMD GPU environment variables must be set before torch import
 # Only set HSA_OVERRIDE_GFX_VERSION for older GPUs that need it.
 # RDNA 3+ (gfx1100+) and RDNA 4 (gfx1200+) are natively supported by ROCm


### PR DESCRIPTION
## Problem

The `scripts/` directory is blanket-excluded in `.dockerignore`, which prevents `scripts/rocm-entrypoint.sh` from reaching the Docker build context. The Dockerfile's final stage copies this file as the container entrypoint:

```dockerfile
COPY --chmod=755 scripts/rocm-entrypoint.sh /usr/local/bin/entrypoint.sh
```

So the ROCm build fails with:

```
failed to solve: failed to compute cache key: failed to calculate checksum of ref
...: "/scripts/rocm-entrypoint.sh": not found
```

## Fix

Add a negation rule in `.dockerignore` to let the entrypoint script through while keeping the rest of `scripts/` excluded:

```diff
 scripts/
+!scripts/rocm-entrypoint.sh
```

Fixes #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker-related packaging rules to ensure the required startup script remains included in container builds.
* **Bug Fixes**
  * Improved GPU/ROCm startup behavior by clearing an empty `HSA_OVERRIDE_GFX_VERSION` value so it no longer interferes with GPU detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->