### PR TITLE
fix(mcp): add model_size parameter to voicebox.speak

### DIFF
--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -12,7 +12,7 @@ import base64 as b64
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastmcp import FastMCP
 
@@ -49,6 +49,7 @@ def register_tools(mcp: FastMCP) -> None:
         engine: str | None = None,
         personality: bool | None = None,
         language: str | None = None,
+        model_size: Literal["1.7B", "0.6B", "1B", "3B"] | None = None,
     ) -> dict[str, Any]:
         """Speak ``text`` in a voice profile.
 
@@ -61,6 +62,12 @@ def register_tools(mcp: FastMCP) -> None:
         LLM before TTS. When omitted, the per-client binding's
         ``default_personality`` flag decides; when that is unset, the
         default is plain TTS.
+
+        ``model_size`` selects a model variant for engines that ship more
+        than one — ``qwen`` and ``qwen_custom_voice`` accept "1.7B" (default)
+        or "0.6B"; ``tada`` accepts "1B" or "3B". Other engines ignore it.
+        Omit to use the engine default. Requesting a smaller variant (e.g.
+        "0.6B") is faster and avoids reloading a heavier model between calls.
         """
         from ..database.models import MCPClientBinding
 
@@ -99,6 +106,7 @@ def register_tools(mcp: FastMCP) -> None:
                 engine=resolved_engine,
                 language=language,
                 personality=use_persona,
+                model_size=model_size,
                 db=db,
             )
         finally:
@@ -228,18 +236,23 @@ async def _speak(
     engine: str | None,
     language: str | None,
     personality: bool,
+    model_size: str | None = None,
     db,
 ) -> dict[str, Any]:
     """Delegate to POST /generate — the route handles personality-rewrite
     internally when ``personality=true`` and the profile has a prompt."""
     from ..routes.generations import generate_speech
 
+    # model_size=None is intentional: generate_speech normalizes it to the
+    # engine default (see routes/generations.py), so an omitted size behaves
+    # exactly like the REST /generate endpoint with no model_size in the body.
     req = models.GenerationRequest(
         profile_id=profile_id,
         text=text,
         language=language or "en",
         engine=engine,
         personality=personality,
+        model_size=model_size,
     )
     generation = await generate_speech(req, db)
     return _speak_response(generation, profile_name, source="mcp")

--- a/backend/tests/test_mcp_speak.py
+++ b/backend/tests/test_mcp_speak.py
@@ -1,0 +1,91 @@
+"""Tests for the voicebox.speak MCP tool's ``model_size`` plumbing (issue #884).
+
+The MCP speak path used to build its ``GenerationRequest`` without a
+``model_size``, so every agent-triggered generation silently fell back to the
+schema default ("1.7B") — there was no way to reach 0.6B (or TADA's 1B/3B)
+through MCP. These tests pin the fix: ``_speak`` now forwards ``model_size``
+straight into the request, matching the REST ``/generate`` surface.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+import backend.routes.generations as generations
+from backend.mcp_server import tools
+
+
+class _FakeGeneration:
+    """Minimal stand-in for GenerationResponse consumed by ``_speak_response``."""
+
+    def model_dump(self, mode="json"):
+        return {"id": "gen-test", "status": "generating"}
+
+
+@pytest.fixture
+def captured_request(monkeypatch):
+    """Replace the real (torch-backed) generate_speech with a capturing stub.
+
+    ``_speak`` imports ``generate_speech`` lazily from ``routes.generations``,
+    so patching the attribute on that module intercepts the call and lets us
+    inspect the ``GenerationRequest`` it would have run.
+    """
+    captured = {}
+
+    async def fake_generate_speech(req, db):
+        captured["req"] = req
+        return _FakeGeneration()
+
+    monkeypatch.setattr(generations, "generate_speech", fake_generate_speech)
+    # Isolate the unit from the MCP event bus — _speak_response fires a
+    # speak-start event we don't care about here.
+    monkeypatch.setattr(tools.mcp_events, "publish", lambda *a, **k: None)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_speak_forwards_explicit_model_size(captured_request):
+    await tools._speak(
+        profile_id="p1",
+        profile_name="Morgan",
+        text="hello",
+        engine="qwen",
+        language="en",
+        personality=False,
+        model_size="0.6B",
+        db=None,
+    )
+    assert captured_request["req"].model_size == "0.6B"
+
+
+@pytest.mark.asyncio
+async def test_speak_omitted_model_size_is_none(captured_request):
+    # Omitted → None; generate_speech normalizes None to the engine default,
+    # so this reproduces the pre-fix behaviour for callers that don't ask.
+    await tools._speak(
+        profile_id="p1",
+        profile_name="Morgan",
+        text="hello",
+        engine="qwen",
+        language="en",
+        personality=False,
+        db=None,
+    )
+    assert captured_request["req"].model_size is None
+
+
+@pytest.mark.asyncio
+async def test_speak_rejects_invalid_model_size(captured_request):
+    # The GenerationRequest schema pattern is the single source of truth for
+    # valid sizes; a bad value is rejected before any generation runs.
+    with pytest.raises(ValidationError):
+        await tools._speak(
+            profile_id="p1",
+            profile_name="Morgan",
+            text="hello",
+            engine="qwen",
+            language="en",
+            personality=False,
+            model_size="9B",
+            db=None,
+        )
+    assert "req" not in captured_request


### PR DESCRIPTION
## What & why

The MCP `voicebox.speak` tool built its `GenerationRequest` without a
`model_size`, so it always fell back to the schema default (`"1.7B"`). As
reported in #884, there was no way to reach the 0.6B Qwen variant — or TADA's
1B/3B — through MCP, and repeated calls at a non-default size thrashed the
model cache by reloading on every request.

## Change

- Add an optional `model_size` parameter to `voicebox.speak` and thread it
  through the `_speak` helper into `GenerationRequest`, matching the REST
  `/generate` surface the issue references.
- When omitted, `model_size` is `None`; `generate_speech` already normalizes
  `None` to the engine default (see `routes/generations.py`), so behaviour is
  unchanged for callers that don't set it — this mirrors a REST `/generate`
  body with no `model_size`.
- The `GenerationRequest` schema pattern (`1.7B|0.6B|1B|3B`) stays the single
  source of truth for validation; engines without multiple sizes ignore it, as
  before.
- Documented the new parameter in the tool docstring so it surfaces to MCP
  clients.

Scope is intentionally limited to the MCP tool per the issue. The REST
`POST /speak` (`SpeakRequest`) mirror has the same gap — happy to follow up in a
separate PR if you'd like.

## Tests

Added `backend/tests/test_mcp_speak.py`:

- forwards an explicit `model_size` into the request
- omitted `model_size` stays `None` (regression guard for the default path)
- invalid size raises `ValidationError` before any generation runs

Verified these three behaviours pass locally against the real `_speak` and
`GenerationRequest` (with `generate_speech` mocked, as the test does).

## Changelog

Left `CHANGELOG.md` untouched (its header says it is auto-compiled at release).
Suggested entry:

> MCP `voicebox.speak` now accepts `model_size` (qwen: 1.7B/0.6B, tada: 1B/3B).

Fixes #884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional model size setting to voice generation requests.
  * Supported engines can now select specific model variants, while other engines continue using their default size.
  * Validation feedback is provided for invalid model size values.

* **Tests**
  * Added coverage for explicit, omitted, and invalid model size settings for the voice generation tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->