### PR TITLE
Add opt-in idle model unloading to free VRAM

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -113,6 +113,7 @@ from .database import get_db
 from .utils.platform_detect import get_backend_type
 from .utils.progress import get_progress_manager
 from .services.task_queue import create_background_task, init_queue
+from .services import idle_unload
 from .routes import register_routers
 
 
@@ -293,6 +294,7 @@ async def _run_startup(application: FastAPI) -> None:
     logger.info("Data directory: %s", config.get_data_dir())
 
     init_queue()
+    idle_unload.start()
 
     # Mark stale "generating" records as failed -- leftovers from a killed process
     from sqlalchemy import text as sa_text

--- a/backend/services/idle_unload.py
+++ b/backend/services/idle_unload.py
@@ -1,0 +1,98 @@
+"""Idle model unloading — free VRAM when no generation has run for a while.
+
+Models load on demand at generate time but are only ever unloaded explicitly
+(POST /models/unload) or at shutdown, so an idle instance pins its weights
+indefinitely — ~5.6GB for qwen-tts-1.7B, which is most of an 8GB card.
+
+This reaper unloads after a period of inactivity. It is OFF by default; set
+VOICEBOX_IDLE_UNLOAD_SECONDS to a positive number of seconds to enable it.
+
+Safety: idleness is read from the serial generation queue's own state, so a
+model is never pulled out from under queued or in-flight work. The next request
+simply reloads the model (the same cold-start cost already paid on first use).
+"""
+
+import asyncio
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+# Seconds of inactivity before unloading. <= 0 disables the reaper entirely.
+IDLE_UNLOAD_SECONDS = int(os.environ.get("VOICEBOX_IDLE_UNLOAD_SECONDS", "0") or 0)
+
+# How often to check. Kept well under the timeout so the granularity is decent.
+_POLL_SECONDS = 15
+
+_last_activity: float = time.monotonic()
+
+
+def mark_activity() -> None:
+    """Record generation activity, resetting the idle countdown."""
+    global _last_activity
+    _last_activity = time.monotonic()
+
+
+def _is_busy() -> bool:
+    """True if any generation is queued or running."""
+    from . import task_queue
+
+    return bool(
+        task_queue._queued_generation_ids or task_queue._running_generation_tasks
+    )
+
+
+def _unload_all() -> None:
+    """Unload every model type, isolating failures so one can't block the others
+    (mirrors the shutdown path in app.py)."""
+    from . import llm, transcribe, tts
+
+    for name, unload in (
+        ("TTS", tts.unload_tts_model),
+        ("Whisper", transcribe.unload_whisper_model),
+        ("LLM", llm.unload_llm_model),
+    ):
+        try:
+            unload()
+        except Exception:
+            logger.exception("Idle unload: failed to unload %s model", name)
+
+
+async def _reaper() -> None:
+    while True:
+        await asyncio.sleep(_POLL_SECONDS)
+
+        # Busy work keeps the model alive and re-arms the countdown, so a long
+        # generation can never be interrupted by the reaper.
+        if _is_busy():
+            mark_activity()
+            continue
+
+        idle_for = time.monotonic() - _last_activity
+        if idle_for < IDLE_UNLOAD_SECONDS:
+            continue
+
+        try:
+            from ..backends import get_tts_backend
+
+            if not get_tts_backend().is_loaded():
+                continue  # nothing loaded — nothing to do
+        except Exception:
+            continue
+
+        logger.info("Idle for %ds — unloading models to free memory", int(idle_for))
+        await asyncio.to_thread(_unload_all)
+        mark_activity()  # don't re-run every poll while still idle
+
+
+def start() -> None:
+    """Start the idle reaper if enabled. Call once at startup."""
+    if IDLE_UNLOAD_SECONDS <= 0:
+        return
+
+    from .task_queue import create_background_task
+
+    mark_activity()
+    create_background_task(_reaper())
+    logger.info("Idle model unloading enabled (%ds)", IDLE_UNLOAD_SECONDS)

--- a/backend/services/idle_unload.py
+++ b/backend/services/idle_unload.py
@@ -43,6 +43,32 @@ def _is_busy() -> bool:
     )
 
 
+def _anything_loaded() -> bool:
+    """True if any model _unload_all() frees is currently resident.
+
+    Checks every backend type, not just TTS: dictation loads Whisper and chat
+    loads the LLM without ever touching TTS, and those hold VRAM too. Each
+    getter is isolated so one failing backend can't mask a loaded sibling —
+    on error we assume loaded, letting _unload_all() (which isolates its own
+    failures) sort it out rather than pinning the weights forever.
+    """
+    from ..backends import get_llm_backend, get_stt_backend, get_tts_backend
+
+    for name, get_backend in (
+        ("TTS", get_tts_backend),
+        ("Whisper", get_stt_backend),
+        ("LLM", get_llm_backend),
+    ):
+        try:
+            if get_backend().is_loaded():
+                return True
+        except Exception:
+            logger.exception("Idle unload: failed to check %s backend", name)
+            return True
+
+    return False
+
+
 def _unload_all() -> None:
     """Unload every model type, isolating failures so one can't block the others
     (mirrors the shutdown path in app.py)."""
@@ -73,13 +99,8 @@ async def _reaper() -> None:
         if idle_for < IDLE_UNLOAD_SECONDS:
             continue
 
-        try:
-            from ..backends import get_tts_backend
-
-            if not get_tts_backend().is_loaded():
-                continue  # nothing loaded — nothing to do
-        except Exception:
-            continue
+        if not _anything_loaded():
+            continue  # nothing loaded — nothing to do
 
         logger.info("Idle for %ds — unloading models to free memory", int(idle_for))
         await asyncio.to_thread(_unload_all)

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -65,6 +65,12 @@ async def _generation_worker():
             _queued_generation_ids.discard(job.generation_id)
             _generation_queue.task_done()
 
+            # Every generation exits through here (success, failure or cancel),
+            # so this is the one place the idle countdown must be reset.
+            from .idle_unload import mark_activity
+
+            mark_activity()
+
 
 async def _force_fail_if_active(generation_id: str, error: str) -> None:
     """Best-effort recovery — flip an active row to failed if the worker


### PR DESCRIPTION
Closes #595 (the VRAM half of it — this adds the automatic trigger, not the manual load/unload UI button).

## Problem

On a headless/server deployment there's no way for models to unload automatically. They load on demand at generate time, but the only things that ever unload them are an explicit `POST /models/unload` or process shutdown (`app.py`). There's no idle path.

So an instance that served one request an hour ago is still pinning its weights — ~5.6GB for qwen-tts-1.7B, which is most of an 8GB card. Anything else sharing that GPU is starved until you restart the container or remember to call the endpoint by hand.

## Change

An asyncio reaper that unloads models after a period of inactivity.

- **Off by default.** Gated on `VOICEBOX_IDLE_UNLOAD_SECONDS`; `0`/unset disables it entirely, so existing behaviour is unchanged for anyone who doesn't opt in.
- **Reuses the existing unload primitives** — the same `tts` / `transcribe` / `llm` unload calls already used on shutdown, with per-model failure isolation so one failure can't block the others.
- **Can't race in-flight work.** "Idle" is read from the serial generation queue's own state (`_queued_generation_ids` / `_running_generation_tasks`), not inferred externally, so a model is never pulled out from under a queued or running generation. A long generation continually re-arms the countdown.
- The next request reloads the model transparently — it just pays the cold-start it already pays on first use.

Three files: a new `backend/services/idle_unload.py`, two lines in `app.py` to start it, and a `mark_activity()` call in the generation worker's `finally` block (the one place every generation exits through, success/failure/cancel alike).

## Testing

Manual, on an RTX 2060 Super (8GB), Docker/CUDA, qwen-tts-1.7B:

| phase | GPU memory |
|---|---|
| baseline, nothing loaded | 442 MiB |
| model loaded, idle | 5166 MiB |
| after reaper fires | 874 MiB |

Reclaims ~4.3GB of resident model weights. Verified separately that:

- the reaper does **not** fire during a running generation (watched it hold off across a ~200s job that peaked at 6504 MiB, with a 120s idle timeout that would otherwise have been eligible mid-job);
- the model **reloads correctly** on the next request after an auto-unload, and that generation completes (`status=completed`, no errors);
- with the env var unset, the reaper never starts.

I did not run Black across the touched files — `app.py` has pre-existing formatting drift (the `all_origins` CORS block) and reformatting it would add unrelated churn to this diff. The new file and my `task_queue.py` edit are both Black-clean on their own.

---

Disclosure: this patch was written with AI assistance (Claude), as was this description. It's tested end-to-end on my own build and the numbers above are real measurements from my hardware, not generated. If AI-assisted contributions aren't welcome here I understand — happy for this to be closed, and it stays a local patch on my build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic unloading of speech recognition, text-to-speech, and language models after a configurable idle period.
  * Unloading is coordinated with generation activity to avoid interrupting queued or in-progress work.
  * Idle activity tracking resets after each generation attempt, including failures and cancellations.
  * Model resources are released independently so an issue unloading one model does not block others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->