### PR TITLE
Fix model cache permission error on startup

### DIFF
--- a/scripts/rocm-entrypoint.sh
+++ b/scripts/rocm-entrypoint.sh
@@ -12,4 +12,11 @@ for dev in /dev/kfd /dev/dri/render*; do
     }
     usermod -aG "$grp" voicebox
 done
+
+# Named volumes are created root-owned when the mount path is absent from the
+# image, so the HuggingFace cache can end up unwritable by the app user.
+# Create and hand it over before dropping privileges.
+mkdir -p /home/voicebox/.cache/huggingface
+chown -R voicebox:voicebox /home/voicebox/.cache
+
 exec gosu voicebox "$@"


### PR DESCRIPTION
When the app starts it runs as the voicebox user, but the model cache directory ends up owned by root, so the first model download fails with a permission error.

This happens because the cache is a named volume mounted at a path that does not exist in the image, so it gets created owned by root. The fix creates and owns the directory in the entrypoint before the app user takes over, which repairs it on every start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hugging Face cache permissions so the application can write to the cache when using newly created volumes.
  * Improved startup reliability when running the service with restricted privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->