### PR TITLE
fix: extend MLX thread-affinity fix (#886) to the Qwen3 LLM backend

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -171,10 +171,10 @@ def check_cuda_compatibility() -> tuple[bool, str | None]:
 
 def empty_device_cache(device: str) -> None:
     """
-    Free cached memory on the given device (CUDA or XPU).
+    Free cached memory on the given device (CUDA, XPU, or MPS).
 
-    Backends should call this after unloading models so VRAM is returned
-    to the OS.
+    Backends should call this after unloading models so VRAM/unified
+    memory is returned to the OS.
     """
     import torch
 
@@ -182,6 +182,8 @@ def empty_device_cache(device: str) -> None:
         torch.cuda.empty_cache()
     elif device == "xpu" and hasattr(torch, "xpu"):
         torch.xpu.empty_cache()
+    elif device == "mps" and hasattr(torch, "mps"):
+        torch.mps.empty_cache()
 
 
 def manual_seed(seed: int, device: str) -> None:

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -5,10 +5,26 @@ MLX backend implementation for TTS and STT using mlx-audio.
 from typing import Optional, List, Tuple
 import asyncio
 import logging
+from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# MLX's Metal command encoder/stream is thread-local: it's bound to
+# whichever thread first touches the GPU device. asyncio.to_thread() uses
+# the loop's default executor, which can (and does) hand different calls
+# to different worker threads — model load on one thread, then generate()
+# on another raises "There is no Stream(gpu, N) in current thread." Pin
+# every MLX call to the same single dedicated worker instead.
+# See https://github.com/jamiepine/voicebox/issues/699
+_mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-worker")
+
+
+def _run_on_mlx_thread(func, *args):
+    """Run ``func(*args)`` on the single dedicated MLX worker thread."""
+    loop = asyncio.get_running_loop()
+    return loop.run_in_executor(_mlx_executor, func, *args)
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage
 # This prevents mlx_audio from making network requests when models are cached
@@ -81,8 +97,8 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size != model_size:
             self.unload_model()
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX thread
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -258,8 +274,8 @@ class MLXTTSBackend:
 
             return audio, sample_rate
 
-        # Run blocking inference in thread pool
-        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        # Run blocking inference on the dedicated MLX thread
+        audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
 
         return audio, sample_rate
 
@@ -292,8 +308,8 @@ class MLXSTTBackend:
         if self.model is not None and self.model_size == model_size:
             return
 
-        # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        # Run blocking load on the dedicated MLX thread
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -363,5 +379,5 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        # Run blocking transcription on the dedicated MLX thread
+        return await _run_on_mlx_thread(_transcribe_sync)

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -93,9 +93,11 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size == model_size:
             return
 
-        # Unload existing model if different size requested
+        # Unload existing model if different size requested — routed
+        # through the same dedicated thread as load/generate so it stays
+        # serialized with any in-flight MLX call (see _run_on_mlx_thread).
         if self.model is not None and self._current_model_size != model_size:
-            self.unload_model()
+            await _run_on_mlx_thread(self.unload_model)
 
         # Run blocking load on the dedicated MLX thread
         await _run_on_mlx_thread(self._load_model_sync, model_size)

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -34,7 +34,7 @@ class PyTorchTTSBackend:
 
     def _get_device(self) -> str:
         """Get the best available device."""
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -256,7 +256,7 @@ class PyTorchSTTBackend:
 
     def _get_device(self) -> str:
         """Get the best available device."""
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -65,7 +65,7 @@ class QwenCustomVoiceBackend:
         self._current_model_size: Optional[str] = None
 
     def _get_device(self) -> str:
-        return get_torch_device(allow_xpu=True, allow_directml=True)
+        return get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True)
 
     def is_loaded(self) -> bool:
         return self.model is not None

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -25,6 +25,7 @@ from . import TTSBackend, LANGUAGE_CODE_TO_NAME
 from .base import (
     is_model_cached,
     get_torch_device,
+    empty_device_cache,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
 )
@@ -127,8 +128,7 @@ class QwenCustomVoiceBackend:
             self.model = None
             self._current_model_size = None
 
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            empty_device_cache(self.device)
 
             logger.info("Qwen CustomVoice unloaded")
 

--- a/backend/backends/qwen_llm_backend.py
+++ b/backend/backends/qwen_llm_backend.py
@@ -209,10 +209,15 @@ class MLXQwenLLMBackend:
         if self.model is not None and self._current_model_size == model_size:
             return
 
-        if self.model is not None and self._current_model_size != model_size:
-            self.unload_model()
+        # Routed through the same dedicated MLX thread as TTS/STT — MLX's
+        # Metal stream is thread-local, so load and generate must run on
+        # one thread (see mlx_backend._run_on_mlx_thread / issue #699).
+        from .mlx_backend import _run_on_mlx_thread
 
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        if self.model is not None and self._current_model_size != model_size:
+            await _run_on_mlx_thread(self.unload_model)
+
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     def _load_model_sync(self, model_size: str) -> None:
         from mlx_lm import load as mlx_load
@@ -255,7 +260,9 @@ class MLXQwenLLMBackend:
         examples: Optional[list[tuple[str, str]]] = None,
     ) -> str:
         await self.load_model(model_size)
-        return await asyncio.to_thread(
+        from .mlx_backend import _run_on_mlx_thread
+
+        return await _run_on_mlx_thread(
             self._generate_sync, prompt, system, max_tokens, temperature, examples
         )
 

--- a/backend/requirements-mlx.txt
+++ b/backend/requirements-mlx.txt
@@ -9,14 +9,42 @@ mlx>=0.30.0
 # M1 installs with `ModuleNotFoundError: miniaudio` (issue #505).
 miniaudio>=1.59
 
-# NOTE: mlx-audio is intentionally not listed here. From 0.3.1 onward it
-# declares `transformers==5.0.0rc3` / `>=5.0.0`, which conflicts with the
-# `transformers<=4.57.6` cap in requirements.txt and breaks CI's clean
-# resolver. The mlx-audio API surface we use (mlx_audio.tts.load,
-# mlx_audio.stt.load) works fine on transformers 4.57.x in practice.
+# sounddevice is a runtime dep of mlx-audio (device enumeration for its
+# playback helpers). mlx-audio 0.4.1 pins sounddevice==0.5.3 exactly; not
+# listing it here left it unresolved on a from-scratch install, which
+# doesn't crash immediately but leaves pip's resolver warning about a
+# missing dependency and mlx-audio's playback helper unusable.
+sounddevice==0.5.3
+
+# NOTE: mlx-lm and mlx-audio are intentionally not listed here — both are
+# installed separately with --no-deps (see `just setup-python` and
+# .github/workflows/release.yml), NOT via this requirements file. From
+# 0.30.0 onward mlx-lm declares `transformers>=5.0.0` (mlx-audio>=0.3.1
+# does the same), which conflicts with the `transformers<=4.57.6` cap in
+# requirements.txt. A plain `pip install -r` here would let pip resolve
+# mlx-lm freely and silently upgrade transformers past that cap, which
+# breaks the qwen_tts (PyTorch) engines at *runtime*, not install time:
+# qwen_tts's `@check_model_inputs()` call site
+# (qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py) uses
+# the pre-5.0 signature (a decorator factory called with no arguments).
+# transformers>=5.0 changed `check_model_inputs` to a plain decorator
+# (`check_model_inputs(func)`, no parens at the call site), so loading
+# Qwen CustomVoice through qwen_tts on the newer transformers raises
+# `TypeError: check_model_inputs() missing 1 required positional
+# argument: 'func'`.
 #
-# Install it via `pip install --no-deps mlx-audio==0.4.1` after this file
-# (see .github/workflows/release.yml). Most other mlx-audio runtime deps
-# (huggingface_hub, librosa, mlx-lm, numba, numpy, protobuf, pyloudnorm,
-# sounddevice, tqdm) are already in requirements.txt or pulled in by
-# other engines.
+# Install mlx-lm and mlx-audio via:
+#   pip install --no-deps mlx-lm==0.31.1
+#   pip install --no-deps mlx-audio==0.4.1
+# --no-deps means both packages' own `transformers>=5.0.0` requirement is
+# never consulted, so transformers stays at whatever requirements.txt
+# installed. The mlx_audio.tts/mlx_audio.stt API surface we use works
+# fine against transformers 4.57.x in practice (verified in dev and CI).
+# `just setup-python` previously installed this file's contents (mlx +
+# miniaudio + sounddevice) and stopped — mlx_lm and mlx_audio were never
+# installed at all, so the backend silently fell back to the PyTorch
+# backend on Apple Silicon instead of MLX (issue #823), and once mlx_lm
+# was installed by hand without --no-deps (the obvious fix to try), it
+# reintroduced the transformers conflict above (issue #699 is the
+# MLX-generation-side symptom of the same root cause). See the two
+# `pip install --no-deps` lines added to `just setup-python` below.

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -175,6 +175,8 @@ async def health():
             default_variant = "cuda"
     elif has_xpu:
         default_variant = "xpu"
+    elif backend_type == "mlx":
+        default_variant = "mps"
 
     return models.HealthResponse(
         status="healthy",

--- a/justfile
+++ b/justfile
@@ -72,6 +72,14 @@ setup-python:
     if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" = "Darwin" ]; then
         echo "Detected Apple Silicon — installing MLX dependencies..."
         {{ pip }} install -r {{ backend_dir }}/requirements-mlx.txt
+        # mlx-lm and mlx-audio are installed --no-deps and separately from
+        # requirements-mlx.txt on purpose — see the NOTE at the bottom of
+        # that file. Without this step the backend silently falls back to
+        # the PyTorch backend on Apple Silicon (issue #823), and installing
+        # mlx-lm without --no-deps upgrades transformers past the
+        # requirements.txt cap and breaks qwen_tts at runtime (issue #699).
+        {{ pip }} install --no-deps mlx-lm==0.31.1
+        {{ pip }} install --no-deps mlx-audio==0.4.1
     fi
     {{ pip }} install git+https://github.com/QwenLM/Qwen3-TTS.git
     {{ pip }} install pyinstaller ruff pytest pytest-asyncio -q


### PR DESCRIPTION
## Summary

**Builds on #886** (its three commits are included here) — extends the dedicated-MLX-thread fix to the one backend it missed: `MLXQwenLLMBackend`.

#886 pins TTS and STT MLX calls to a single worker thread, but the Qwen3 LLM backend (`backend/backends/qwen_llm_backend.py`) still dispatches `load_model`/`generate` through `asyncio.to_thread()`. Result: with #886 applied, TTS and STT work, but `POST /llm/generate` (personality Compose/Rewrite, dictation refinement, `voicebox.speak` with `personality: true`) still fails 100% with the same error, raised from `mlx_lm.generate`'s `wired_limit` context manager on exit:

```
RuntimeError: There is no Stream(gpu, 0) in current thread.
```

## Fix

Route the MLX LLM backend's unload/load/generate through the same `_run_on_mlx_thread` helper #886 introduces, so every MLX call in the process (TTS, STT, and LLM) shares the one dedicated worker thread. Sharing a single serialized worker also matches the app's "one LLM, one model cache, one GPU-memory footprint" design.

## Verification

Apple M3 Pro, macOS 26.5 (Darwin 25.5.0), Python 3.12.8, `mlx 0.32.0` / `mlx-lm 0.31.1` / `mlx-audio 0.4.1`, Qwen3 0.6B (4-bit MLX):

- Before: `POST /llm/generate` → 500, traceback above, 100% repro from a fresh backend start.
- After: `POST /llm/generate` returns generated text; repeated calls stable.
- Regression check: Qwen3-TTS 1.7B `/generate` and Whisper Turbo `/transcribe` still work after the change (round-trip verified: generated audio transcribes back to the input text).

Happy to rebase/fold into #886 if @AlexStephenLytton prefers to pick the commit into that branch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Silicon MPS support for PyTorch and Qwen voice backends.
  * MLX health checks now report the MPS backend variant.

* **Bug Fixes**
  * Improved MLX model loading, speech generation, and transcription reliability.
  * Added MPS memory cleanup when models are unloaded.
  * Improved Apple Silicon setup and audio-device detection.

* **Chores**
  * Updated Apple Silicon installation steps and runtime requirements for MLX features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->