### PR TITLE
Fix: keep the uploaded file extension when transcribing

### DIFF
--- a/backend/routes/transcription.py
+++ b/backend/routes/transcription.py
@@ -15,6 +15,10 @@ router = APIRouter()
 
 UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1MB
 
+# Same set profiles.py accepts for voice samples. librosa picks its decoder from the
+# file extension, so the temp file has to keep the uploaded one.
+ALLOWED_AUDIO_EXTS = {".wav", ".mp3", ".m4a", ".ogg", ".flac", ".aac", ".webm", ".opus"}
+
 
 @router.post("/transcribe", response_model=models.TranscriptionResponse)
 async def transcribe_audio(
@@ -23,7 +27,10 @@ async def transcribe_audio(
     model: str | None = Form(None),
 ):
     """Transcribe audio file to text."""
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+    uploaded_ext = Path(file.filename or "").suffix.lower()
+    file_suffix = uploaded_ext if uploaded_ext in ALLOWED_AUDIO_EXTS else ".wav"
+
+    with tempfile.NamedTemporaryFile(suffix=file_suffix, delete=False) as tmp:
         while chunk := await file.read(UPLOAD_CHUNK_SIZE):
             tmp.write(chunk)
         tmp_path = tmp.name


### PR DESCRIPTION
## The bug

`POST /transcribe` writes every upload to a temp file named `.wav`, whatever the file actually is:

```python
with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
```

`load_audio` calls `librosa.load`, which picks its decoder from the extension. So an `.m4a` (or `.mp3`, `.flac`, `.ogg`) upload is handed to the wav decoder and dies:

```
{"detail":"could not open/decode file"}
```

The formats work everywhere else in the app, so this reads as "Voicebox cannot transcribe my recording" rather than "the temp file was misnamed". I hit it trying to transcribe an `.m4a` voice memo to use as a cloning reference.

## The fix

`profiles.py` already solves exactly this for voice samples (lines 161-165): keep the uploaded extension when it is one of the audio types accepted, and fall back to `.wav` otherwise. This applies the same approach, with the same set, to `/transcribe`.

The fallback matters: an unknown or missing extension still becomes `.wav`, so today's behaviour is unchanged for anything that already worked, and an unexpected filename can never inject an arbitrary suffix.

## Verification

The strongest evidence is that your own code already proves it. `POST /profiles/{id}/samples` keeps the uploaded extension, `POST /transcribe` does not, and they share `load_audio`. Same server, same file:

- the `.m4a` posted to `/profiles/{id}/samples` → **200**, decoded and transcoded to wav
- the same `.m4a` posted to `/transcribe` → `could not open/decode file`
- the same audio converted to wav and posted to `/transcribe` → **200**, transcribed fine

So the only difference between the path that works and the path that fails is the temp file's name.

I also checked the suffix selection across the cases that matter: `Sepa.m4a` → `.m4a`, `clip.MP3` → `.mp3` (case-insensitive), `noext` → `.wav`, `evil.exe` → `.wav`, and empty/None filenames → `.wav`.

Tested against v0.3.x on macOS (MLX). I could not run the patched server itself, since my system Python does not have the backend's dependencies and I was testing against the bundled `voicebox-server` binary, so the end-to-end confirmation above is on the shipped build rather than this patch. The change is small enough to read, but worth saying plainly.

## One thing I deliberately did not do

That extension set now exists in four places, and three of them disagree:

| Where | Set |
| --- | --- |
| `routes/generations.py:25` | no `.opus` |
| `routes/profiles.py:161` | has `.opus` |
| `services/captures.py:75` | no `.aac`, no `.opus` |
| `routes/transcription.py` (this PR) | copied from `profiles.py` |

Unifying them would change which formats three unrelated endpoints accept, which felt like the wrong thing to smuggle into a bug fix. Happy to send that as a separate PR if you want it, or to point this one at a shared constant instead if you would rather it not add a fourth copy.

## Unrelated, while I was in here

`whisper-turbo` reliably 500s on MLX with `There is no Stream(gpu, 2) in current thread`, and can take the process down; `base` and `small` work. I can reproduce it consistently but do not understand the MLX threading here well enough to propose a fix, so I have left it out rather than guess. Happy to file it as an issue with the reproduction if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio transcription compatibility by preserving supported uploaded audio file extensions.
  * Added a safe fallback to WAV when an extension is missing or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->