### PR TITLE
fix(rocm): add MIOpen stability env vars to docker-compose.rocm.yml

### DIFF
--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -34,3 +34,15 @@ services:
 
       # Tune the ROCm memory allocator
       - PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.8,max_split_size_mb:512
+
+      # Redirect MIOpen kernel cache to a writable, persistent directory.
+      # Without this, MIOpen may fail to write its cache and throw
+      # miopenStatusUnknownError on fresh containers.
+      - MIOPEN_USER_DB_PATH=/app/data/cache/miopen_db
+      - MIOPEN_CUSTOM_CACHE_DIR=/app/data/cache/miopen_cache
+
+      # Use fast heuristics for kernel selection instead of exhaustive
+      # benchmarking. On RDNA4, exhaustive mode tries kernels that fail to
+      # allocate workspace memory (ptr: 0 size: 0), causing system stuttering
+      # on every generation even when the cache is present.
+      - MIOPEN_FIND_MODE=FAST


### PR DESCRIPTION
## Problem

When running Voicebox with ROCm on RDNA4 GPUs (e.g. RX 9070), inference fails with `miopenStatusUnknownError` and causes severe system stuttering with repeated MIOpen warnings:

```
MIOpen(HIP): Warning [IsEnoughWorkspace] [EvaluateInvokers] Solver <GemmFwdRest>, workspace required: 516096000, provided ptr: 0 size: 0
```

Two issues:
1. Without explicit cache paths, MIOpen fails to write its kernel cache in a fresh container, leading to `miopenStatusUnknownError`.
2. MIOpen's default exhaustive benchmarking mode tries every kernel variant on every generation. On RDNA4, many kernels fail to allocate workspace memory (returning `ptr: 0 size: 0`), causing MIOpen to thrash through failing kernels and stall the GPU.

## Fix

Add three environment variables to `docker-compose.rocm.yml`:

| Variable | Purpose |
|---|---|
| `MIOPEN_USER_DB_PATH` | Redirect MIOpen kernel cache to a writable, persistent directory |
| `MIOPEN_CUSTOM_CACHE_DIR` | Same, for custom operator cache |
| `MIOPEN_FIND_MODE=FAST` | Use heuristic kernel selection instead of exhaustive benchmarking |

`MIOPEN_FIND_MODE=FAST` does not affect output quality. All MIOpen kernel variants produce the same numerical result; fast mode simply selects a known-good kernel using heuristics instead of benchmarking every variant on the GPU.

## Testing

Tested on RX 9070 (gfx1201) with ROCm 7.2 and PyTorch 2.12.1+rocm7.2. Each variable was tested in isolation:
- Without cache path vars: `miopenStatusUnknownError` on inference
- Without `MIOPEN_FIND_MODE=FAST`: system stuttering during inference, repeated MIOpen workspace warnings on every generation even when cache is present
- With all three variables: clean logs, no warnings, smooth inference, voice generation works correctly

## Hardware note

This was tested on a Ryzen 7 9800X3D + RX 9070 with a Gigabyte B650M DS3H motherboard.

## Dependencies

This PR depends on several other fixes that must be in place before the MIOpen fixes can be tested or used:

- **#861**  — exempts `scripts/rocm-entrypoint.sh` from `.dockerignore`. Without this, the ROCm Docker build is broken because the entrypoint script is excluded from the build context.
- **#677** — fixes HuggingFace cache permissions so the container can write model files. The MIOpen cache paths point to `/app/data/cache/`, which requires the volume permissions to be correct. **See my suggestion on that issue with alternative approach.**
- **#584** — fixes Docker permission issues with the voicebox user UID and bind-mounted directories. Without correct permissions, MIOpen cannot write its cache to the data volume. **See my suggestion on that issue with alternative approach.**
- **#864** **HSA override fix**: unsets the empty `HSA_OVERRIDE_GFX_VERSION` environment variable that docker-compose passes by default. Without this, no GPU is detected at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ROCm/AMD GPU startup behavior by preserving MIOpen cache and database data in a persistent location.
  * Enabled faster kernel selection to reduce initialization time for supported GPU workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->