### PR TITLE
fix(linux): startup crash — click-through toggle aborts on unrealized GTK window

### DIFF
--- a/tauri/src-tauri/src/hotkey_monitor.rs
+++ b/tauri/src-tauri/src/hotkey_monitor.rs
@@ -264,6 +264,9 @@ fn apply_effect(app: &AppHandle, effect: Effect) {
                         let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
                     }
                 }
+                // Skip on Linux: aborts if the window was never realized
+                // (see show_dictate_window in main.rs).
+                #[cfg(not(target_os = "linux"))]
                 let _ = window.set_ignore_cursor_events(false);
                 // Deliberately no set_focus() — taking key focus would yank
                 // it out of whatever app the user was typing in, which is

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -112,6 +112,10 @@ pub fn show_dictate_window(app: &tauri::AppHandle) {
             let _ = window.set_position(PhysicalPosition::new(x, y));
         }
     }
+    // Skip on Linux: tao's CursorIgnoreEvents handler unwraps the GdkWindow,
+    // which is None until the window is first shown, aborting the process.
+    // The click-through toggle is a macOS workaround and is never set on Linux.
+    #[cfg(not(target_os = "linux"))]
     let _ = window.set_ignore_cursor_events(false);
     let _ = window.show();
 }
@@ -1421,6 +1425,9 @@ pub fn run() {
                 let handle_for_hide = app.handle().clone();
                 app.handle().listen("dictate:hide", move |_event| {
                     if let Some(window) = handle_for_hide.get_webview_window(DICTATE_WINDOW_LABEL) {
+                        // Skip on Linux: aborts if the window was never realized
+                        // (see show_dictate_window).
+                        #[cfg(not(target_os = "linux"))]
                         let _ = window.set_ignore_cursor_events(true);
                         let _ = window.set_position(PhysicalPosition::new(-10_000, -10_000));
                         let _ = window.hide();


### PR DESCRIPTION
## Problem

On Linux, Voicebox aborts (SIGABRT) within seconds of launch, on both Wayland and X11:

```
thread 'main' panicked at tao-0.34.5/src/platform_impl/linux/event_loop.rs:449:18:
called `Option::unwrap()` on a `None` value
thread 'main' panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
```

## Cause

The dictate pill window is built **hidden** at setup (`.visible(false)`), so GTK never realizes it — it has no underlying `GdkWindow`. As soon as the pill webview mounts, the frontend emits `dictate:hide` (DictateWindow.tsx enters the `hidden` state), and the Rust handler calls `window.set_ignore_cursor_events(true)`. tao's `WindowRequest::CursorIgnoreEvents` path does `window.window().unwrap()` on the unrealized window → `None` → panic inside a glib dispatch that cannot unwind → process abort.

This affects every Linux user at startup; the realization behavior is identical on X11 and Wayland.

## Fix

Gate the three `set_ignore_cursor_events` call sites behind `#[cfg(not(target_os = "linux"))]`. The click-through toggle exists as a macOS workaround (transparent always-on-top NSWindows lingering as invisible click targets — see the existing comments); on GTK, `hide()` unmaps the window and unmapped windows can't receive input, and the window is parked at (-10_000, -10_000) besides. Gating both the `true` and `false` calls keeps the state balanced: never set, never needs unsetting.

macOS and Windows compile byte-identical code to before — zero behavior change outside Linux.

## Testing

- Reproduced the abort on Fedora 44 (Wayland, GNOME) with 3 coredumps confirming the same stack.
- With this patch the app launches, spawns the sidecar, serves `/health`, and runs through TTS generation without the abort.

A cleaner long-term fix would be tao handling unrealized windows gracefully in `CursorIgnoreEvents` instead of unwrapping; this PR is the pragmatic app-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Related issues

Fixes #873 (same crash, same diagnosis — `set_ignore_cursor_events` on the transparent dictate window, tao 0.34.5 `event_loop.rs:449`).
Fixes #680 (same panic at startup on Kubuntu 24.04 / X11 — confirms this is not Wayland-specific).
Likely also resolves #803 (same unwrap in tao 0.35.3 at its shifted line 457, reported as Wayland+NVIDIA — worth a retest with this patch rather than auto-closing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Linux startup crash that could occur when opening the dictation window.
  * Improved dictation window show and hide behavior on Linux by avoiding an unsupported cursor-interaction setting during window initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->