### PR TITLE
fix(rocm): unset empty HSA_OVERRIDE_GFX_VERSION before torch loads

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -38,6 +38,13 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# An empty HSA_OVERRIDE_GFX_VERSION poisons the ROCm HSA runtime. It is
+# treated as "force-empty" and no GPU is detected, even natively supported
+# ones (e.g. gfx1201 / RX 9070 on ROCm 7.2). docker-compose can't
+# conditionally omit an env var, so we clean it up here before torch loads.
+if not os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
+    os.environ.pop("HSA_OVERRIDE_GFX_VERSION", None)
+
 # AMD GPU environment variables must be set before torch import
 # Only set HSA_OVERRIDE_GFX_VERSION for older GPUs that need it.
 # RDNA 3+ (gfx1100+) and RDNA 4 (gfx1200+) are natively supported by ROCm


### PR DESCRIPTION
## Problem

When running Voicebox with ROCm in Docker, no GPU is detected even when the hardware is present and ROCm PyTorch is installed:

```
RuntimeError: No CUDA GPUs are available
```

## Root cause

`docker-compose.rocm.yml` sets:

```yaml
HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}
```

This uses the shell default syntax, which sets the variable to an **empty string** when no value is provided. Docker compose cannot conditionally omit an environment variable — it either sets it (even to empty) or doesn't include the line at all.

An empty string is not the same as unset. ROCm's HSA runtime interprets `HSA_OVERRIDE_GFX_VERSION=""` as "force the GPU version to empty", which causes it to find zero GPUs. This affects all GPUs, including ones that are natively supported by ROCm (e.g. gfx1201 / RX 9070 on ROCm 7.2) and don't need an override at all.

Verified inside the container:
- Empty string → `torch.cuda.is_available()` = False, 0 devices
- Unset → True, 2 devices
- `12.0.0` → True, 2 devices

## Fix

In `backend/app.py`, before torch is imported, pop the environment variable when it is empty:

```python
if not os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
    os.environ.pop("HSA_OVERRIDE_GFX_VERSION", None)
```

This ensures that when docker-compose passes an empty string, the variable is fully removed from the environment before ROCm initialises. Users who explicitly set `HSA_OVERRIDE_GFX_VERSION` for older GPUs (RDNA 1-3) are not affected — the variable is only popped when it is empty.

## Testing

Tested on RX 9070 (gfx1201) with ROCm 7.2 and PyTorch 2.12.1+rocm7.2:
- Without fix: `torch.cuda.is_available()` = False, 0 devices
- With fix: `torch.cuda.is_available()` = True, 2 devices (AMD Radeon RX 9070 + AMD Ryzen 7 9800X3D iGPU)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU startup behavior by ignoring empty `HSA_OVERRIDE_GFX_VERSION` values before hardware detection runs.
  * Prevents an unset override from being treated as a forced empty GPU configuration, helping avoid ROCm runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->