### PR TITLE
Fix docker build failing on the missing rocm entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ landing/
 docs/
 mlx-test/
 scripts/
+!scripts/rocm-entrypoint.sh
 
 # Dependencies & build artifacts (rebuilt in Docker)
 node_modules/


### PR DESCRIPTION
When you build the image with docker compose up, the build stops with an error saying scripts/rocm-entrypoint.sh could not be found (copier stat, no such file or directory).

The reason is that the Dockerfile copies scripts/rocm-entrypoint.sh into the image, but .dockerignore excludes the entire scripts/ directory, so the file is stripped from the build context before the copy can happen. This breaks the main Dockerfile for everyone, not just the rocm overlay.

The fix keeps scripts/ ignored but lets the one file the image actually depends on through, scripts/rocm-entrypoint.sh. Everything else in scripts/ stays excluded as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the ROCm container entrypoint script is included in Docker builds, preventing it from being accidentally excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->