### PR TITLE
Fixes #873 by avoiding the `tao` Linux/X11 panic triggered when `set_ignore_cursor_events()` is called on the transparent dictate overlay window.

### DIFF
--- a/tauri/src-tauri/src/hotkey_monitor.rs
+++ b/tauri/src-tauri/src/hotkey_monitor.rs
@@ -264,7 +264,10 @@ fn apply_effect(app: &AppHandle, effect: Effect) {
                         let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
                     }
                 }
-                let _ = window.set_ignore_cursor_events(false);
+                #[cfg(not(target_os = "linux"))]
+                {
+                    let _ = window.set_ignore_cursor_events(false);
+                }
                 // Deliberately no set_focus() — taking key focus would yank
                 // it out of whatever app the user was typing in, which is
                 // the opposite of what a dictation overlay should do.

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -38,7 +38,11 @@ fn build_dictate_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewW
     .title("Voicebox Dictate")
     .inner_size(DICTATE_WINDOW_WIDTH, DICTATE_WINDOW_HEIGHT)
     .decorations(false)
-    .transparent(true)
+    // Transparent windows can cause tao to panic on Linux/X11 when
+    // set_ignore_cursor_events is called because the underlying GDK window
+    // may not be realized. Keep transparency for platforms where the
+    // click-through workaround is supported.
+    .transparent(!cfg!(target_os = "linux"))
     .always_on_top(true)
     // Follow the user across macOS Spaces / virtual desktops instead of
     // being pinned to the Space where the window was first created.
@@ -112,7 +116,10 @@ pub fn show_dictate_window(app: &tauri::AppHandle) {
             let _ = window.set_position(PhysicalPosition::new(x, y));
         }
     }
-    let _ = window.set_ignore_cursor_events(false);
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = window.set_ignore_cursor_events(false);
+    }
     let _ = window.show();
 }
 
@@ -1421,7 +1428,10 @@ pub fn run() {
                 let handle_for_hide = app.handle().clone();
                 app.handle().listen("dictate:hide", move |_event| {
                     if let Some(window) = handle_for_hide.get_webview_window(DICTATE_WINDOW_LABEL) {
-                        let _ = window.set_ignore_cursor_events(true);
+                        #[cfg(not(target_os = "linux"))]
+                        {
+                            let _ = window.set_ignore_cursor_events(true);
+                        }
                         let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
                         let _ = window.hide();
                     }


### PR DESCRIPTION
## Summary

Fixes #873 by avoiding the `tao` Linux/X11 panic triggered when `set_ignore_cursor_events()` is called on the transparent dictate overlay window.

## Changes

- Disable dictate window transparency on Linux.
- Skip `set_ignore_cursor_events(true)` in the `dictate:hide` handler on Linux.
- Skip `set_ignore_cursor_events(false)` in dictate show paths on Linux.
- Preserve existing behavior on macOS and Windows.

## Why

On Linux/X11, transparent Tauri windows can leave tao without a realized GDK window. Calling `set_ignore_cursor_events()` then panics inside tao when it unwraps a missing window handle.

On Linux, the dictate overlay is already moved off-screen and hidden when dismissed, so skipping click-through toggling avoids the crash without leaving an interactive invisible window.

## Verification

- `cargo check` was attempted but could not complete because the local checkout is missing the expected Tauri sidecar binary:
  `binaries/voicebox-server-x86_64-unknown-linux-gnu`
- `cargo fmt --check` was attempted, but the repository currently has pre-existing formatting differences across unrelated Rust files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux stability when using the dictate window by preventing crashes related to click-through behavior.
  * Preserved cursor interaction behavior on supported platforms while avoiding unsupported Linux window handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->