### PR TITLE
fix: MLX thread affinity crash + missing mlx-lm/mlx-audio in dev setup

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -171,10 +171,10 @@ def check_cuda_compatibility() -> tuple[bool, str | None]:
 
 def empty_device_cache(device: str) -> None:
     """
-    Free cached memory on the given device (CUDA or XPU).
+    Free cached memory on the given device (CUDA, XPU, or MPS).
 
-    Backends should call this after unloading models so VRAM is returned
-    to the OS.
+    Backends should call this after unloading models so VRAM/unified
+    memory is returned to the OS.
     """
     import torch
 
@@ -182,6 +182,8 @@ def empty_device_cache(device: str) -> None:
         torch.cuda.empty_cache()
     elif device == "xpu" and hasattr(torch, "xpu"):
         torch.xpu.empty_cache()
+    elif device == "mps" and hasattr(torch, "mps"):
+        torch.mps.empty_cache()
 
 
 def manual_seed(seed: int, device: str) -> None:

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -5,10 +5,26 @@ MLX backend implementation for TTS and STT using mlx-audio.
 from typing import Optional, List, Tuple
 import asyncio
 import logging
+from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# MLX's Metal command encoder/stream is thread-local: it's bound to
+# whichever thread first touches the GPU device. asyncio.to_thread() uses
+# the loop's default executor, which can (and does) hand different calls
+# to different worker threads — model load on one thread, then generate()
+# on another raises "There is no Stream(gpu, N) in current thread." Pin
+# every MLX call to the same single dedicated worker instead.
+# See https://github.com/jamiepine/voicebox/issues/699
+_mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-worker")
+
+
+def _run_on_mlx_thread(func, *args):
+    """Run ``func(*args)`` on the single dedicated MLX worker thread."""
+    loop = asyncio.get_running_loop()
+    return loop.run_in_executor(_mlx_executor, func, *args)
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage
 # This prevents mlx_audio from making network requests when models are cached
@@ -81,8 +97,8 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size != model_size:
             self.unload_model()
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX thread
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -258,8 +274,8 @@ class MLXTTSBackend:
 
             return audio, sample_rate
 
-        # Run blocking inference in thread pool
-        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        # Run blocking inference on the dedicated MLX thread
+        audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
 
         return audio, sample_rate
 
@@ -292,8 +308,8 @@ class MLXSTTBackend:
         if self.model is not None and self.model_size == model_size:
             return
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX thread
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -363,5 +379,5 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        # Run blocking transcription on the dedicated MLX thread
+        return await _run_on_mlx_thread(_transcribe_sync)

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -93,9 +93,11 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size == model_size:
             return
 
-        # Unload existing model if different size requested
+        # Unload existing model if different size requested — routed
+        # through the same dedicated thread as load/generate so it stays
+        # serialized with any in-flight MLX call (see _run_on_mlx_thread).
         if self.model is not None and self._current_model_size != model_size:
-            self.unload_model()
+            await _run_on_mlx_thread(self.unload_model)
 
         # Run blocking load on the dedicated MLX thread
         await _run_on_mlx_thread(self._load_model_sync, model_size)

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -34,7 +34,7 @@ class PyTorchTTSBackend:
 
     def _get_device(self) -> str:
         """Get the best available device."""
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -256,7 +256,7 @@ class PyTorchSTTBackend:
 
     def _get_device(self) -> str:
         """Get the best available device."""
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -65,7 +65,7 @@ class QwenCustomVoiceBackend:
         self._current_model_size: Optional[str] = None
 
     def _get_device(self) -> str:
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -25,6 +25,7 @@ from . import TTSBackend, LANGUAGE_CODE_TO_NAME
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -127,8 +128,7 @@ class QwenCustomVoiceBackend:
             self.model = None
             self._current_model_size = None
 
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            empty_device_cache(self.device)
 
             logger.info("Qwen CustomVoice unloaded")
 

--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -9,14 +9,42 @@ mlx>=0.30.0
 # M1 installs with `ModuleNotFoundError: miniaudio` (issue #505).
 miniaudio>=1.59
 
-# NOTE: mlx-audio is intentionally not listed here. From 0.3.1 onward it
-# declares `transformers==5.0.0rc3` / `>=5.0.0`, which conflicts with the
-# `transformers<=4.57.6` cap in requirements.txt and breaks CI's clean
-# resolver. The mlx-audio API surface we use (mlx_audio.tts.load,
-# mlx_audio.stt.load) works fine on transformers 4.57.x in practice.
+# sounddevice is a runtime dep of mlx-audio (device enumeration for its
+# playback helpers). mlx-audio 0.4.1 pins sounddevice==0.5.3 exactly; not
+# listing it here left it unresolved on a from-scratch install, which
+# doesn't crash immediately but leaves pip's resolver warning about a
+# missing dependency and mlx-audio's playback helper unusable.
+sounddevice==0.5.3
+
+# NOTE: mlx-lm and mlx-audio are intentionally not listed here — both are
+# installed separately with --no-deps (see `just setup-python` and
+# .github/workflows/release.yml), NOT via this requirements file. From
+# 0.30.0 onward mlx-lm declares `transformers>=5.0.0` (mlx-audio>=0.3.1
+# does the same), which conflicts with the `transformers<=4.57.6` cap in
+# requirements.txt. A plain `pip install -r` here would let pip resolve
+# mlx-lm freely and silently upgrade transformers past that cap, which
+# breaks the qwen_tts (PyTorch) engines at *runtime*, not install time:
+# qwen_tts's `@check_model_inputs()` call site
+# (qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py) uses
+# the pre-5.0 signature (a decorator factory called with no arguments).
+# transformers>=5.0 changed `check_model_inputs` to a plain decorator
+# (`check_model_inputs(func)`, no parens at the call site), so loading
+# Qwen CustomVoice through qwen_tts on the newer transformers raises
+# `TypeError: check_model_inputs() missing 1 required positional
+# argument: 'func'`.
 #
-# Install it via `pip install --no-deps mlx-audio==0.4.1` after this file
-# (see .github/workflows/release.yml). Most other mlx-audio runtime deps
-# (huggingface_hub, librosa, mlx-lm, numba, numpy, protobuf, pyloudnorm,
-# sounddevice, tqdm) are already in requirements.txt or pulled in by
-# other engines.
+# Install mlx-lm and mlx-audio via:
+#   pip install --no-deps mlx-lm==0.31.1
+#   pip install --no-deps mlx-audio==0.4.1
+# --no-deps means both packages' own `transformers>=5.0.0` requirement is
+# never consulted, so transformers stays at whatever requirements.txt
+# installed. The mlx_audio.tts/mlx_audio.stt API surface we use works
+# fine against transformers 4.57.x in practice (verified in dev and CI).
+# `just setup-python` previously installed this file's contents (mlx +
+# miniaudio + sounddevice) and stopped — mlx_lm and mlx_audio were never
+# installed at all, so the backend silently fell back to the PyTorch
+# backend on Apple Silicon instead of MLX (issue #823), and once mlx_lm
+# was installed by hand without --no-deps (the obvious fix to try), it
+# reintroduced the transformers conflict above (issue #699 is the
+# MLX-generation-side symptom of the same root cause). See the two
+# `pip install --no-deps` lines added to `just setup-python` below.

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -175,6 +175,8 @@ async def health():
             default_variant = "cuda"
     elif has_xpu:
         default_variant = "xpu"
+    elif backend_type == "mlx":
+        default_variant = "mps"
 
     return models.HealthResponse(
         status="healthy",

--- a/justfile
+++ b/justfile
@@ -72,6 +72,14 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        # mlx-lm and mlx-audio are installed --no-deps and separately from
+        # requirements-mlx.txt on purpose — see the NOTE at the bottom of
+        # that file. Without this step the backend silently falls back to
+        # the PyTorch backend on Apple Silicon (issue #823), and installing
+        # mlx-lm without --no-deps upgrades transformers past the
+        # requirements.txt cap and breaks qwen_tts at runtime (issue #699).
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q


### PR DESCRIPTION
## Summary

Two related bugs on Apple Silicon that turned out to share a root cause, plus one cosmetic health-endpoint fix found while chasing them down.

- Fixes #699 (Qwen TTS generation fails 100% with `Stream(gpu, 1) not in current thread`)
- Fixes #823 (`just setup-python` doesn't install mlx-audio/mlx-lm — MLX backend fails on fresh Apple Silicon dev setup)
- Related to #706 / #723 (MLX falls back to CPU / `backend_variant` misreports) — the health.py fix here addresses the *reporting* side of those; see notes below on what it does and doesn't cover.

## What's actually going on

Starting from a clean `just setup-python` on Apple Silicon, MLX never actually gets used:

1. `requirements-mlx.txt` only lists `mlx` + `miniaudio`. `just setup-python` installs it and stops — it never runs the `pip install --no-deps mlx-lm==0.31.1` / `mlx-audio==0.4.1` steps that `.github/workflows/release.yml` already does for packaged builds. Without `mlx_audio` importable, `get_backend_type()` silently falls back to `"pytorch"` — no error, no log line calling it out, health endpoint still looks plausible. This is #823.

2. The obvious fix once you notice #823 is `pip install mlx-lm` by hand. That reintroduces a *second* problem: `mlx-lm>=0.30.0` requires `transformers>=5.0.0`, conflicting with the `transformers<=4.57.6` cap in `requirements.txt`. `transformers>=5.0` changed `check_model_inputs` from a decorator factory (`@check_model_inputs()`) to a plain decorator (`@check_model_inputs`, i.e. `check_model_inputs(func)`). `qwen_tts`'s CustomVoice tokenizer (`qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py`) still calls the old convention, so once transformers gets silently bumped, loading Qwen CustomVoice raises:
   ```
   TypeError: check_model_inputs() missing 1 required positional argument: 'func'
   ```
   `--no-deps` avoids this entirely (mlx-lm's own transformers requirement is never consulted, so transformers stays at whatever `requirements.txt` installed) — which is exactly what `release.yml` already does, it just never made it into `justfile`.

3. Once mlx-audio *is* installed and the backend actually reaches MLX, every model load/generate/transcribe call runs through `asyncio.to_thread()`, which uses the event loop's default thread pool — no guarantee that two calls land on the same OS thread. MLX's Metal command encoder/stream is thread-local (bound to whichever thread first touched the GPU device), so if model load and a later `generate()` land on different pool threads, MLX raises:
   ```
   There is no Stream(gpu, 1) in current thread.
   ```
   This is #699, reproducible 100% of the time per the original report. Fix: pin every MLX call to one dedicated worker thread instead of the shared pool.

4. Along the way: `/health`'s `backend_variant` field never had a branch for `backend_type == "mlx"`, so it always reported `"cpu"` regardless of whether MLX was actually active — this is what #706 and #723 point at as evidence MLX wasn't using the GPU. Added the missing branch (`"mps"`). This is a reporting fix only; it doesn't address whatever's causing MLX-Metal generation to be slower than PyTorch-CPU on the hardware in those two reports specifically — I don't have that hardware to reproduce on, so I'm not claiming this closes them, just that the `backend_variant` field itself was lying.

## Changes

- `justfile`: add the two missing `pip install --no-deps` lines to the Unix `setup-python` recipe, mirroring `release.yml` exactly.
- `backend/requirements-mlx.txt`: add `sounddevice==0.5.3` (mlx-audio's own pin, previously unresolved on a from-scratch install), and a NOTE explaining why `mlx-lm`/`mlx-audio` are deliberately *not* listed here and must go through the `--no-deps` path instead.
- `backend/backends/mlx_backend.py`: dedicated single-worker `ThreadPoolExecutor` for all MLX calls (`_run_on_mlx_thread`), replacing the 4 `asyncio.to_thread()` call sites across `MLXTTSBackend` and `MLXSTTBackend`.
- `backend/routes/health.py`: 2-line addition — `elif backend_type == "mlx": default_variant = "mps"`.

## Testing

All verified on real Apple Silicon hardware (M4):

- Clean venv, ran `just setup-python` equivalent commands by hand (matching the justfile diff) → `mlx_audio` importable, `/health` reports `backend_type: "mlx"`, `backend_variant: "mps"` (previously `"pytorch"` / `"cpu"`).
- Multiple back-to-back `qwen` engine generations (model load + several `generate()` calls across different requests) with no `Stream(gpu, N)` crash.
- Qwen CustomVoice 0.6B: `pip install mlx-lm==0.31.1` (no `--no-deps`, reproducing the trap) → confirmed the exact `check_model_inputs()` TypeError from the report above. Reinstalled per this PR's `--no-deps` sequence → CustomVoice downloads, loads, and generates successfully.
- Regression-tested the base `qwen` MLX engine after the transformers fix to make sure it still works (it does — mlx_audio.tts doesn't touch qwen_tts at all, only the CustomVoice/PyTorch code path does).

Happy to adjust anything — this is my first PR against this repo, let me know if there's a preferred format for splitting these into separate PRs instead of one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MLX speech-to-text and text-to-speech stability on Apple Silicon by running blocking MLX tasks through a dedicated worker.
  - Prevented unintended network activity during MLX model/cache operations.
  - Fixed health check variant selection to correctly surface the MPS variant for the MLX backend.
  - Expanded device selection to use Apple MPS for PyTorch and Qwen custom voice backends, including clearing MPS cache during unload.

- **Chores**
  - Updated Apple Silicon dependency setup by pinning MLX backend packages (including audio) and the required sounddevice runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->