### PR TITLE
fix(dictation): warm the mic so push-to-talk doesn't clip the first words

### DIFF
--- a/app/src/components/DictateWindow/DictateWindow.tsx
+++ b/app/src/components/DictateWindow/DictateWindow.tsx
@@ -42,6 +42,10 @@ export function DictateWindow() {
   const focusRef = useRef<FocusSnapshot | null>(null);
 
   const session = useCaptureRecordingSession({
+    // This floating window is always mounted, so keeping the mic warm here
+    // removes the first-words clipping on push-to-talk without holding the
+    // device open from the main app window.
+    keepMicWarm: true,
     onFinalText: async (text, _capture, allowAutoPaste) => {
       const focus = focusRef.current;
       // Consume-once: a second chord before this fires would overwrite
@@ -141,9 +145,7 @@ export function DictateWindow() {
     audio.onplaying = () => {
       emit('dictate:show').catch(() => {});
       setSpeaking((prev) =>
-        prev && prev.generationId === generationId
-          ? { ...prev, startedAt: Date.now() }
-          : prev,
+        prev && prev.generationId === generationId ? { ...prev, startedAt: Date.now() } : prev,
       );
       setSpeakElapsed(0);
     };

--- a/app/src/lib/hooks/useAudioRecording.ts
+++ b/app/src/lib/hooks/useAudioRecording.ts
@@ -5,11 +5,47 @@ import { convertToWav } from '@/lib/utils/audio';
 interface UseAudioRecordingOptions {
   maxDurationSeconds?: number;
   onRecordingComplete?: (blob: Blob, duration?: number) => void;
+  /**
+   * Keep the microphone ``MediaStream`` open between recordings instead of
+   * tearing it down on every stop. This is what removes the "first words get
+   * clipped" problem on push-to-talk dictation: ``getUserMedia`` on macOS can
+   * take several hundred ms — up to a second cold — to hand back a stream, and
+   * ``MediaRecorder`` only starts capturing *after* it resolves, so everything
+   * spoken in that window is lost. With a warm stream already open, the next
+   * ``startRecording`` skips ``getUserMedia`` entirely and ``MediaRecorder``
+   * captures from the first frame.
+   *
+   * Off by default so the voice-clone sample recorders (which record once and
+   * should release the device immediately) keep their existing behavior; only
+   * the dictation session opts in. When on, the stream is released after
+   * ``WARM_IDLE_RELEASE_MS`` of inactivity so the OS mic indicator doesn't stay
+   * lit forever when the user isn't dictating.
+   */
+  keepWarm?: boolean;
 }
+
+// Audio constraints for capture. Kept identical to the previous inline value so
+// this change is purely about *when* the stream is opened, not *how*.
+const AUDIO_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+};
+
+// How long a warm stream lingers after the last recording before it's released.
+// Long enough that back-to-back dictations reuse the same warm stream (no
+// clipping), short enough that the mic indicator clears soon after the user
+// stops. A follow-up could re-warm just-in-time on a chord-arming event from
+// Rust to also cover the first dictation after this window elapses.
+const WARM_IDLE_RELEASE_MS = 60_000;
+
+const streamHasLiveAudio = (stream: MediaStream | null): stream is MediaStream =>
+  !!stream && stream.getAudioTracks().some((t) => t.readyState === 'live');
 
 export function useAudioRecording({
   maxDurationSeconds,
   onRecordingComplete,
+  keepWarm = false,
 }: UseAudioRecordingOptions = {}) {
   const platform = usePlatform();
   const [isRecording, setIsRecording] = useState(false);
@@ -17,10 +53,91 @@ export function useAudioRecording({
   const [error, setError] = useState<string | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  // The stream currently backing the MediaRecorder. When ``keepWarm`` is set
+  // this is the same object as ``warmStreamRef`` and is *not* torn down on
+  // stop; otherwise it's stopped as soon as the recording completes.
   const streamRef = useRef<MediaStream | null>(null);
+  // Persistent pre-opened stream reused across recordings when ``keepWarm``.
+  const warmStreamRef = useRef<MediaStream | null>(null);
+  const idleReleaseTimerRef = useRef<number | null>(null);
   const timerRef = useRef<number | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const cancelledRef = useRef<boolean>(false);
+
+  const clearIdleRelease = useCallback(() => {
+    if (idleReleaseTimerRef.current !== null) {
+      window.clearTimeout(idleReleaseTimerRef.current);
+      idleReleaseTimerRef.current = null;
+    }
+  }, []);
+
+  const releaseWarmStream = useCallback(() => {
+    clearIdleRelease();
+    warmStreamRef.current?.getTracks().forEach((track) => {
+      track.stop();
+    });
+    warmStreamRef.current = null;
+  }, [clearIdleRelease]);
+
+  const scheduleIdleRelease = useCallback(() => {
+    if (!keepWarm) return;
+    clearIdleRelease();
+    idleReleaseTimerRef.current = window.setTimeout(() => {
+      idleReleaseTimerRef.current = null;
+      releaseWarmStream();
+    }, WARM_IDLE_RELEASE_MS);
+  }, [keepWarm, clearIdleRelease, releaseWarmStream]);
+
+  // Assert that getUserMedia is reachable, mirroring the previous inline guard
+  // (Tauri webviews occasionally expose ``navigator.mediaDevices`` a beat late).
+  const assertMediaDevices = useCallback(async () => {
+    if (typeof navigator === 'undefined') {
+      throw new Error('Navigator API is not available. This might be a Tauri configuration issue.');
+    }
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        throw new Error(
+          platform.metadata.isTauri
+            ? 'Microphone access is not available. Please ensure:\n1. The app has microphone permissions in System Settings (macOS: System Settings > Privacy & Security > Microphone)\n2. You restart the app after granting permissions\n3. You are using Tauri v2 with a webview that supports getUserMedia'
+            : 'Microphone access is not available. Please ensure you are using a secure context (HTTPS or localhost) and that your browser has microphone permissions enabled.',
+        );
+      }
+    }
+  }, [platform.metadata.isTauri]);
+
+  // Return a live capture stream, reusing the warm one when available so the
+  // hot path (chord-down → record) never waits on getUserMedia.
+  const acquireStream = useCallback(async (): Promise<MediaStream> => {
+    if (streamHasLiveAudio(warmStreamRef.current)) {
+      return warmStreamRef.current;
+    }
+    // A dead warm stream (device unplugged / tracks ended) — drop it and reopen.
+    if (warmStreamRef.current) releaseWarmStream();
+    await assertMediaDevices();
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: AUDIO_CONSTRAINTS,
+    });
+    if (keepWarm) warmStreamRef.current = stream;
+    return stream;
+  }, [assertMediaDevices, keepWarm, releaseWarmStream]);
+
+  /**
+   * Open the microphone ahead of the first recording so the initial dictation
+   * doesn't clip. No-op unless ``keepWarm`` is set. Safe to call repeatedly and
+   * safe to fail (e.g. permission not yet granted) — ``startRecording`` still
+   * surfaces a real error if capture is genuinely unavailable.
+   */
+  const prewarm = useCallback(async () => {
+    if (!keepWarm) return;
+    clearIdleRelease();
+    try {
+      await acquireStream();
+    } catch {
+      // Permission missing / device busy — recording will report it properly.
+    }
+    scheduleIdleRelease();
+  }, [keepWarm, clearIdleRelease, acquireStream, scheduleIdleRelease]);
 
   const startRecording = useCallback(async () => {
     try {
@@ -28,45 +145,10 @@ export function useAudioRecording({
       chunksRef.current = [];
       cancelledRef.current = false;
       setDuration(0);
+      clearIdleRelease();
 
-      // Check if getUserMedia is available
-      // In Tauri, navigator.mediaDevices might not be available immediately
-      if (typeof navigator === 'undefined') {
-        const errorMsg =
-          'Navigator API is not available. This might be a Tauri configuration issue.';
-        setError(errorMsg);
-        throw new Error(errorMsg);
-      }
-
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        // Try waiting a bit for Tauri webview to initialize
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-          console.error('MediaDevices check:', {
-            hasNavigator: typeof navigator !== 'undefined',
-            hasMediaDevices: !!navigator?.mediaDevices,
-            hasGetUserMedia: !!navigator?.mediaDevices?.getUserMedia,
-            isTauri: platform.metadata.isTauri,
-          });
-
-          const errorMsg = platform.metadata.isTauri
-            ? 'Microphone access is not available. Please ensure:\n1. The app has microphone permissions in System Settings (macOS: System Settings > Privacy & Security > Microphone)\n2. You restart the app after granting permissions\n3. You are using Tauri v2 with a webview that supports getUserMedia'
-            : 'Microphone access is not available. Please ensure you are using a secure context (HTTPS or localhost) and that your browser has microphone permissions enabled.';
-          setError(errorMsg);
-          throw new Error(errorMsg);
-        }
-      }
-
-      // Request microphone access
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-        },
-      });
-
+      // Reuse the warm stream when present (instant); otherwise open one now.
+      const stream = await acquireStream();
       streamRef.current = stream;
 
       // Create MediaRecorder with preferred MIME type
@@ -99,11 +181,17 @@ export function useAudioRecording({
 
         const webmBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
 
-        // Stop all tracks now that we have the data
-        streamRef.current?.getTracks().forEach((track) => {
-          track.stop();
-        });
-        streamRef.current = null;
+        // Release the device unless we're keeping it warm for the next capture.
+        // When warm, the tracks stay live and an idle timer will reclaim them.
+        if (keepWarm) {
+          streamRef.current = null;
+          scheduleIdleRelease();
+        } else {
+          streamRef.current?.getTracks().forEach((track) => {
+            track.stop();
+          });
+          streamRef.current = null;
+        }
 
         // Don't fire completion callback if the recording was cancelled
         if (wasCancelled) return;
@@ -162,7 +250,14 @@ export function useAudioRecording({
       setError(errorMessage);
       setIsRecording(false);
     }
-  }, [maxDurationSeconds, onRecordingComplete]);
+  }, [
+    maxDurationSeconds,
+    onRecordingComplete,
+    acquireStream,
+    keepWarm,
+    clearIdleRelease,
+    scheduleIdleRelease,
+  ]);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {
@@ -185,25 +280,37 @@ export function useAudioRecording({
       setDuration(0);
     }
 
-    // Stop all tracks
-    streamRef.current?.getTracks().forEach((track) => {
-      track.stop();
-    });
-    streamRef.current = null;
+    // Keep the device warm for the next capture when opted in; otherwise stop
+    // the tracks so the mic is released immediately.
+    if (keepWarm) {
+      streamRef.current = null;
+      scheduleIdleRelease();
+    } else {
+      streamRef.current?.getTracks().forEach((track) => {
+        track.stop();
+      });
+      streamRef.current = null;
+    }
 
     if (timerRef.current !== null) {
       clearInterval(timerRef.current);
       timerRef.current = null;
     }
-  }, []);
+  }, [keepWarm, scheduleIdleRelease]);
 
-  // Cleanup on unmount
+  // Cleanup on unmount — always fully release the device, warm or not.
   useEffect(() => {
     return () => {
       if (timerRef.current !== null) {
         clearInterval(timerRef.current);
       }
+      if (idleReleaseTimerRef.current !== null) {
+        window.clearTimeout(idleReleaseTimerRef.current);
+      }
       streamRef.current?.getTracks().forEach((track) => {
+        track.stop();
+      });
+      warmStreamRef.current?.getTracks().forEach((track) => {
         track.stop();
       });
     };
@@ -216,5 +323,6 @@ export function useAudioRecording({
     startRecording,
     stopRecording,
     cancelRecording,
+    prewarm,
   };
 }

--- a/app/src/lib/hooks/useCaptureRecordingSession.ts
+++ b/app/src/lib/hooks/useCaptureRecordingSession.ts
@@ -3,11 +3,7 @@ import { emit as tauriEmit } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PillState } from '@/components/CapturePill/CapturePill';
 import { apiClient } from '@/lib/api/client';
-import type {
-  CaptureListResponse,
-  CaptureResponse,
-  CaptureSource,
-} from '@/lib/api/types';
+import type { CaptureListResponse, CaptureResponse, CaptureSource } from '@/lib/api/types';
 import { useAudioRecording } from '@/lib/hooks/useAudioRecording';
 
 /**
@@ -55,6 +51,14 @@ export type CapturePillState = PillState | 'hidden';
 
 export interface UseCaptureRecordingSessionOptions {
   /**
+   * Keep the microphone warm between captures and pre-open it on mount, so
+   * push-to-talk dictation doesn't clip the first words while ``getUserMedia``
+   * initialises the device. Enabled by the always-mounted floating dictate
+   * window; left off for the main-window Dictate button, which records far
+   * less often and shouldn't hold the mic open in the background.
+   */
+  keepMicWarm?: boolean;
+  /**
    * Fired after a capture row is created on the server. Callers can use this
    * to select the new capture or emit a Tauri event to a sibling window.
    */
@@ -68,11 +72,7 @@ export interface UseCaptureRecordingSessionOptions {
    * lands after the user flips the toggle still uses the value the capture
    * was created under.
    */
-  onFinalText?: (
-    text: string,
-    capture: CaptureResponse,
-    allowAutoPaste: boolean,
-  ) => void;
+  onFinalText?: (text: string, capture: CaptureResponse, allowAutoPaste: boolean) => void;
 }
 
 export interface UseCaptureRecordingSessionResult {
@@ -221,11 +221,7 @@ export function useCaptureRecordingSession(
       } else {
         if (pillStateRef.current === 'transcribing') scheduleHidePill();
         if (capture.transcript_raw) {
-          onFinalTextRef.current?.(
-            capture.transcript_raw,
-            capture,
-            capture.allow_auto_paste,
-          );
+          onFinalTextRef.current?.(capture.transcript_raw, capture, capture.allow_auto_paste);
         }
       }
     },
@@ -249,7 +245,9 @@ export function useCaptureRecordingSession(
     startRecording: beginAudioRecording,
     stopRecording,
     error: recordError,
+    prewarm,
   } = useAudioRecording({
+    keepWarm: options.keepMicWarm ?? false,
     onRecordingComplete: (blob, recordedDuration) => {
       // Trigger-happy tap — MediaRecorder hasn't emitted a usable chunk yet
       // so the blob is empty or unparseable. Surface it as a transient pill
@@ -277,6 +275,13 @@ export function useCaptureRecordingSession(
       showError(recordError);
     }
   }, [recordError, showError]);
+
+  // Pre-open the mic once the session mounts so the very first dictation
+  // doesn't clip. Only meaningful when ``keepMicWarm`` is set (prewarm is a
+  // no-op otherwise); the warm stream self-releases after an idle window.
+  useEffect(() => {
+    if (options.keepMicWarm) void prewarm();
+  }, [options.keepMicWarm, prewarm]);
 
   const startRecording = useCallback(() => {
     if (isRecording) return;
@@ -308,8 +313,7 @@ export function useCaptureRecordingSession(
     [refineMutation],
   );
 
-  const pillElapsedMs =
-    pillState === 'recording' ? Math.round(duration * 1000) : frozenElapsedMs;
+  const pillElapsedMs = pillState === 'recording' ? Math.round(duration * 1000) : frozenElapsedMs;
 
   return {
     pillState,


### PR DESCRIPTION
## Problem

On push-to-talk dictation the **first ~1 second of speech — often the first few words — is clipped** on every capture. Steps to reproduce (macOS, Apple Silicon):

1. Configure a push-to-talk shortcut and grant Microphone / Accessibility / Input Monitoring.
2. Focus a text field, hold the shortcut and **start speaking immediately**.
3. Release. The transcript consistently drops the opening words.

## Root cause

`useAudioRecording.startRecording()` opens a **fresh** `getUserMedia` stream on every recording and stops its tracks again on every stop:

```ts
const stream = await navigator.mediaDevices.getUserMedia({ audio: {...} }); // slow on macOS
...
mediaRecorder.start(); // only starts capturing AFTER the await resolves
```

On macOS opening the input device takes several hundred ms — up to ~1s cold — and `MediaRecorder` only begins capturing once the promise resolves. Everything spoken in that window is lost, and because the stream is torn down after each capture, **every** dictation pays the cost, not just the first.

This is distinct from the fullscreen bug (#836 / #848, where `getUserMedia` never resolves at all in a native-fullscreen Space) and from #843 (raw-audio constraints / waveform stream) — neither keeps the dictation mic warm.

## Changes

- **`useAudioRecording`** — new opt-in `keepWarm` option. When set, the capture `MediaStream` is kept open between recordings and reused, so the hot path (chord-down → record) never awaits `getUserMedia` and `MediaRecorder` captures from the first frame. Adds a `prewarm()` that pre-opens the device, and a dead-stream guard that re-acquires if the tracks have ended (device unplugged / switched). The warm stream self-releases after `WARM_IDLE_RELEASE_MS` (60s) of inactivity so the OS mic indicator clears when the user isn't dictating.
- **`useCaptureRecordingSession`** — new `keepMicWarm` option, threaded through to `useAudioRecording`, plus a mount effect that calls `prewarm()` so even the first dictation is warm.
- **`DictateWindow`** — the always-mounted floating pill opts in with `keepMicWarm`. Warming lives here (not the main window) so the mic is only held open by the surface that actually services the global shortcut.

Behavior is **unchanged** for the voice-clone sample recorders (`ProfileForm`, `SampleUpload`) and the main-window Dictate button — they don't pass `keepWarm`/`keepMicWarm`, so they still open once and release the device immediately.

## Trade-off / notes

- With `keepWarm` the mic is held open (indicator lit) during active dictation and for up to `WARM_IDLE_RELEASE_MS` after — the price of zero clipping. Happy to make the timeout configurable or gate warming behind a setting if you'd prefer.
- The one case still not covered is the *very first* dictation after the idle window elapses (it re-warms lazily). A clean follow-up would be to emit a lightweight "chord armed" event from the Rust hotkey monitor on modifier-down and call `prewarm()` on it, fully eliminating clipping without holding the device open at all.

## Verification

- `bunx tsc -p app/tsconfig.json --noEmit` — passes.
- `biome lint` on the changed files — clean (no new warnings; the pre-existing `useExhaustiveDependencies` warnings in `DictateWindow` are untouched).
- Manually: on macOS 26.5.2 / Apple Silicon, held the shortcut and spoke immediately — opening words are now captured; back-to-back dictations start instantly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dictation startup by preparing the microphone in advance, helping prevent clipped words at the beginning of recordings.
  * Kept the microphone ready between recordings for faster subsequent dictation.
  * Automatically releases the microphone after inactivity to conserve device resources.
* **Bug Fixes**
  * Improved microphone handling when recording is canceled or stopped.
  * Gracefully handles unavailable microphone permissions or devices during pre-activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->