### PR TITLE
Add Romanian TTS support via a new MMS engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 
+### Voice Generation
+
+- **Romanian TTS via a new MMS engine.** A new `mms` engine wraps Meta's
+  MMS-TTS Romanian checkpoint (`facebook/mms-tts-ron`) — a ~150MB VITS model
+  that runs realtime on CPU, using the already-bundled transformers runtime
+  (zero new dependencies). It ships as a preset voice (like Kokoro): create a
+  profile with the Romanian MMS voice and generate. Romanian text using either
+  diacritic convention (cedilla ş/ţ or comma-below ș/ț) is normalized
+  automatically so no character is silently dropped by the tokenizer.
+
 ### Linux
 
 - **ROCm setup works on Linux AMD systems.** Docker ROCm builds now keep PyTorch

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@
 
 ## What is Voicebox?
 
-Voicebox is a **local-first AI voice studio** — a free and open-source alternative to **ElevenLabs** and **WisprFlow** in one app. Clone voices from a few seconds of audio, generate speech in 23 languages across 7 TTS engines, dictate into any text field with a global hotkey, and give any MCP-aware AI agent a voice of your choosing.
+Voicebox is a **local-first AI voice studio** — a free and open-source alternative to **ElevenLabs** and **WisprFlow** in one app. Clone voices from a few seconds of audio, generate speech in 24 languages across 8 TTS engines, dictate into any text field with a global hotkey, and give any MCP-aware AI agent a voice of your choosing.
 
 The two cloud incumbents sit on opposite halves of the voice I/O loop — ElevenLabs on output, WisprFlow on input. Voicebox does both, bridges them with a bundled local LLM for refinement and per-profile personas, and runs the whole thing on your machine.
 
 - **Complete privacy** — models, voice data, and captures never leave your machine
-- **7 TTS engines** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, and Kokoro
+- **8 TTS engines** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, Kokoro, and MMS
 - **Voice cloning and preset voices** — zero-shot cloning from a reference sample, or 50+ curated preset voices via Kokoro and Qwen CustomVoice
-- **23 languages** — from English to Arabic, Japanese, Hindi, Swahili, and more
+- **24 languages** — from English to Arabic, Japanese, Hindi, Romanian, Swahili, and more
 - **Post-processing effects** — pitch shift, reverb, delay, chorus, compression, and filters
 - **Expressive speech** — paralinguistic tags like `[laugh]`, `[sigh]`, `[gasp]` via Chatterbox Turbo; natural-language delivery control via Qwen CustomVoice
 - **Unlimited length** — auto-chunking with crossfade for scripts, articles, and chapters
@@ -109,7 +109,7 @@ The two cloud incumbents sit on opposite halves of the voice I/O loop — Eleven
 
 ### Multi-Engine Voice Cloning
 
-Seven TTS engines with different strengths, switchable per-generation:
+Eight TTS engines with different strengths, switchable per-generation:
 
 | Engine                      | Languages | Strengths                                                                                                                                |
 | --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
@@ -120,6 +120,7 @@ Seven TTS engines with different strengths, switchable per-generation:
 | **Chatterbox Turbo**        | English   | Fast 350M model with paralinguistic emotion/sound tags                                                                                   |
 | **TADA** (1B / 3B)          | 10        | HumeAI speech-language model — 700s+ coherent audio, text-acoustic dual alignment                                                        |
 | **Kokoro**                  | 8         | 50 curated preset voices, tiny 82M model, fast CPU inference                                                                             |
+| **MMS** (Meta)              | Romanian  | Per-language VITS checkpoints (~150MB), CPU realtime, preset voice — the only engine with Romanian                                       |
 
 ### Emotions & Paralinguistic Tags
 
@@ -369,7 +370,7 @@ Full API documentation available at `http://127.0.0.1:17493/docs`.
 | Frontend      | React, TypeScript, Tailwind CSS                                                 |
 | State         | Zustand, React Query                                                            |
 | Backend       | FastAPI (Python)                                                                |
-| TTS Engines   | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
+| TTS Engines   | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro, MMS |
 | STT           | Whisper / Whisper Turbo (PyTorch or MLX)                                        |
 | Local LLM     | Qwen3 (0.6B / 1.7B / 4B), shared runtime with TTS / STT                         |
 | MCP Server    | FastMCP mounted at `/mcp` (Streamable HTTP) + bundled stdio shim binary         |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The two cloud incumbents sit on opposite halves of the voice I/O loop — Eleven
 
 - **Complete privacy** — models, voice data, and captures never leave your machine
 - **8 TTS engines** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, Kokoro, and MMS
-- **Voice cloning and preset voices** — zero-shot cloning from a reference sample, or 50+ curated preset voices via Kokoro and Qwen CustomVoice
+- **Voice cloning and preset voices** — zero-shot cloning from a reference sample, or 50+ curated preset voices via Kokoro, Qwen CustomVoice, and MMS (Romanian)
 - **24 languages** — from English to Arabic, Japanese, Hindi, Romanian, Swahili, and more
 - **Post-processing effects** — pitch shift, reverb, delay, chorus, compression, and filters
 - **Expressive speech** — paralinguistic tags like `[laugh]`, `[sigh]`, `[gasp]` via Chatterbox Turbo; natural-language delivery control via Qwen CustomVoice

--- a/app/src/components/CapturesTab/CapturesTab.tsx
+++ b/app/src/components/CapturesTab/CapturesTab.tsx
@@ -269,7 +269,7 @@ export function CapturesTab() {
       // override fall through to whatever the backend picks.
       const engine = voice.default_engine as
         | 'qwen' | 'qwen_custom_voice' | 'luxtts' | 'chatterbox'
-        | 'chatterbox_turbo' | 'tada' | 'kokoro'
+        | 'chatterbox_turbo' | 'tada' | 'kokoro' | 'mms'
         | undefined;
       return apiClient.generateSpeech({
         profile_id: voice.id,

--- a/app/src/components/CapturesTab/CapturesTab.tsx
+++ b/app/src/components/CapturesTab/CapturesTab.tsx
@@ -64,7 +64,7 @@ import type {
   CaptureSource,
   VoiceProfileResponse,
 } from '@/lib/api/types';
-import type { LanguageCode } from '@/lib/constants/languages';
+import { ENGINE_LANGUAGES, type LanguageCode } from '@/lib/constants/languages';
 import { BOTTOM_SAFE_AREA_PADDING } from '@/lib/constants/ui';
 import { useCaptureRecordingSession } from '@/lib/hooks/useCaptureRecordingSession';
 import { useDictationReadiness } from '@/lib/hooks/useDictationReadiness';
@@ -263,7 +263,6 @@ export function CapturesTab() {
     mutationFn: async ({ capture, voice }: { capture: CaptureResponse; voice: VoiceProfileResponse }) => {
       const text = capture.transcript_refined || capture.transcript_raw;
       if (!text.trim()) throw new Error(t('captures.noTranscriptError'));
-      const language = (capture.language || voice.language) as LanguageCode;
       // Preset profiles (Kokoro etc.) reject the qwen default — honor the
       // profile's stored engine preference. Cloned profiles without an
       // override fall through to whatever the backend picks.
@@ -271,6 +270,16 @@ export function CapturesTab() {
         | 'qwen' | 'qwen_custom_voice' | 'luxtts' | 'chatterbox'
         | 'chatterbox_turbo' | 'tada' | 'kokoro' | 'mms'
         | undefined;
+      // Prefer the capture's language, but only if the target engine can
+      // speak it (e.g. MMS is Romanian-only, Kokoro covers 8 languages) —
+      // otherwise fall back to the profile's own language.
+      const captureLanguage = capture.language as LanguageCode | undefined;
+      const supported = engine ? ENGINE_LANGUAGES[engine] : undefined;
+      const language = (
+        captureLanguage && (!supported || supported.includes(captureLanguage))
+          ? captureLanguage
+          : voice.language
+      ) as LanguageCode;
       return apiClient.generateSpeech({
         profile_id: voice.id,
         text,

--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -27,6 +27,7 @@ const ENGINE_OPTIONS = [
   { value: 'tada:1B', label: 'TADA 1B', engine: 'tada' },
   { value: 'tada:3B', label: 'TADA 3B Multilingual', engine: 'tada' },
   { value: 'kokoro', label: 'Kokoro 82M', engine: 'kokoro' },
+  { value: 'mms', label: 'MMS Romanian', engine: 'mms' },
 ] as const;
 
 const ENGINE_DESCRIPTIONS: Record<string, string> = {
@@ -37,6 +38,7 @@ const ENGINE_DESCRIPTIONS: Record<string, string> = {
   chatterbox_turbo: 'English, [laugh] [cough] tags',
   tada: 'HumeAI, 700s+ coherent audio',
   kokoro: '82M params, CPU realtime, 8 langs',
+  mms: 'Meta MMS, Romanian, CPU realtime',
 };
 
 /** Engines that only support English and should force language to 'en' on select. */

--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -151,7 +151,8 @@ export function FloatingGenerateBox({
     | 'chatterbox_turbo'
     | 'tada'
     | 'kokoro'
-    | 'qwen_custom_voice';
+    | 'qwen_custom_voice'
+    | 'mms';
   useEffect(() => {
     if (selectedProfile?.language) {
       form.setValue('language', selectedProfile.language as LanguageCode);
@@ -163,7 +164,7 @@ export function FloatingGenerateBox({
     } else if (selectedProfile && selectedProfile.voice_type !== 'preset') {
       // Cloned/designed profile with no default — ensure a compatible (non-preset) engine
       const currentEngine = form.getValues('engine');
-      const presetEngines = new Set(['kokoro', 'qwen_custom_voice']);
+      const presetEngines = new Set(['kokoro', 'qwen_custom_voice', 'mms']);
       if (currentEngine && presetEngines.has(currentEngine)) {
         form.setValue('engine', 'qwen');
       }

--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -414,7 +414,8 @@ export function ModelManagement() {
         m.model_name.startsWith('luxtts') ||
         m.model_name.startsWith('chatterbox') ||
         m.model_name.startsWith('tada') ||
-        m.model_name.startsWith('kokoro'),
+        m.model_name.startsWith('kokoro') ||
+        m.model_name.startsWith('mms'),
     ) ?? [];
   const whisperModels = modelStatus?.models.filter((m) => m.model_name.startsWith('whisper')) ?? [];
   const llmModels = modelStatus?.models.filter((m) => m.model_name.startsWith('qwen3-')) ?? [];

--- a/app/src/components/VoiceProfiles/ProfileCard.tsx
+++ b/app/src/components/VoiceProfiles/ProfileCard.tsx
@@ -22,6 +22,7 @@ import { useUIStore } from '@/stores/uiStore';
 const ENGINE_DISPLAY_NAMES: Record<string, string> = {
   kokoro: 'Kokoro',
   qwen_custom_voice: 'CustomVoice',
+  mms: 'MMS',
 };
 
 interface ProfileCardProps {

--- a/app/src/components/VoiceProfiles/ProfileForm.tsx
+++ b/app/src/components/VoiceProfiles/ProfileForm.tsx
@@ -61,7 +61,7 @@ import { AudioSampleUpload } from './AudioSampleUpload';
 import { SampleList } from './SampleList';
 
 const MAX_AUDIO_DURATION_SECONDS = 30;
-const PRESET_ONLY_ENGINES = new Set(['kokoro', 'qwen_custom_voice']);
+const PRESET_ONLY_ENGINES = new Set(['kokoro', 'qwen_custom_voice', 'mms']);
 const DEFAULT_ENGINE_OPTIONS = [
   { value: 'qwen', label: 'Qwen3-TTS' },
   { value: 'qwen_custom_voice', label: 'Qwen CustomVoice' },
@@ -70,6 +70,7 @@ const DEFAULT_ENGINE_OPTIONS = [
   { value: 'chatterbox_turbo', label: 'Chatterbox Turbo' },
   { value: 'tada', label: 'TADA' },
   { value: 'kokoro', label: 'Kokoro 82M' },
+  { value: 'mms', label: 'MMS Romanian' },
 ] as const;
 
 function makeProfileSchema(t: (key: string) => string) {
@@ -898,6 +899,7 @@ export function ProfileForm() {
                               <SelectContent>
                                 <SelectItem value="kokoro">Kokoro 82M</SelectItem>
                                 <SelectItem value="qwen_custom_voice">Qwen CustomVoice</SelectItem>
+                                <SelectItem value="mms">MMS Romanian</SelectItem>
                               </SelectContent>
                             </Select>
                           </FormItem>

--- a/app/src/components/VoiceProfiles/ProfileList.tsx
+++ b/app/src/components/VoiceProfiles/ProfileList.tsx
@@ -9,7 +9,7 @@ import { ProfileCard } from './ProfileCard';
 import { ProfileForm } from './ProfileForm';
 
 /** Engines that use preset (built-in) voices instead of cloned profiles. */
-const PRESET_ENGINES = new Set(['kokoro', 'qwen_custom_voice']);
+const PRESET_ENGINES = new Set(['kokoro', 'qwen_custom_voice', 'mms']);
 
 export function ProfileList() {
   const { t } = useTranslation();

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -78,7 +78,8 @@ export interface GenerationRequest {
     | 'chatterbox'
     | 'chatterbox_turbo'
     | 'tada'
-    | 'kokoro';
+    | 'kokoro'
+    | 'mms';
   instruct?: string;
   /** When true and the profile has a personality prompt, input text is rewritten in-character before TTS. */
   personality?: boolean;

--- a/app/src/lib/constants/languages.ts
+++ b/app/src/lib/constants/languages.ts
@@ -6,6 +6,7 @@
  * Chatterbox Multilingual supports 23 languages.
  * Chatterbox Turbo is English-only.
  * Kokoro supports 8 languages.
+ * MMS is Romanian-only (per-language Meta checkpoints).
  */
 
 /** All languages that any engine supports. */
@@ -28,6 +29,7 @@ export const ALL_LANGUAGES = {
   no: 'Norwegian',
   pl: 'Polish',
   pt: 'Portuguese',
+  ro: 'Romanian',
   ru: 'Russian',
   sv: 'Swedish',
   sw: 'Swahili',
@@ -70,6 +72,7 @@ export const ENGINE_LANGUAGES: Record<string, readonly LanguageCode[]> = {
   tada: ['en', 'ar', 'zh', 'de', 'es', 'fr', 'it', 'ja', 'pl', 'pt'],
   kokoro: ['en', 'es', 'fr', 'hi', 'it', 'pt', 'ja', 'zh'],
   qwen_custom_voice: ['zh', 'en', 'ja', 'ko', 'de', 'fr', 'ru', 'pt', 'es', 'it'],
+  mms: ['ro'],
 } as const;
 
 /** Helper: get language options for a given engine. */

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -27,6 +27,7 @@ const generationSchema = z.object({
       'chatterbox_turbo',
       'tada',
       'kokoro',
+      'mms',
     ])
     .optional(),
   personality: z.boolean().optional(),
@@ -100,9 +101,11 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'tada-1b'
                 : engine === 'kokoro'
                   ? 'kokoro'
-                  : engine === 'qwen_custom_voice'
-                    ? `qwen-custom-voice-${data.modelSize}`
-                    : `qwen-tts-${data.modelSize}`;
+                  : engine === 'mms'
+                    ? 'mms-tts-ron'
+                    : engine === 'qwen_custom_voice'
+                      ? `qwen-custom-voice-${data.modelSize}`
+                      : `qwen-tts-${data.modelSize}`;
       const displayName =
         engine === 'luxtts'
           ? 'LuxTTS'
@@ -116,13 +119,15 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'TADA 1B'
                 : engine === 'kokoro'
                   ? 'Kokoro 82M'
-                  : engine === 'qwen_custom_voice'
-                    ? data.modelSize === '1.7B'
-                      ? 'Qwen CustomVoice 1.7B'
-                      : 'Qwen CustomVoice 0.6B'
-                    : data.modelSize === '1.7B'
-                      ? 'Qwen TTS 1.7B'
-                      : 'Qwen TTS 0.6B';
+                  : engine === 'mms'
+                    ? 'MMS Romanian (Meta)'
+                    : engine === 'qwen_custom_voice'
+                      ? data.modelSize === '1.7B'
+                        ? 'Qwen CustomVoice 1.7B'
+                        : 'Qwen CustomVoice 0.6B'
+                      : data.modelSize === '1.7B'
+                        ? 'Qwen TTS 1.7B'
+                        : 'Qwen TTS 0.6B';
 
       // Check if model needs downloading
       try {

--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -57,6 +57,7 @@ const ENGINE_DISPLAY_NAMES: Record<string, string> = {
   luxtts: 'LuxTTS',
   chatterbox: 'Chatterbox',
   chatterbox_turbo: 'Chatterbox Turbo',
+  mms: 'MMS TTS',
 };
 
 export function formatEngineName(engine?: string, modelSize?: string): string {

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -215,6 +215,7 @@ TTS_ENGINES = {
     "chatterbox_turbo": "Chatterbox Turbo",
     "tada": "TADA",
     "kokoro": "Kokoro",
+    "mms": "MMS TTS",
 }
 
 LLM_ENGINES = {
@@ -363,6 +364,14 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             hf_repo_id="hexgrad/Kokoro-82M",
             size_mb=350,
             languages=["en", "es", "fr", "hi", "it", "pt", "ja", "zh"],
+        ),
+        ModelConfig(
+            model_name="mms-tts-ron",
+            display_name="MMS Romanian (Meta)",
+            engine="mms",
+            hf_repo_id="facebook/mms-tts-ron",
+            size_mb=150,
+            languages=["ro"],
         ),
     ]
 
@@ -704,6 +713,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .kokoro_backend import KokoroTTSBackend
 
             backend = KokoroTTSBackend()
+        elif engine == "mms":
+            from .mms_backend import MMSTTSBackend
+
+            backend = MMSTTSBackend()
         elif engine == "qwen_custom_voice":
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 

--- a/backend/backends/mms_backend.py
+++ b/backend/backends/mms_backend.py
@@ -11,8 +11,10 @@ speaker, so profiles follow the preset-voice pattern (like Kokoro).
 Languages supported:
   - Romanian (ro) — ``facebook/mms-tts-ron``
 
-Adding a language is a one-line addition to ``MMS_HF_REPOS`` plus a voice
-entry in ``MMS_VOICES`` and a ``ModelConfig`` registration.
+Adding a language requires an entry in ``MMS_HF_REPOS`` and ``MMS_VOICES``,
+a ``ModelConfig`` registration, and threading the requested language through
+``_get_model_path``/``_load_model_sync`` — today those resolve to
+``MMS_DEFAULT_LANGUAGE`` because only one checkpoint ships.
 """
 
 import asyncio

--- a/backend/backends/mms_backend.py
+++ b/backend/backends/mms_backend.py
@@ -1,0 +1,210 @@
+"""
+MMS-TTS backend implementation.
+
+Wraps Meta's Massively Multilingual Speech (MMS) TTS checkpoints — one VITS
+model per language (``facebook/mms-tts-{iso3}``). Pure PyTorch via
+``transformers``, CPU realtime, 16kHz output, CC-BY-NC 4.0 license.
+
+MMS has no concept of voice cloning: each checkpoint is a single preset
+speaker, so profiles follow the preset-voice pattern (like Kokoro).
+
+Languages supported:
+  - Romanian (ro) — ``facebook/mms-tts-ron``
+
+Adding a language is a one-line addition to ``MMS_HF_REPOS`` plus a voice
+entry in ``MMS_VOICES`` and a ``ModelConfig`` registration.
+"""
+
+import asyncio
+import logging
+import unicodedata
+
+import numpy as np
+
+from .base import (
+    combine_voice_prompts as _combine_voice_prompts,
+    empty_device_cache,
+    get_torch_device,
+    is_model_cached,
+    manual_seed,
+    model_load_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+# Our ISO 639-1 language codes -> MMS per-language HF checkpoints (ISO 639-3)
+MMS_HF_REPOS = {"ro": "facebook/mms-tts-ron"}
+MMS_DEFAULT_LANGUAGE = "ro"
+
+# Confirmed against model.config.sampling_rate for mms-tts-ron
+MMS_SAMPLE_RATE = 16000
+
+# Default voice if none specified
+MMS_DEFAULT_VOICE = "mms_ro_default"
+
+# All available MMS voices: (voice_id, display_name, gender, lang_code).
+# One entry per language checkpoint — MMS ships a single speaker each.
+MMS_VOICES = [
+    ("mms_ro_default", "Romanian (MMS)", "male", "ro"),
+]
+
+# The mms-tts-ron vocab mixes Romanian diacritic conventions: it contains
+# comma-below ș (U+0219) but cedilla ţ (U+0163), and lacks their
+# counterparts ş (U+015F) and ț (U+021B). The character-level VitsTokenizer
+# silently drops characters outside its vocab, so both real-world variants
+# must be mapped onto the trained form. Uppercase variants are included —
+# the tokenizer lowercases after this mapping (Ș -> ș, Ţ -> ţ).
+_RO_DIACRITICS_TRANSLATION = str.maketrans(
+    {
+        "ş": "ș",  # ş (s-cedilla) -> ș (s-comma-below)
+        "Ş": "Ș",  # Ş (S-cedilla) -> Ș (S-comma-below)
+        "ț": "ţ",  # ț (t-comma-below) -> ţ (t-cedilla)
+        "Ț": "Ţ",  # Ț (T-comma-below) -> Ţ (T-cedilla)
+    }
+)
+
+
+def normalize_romanian_text(text: str) -> str:
+    """Normalize Romanian text to the diacritic forms in the MMS vocab.
+
+    Applies NFC normalization first (composing any decomposed
+    letter + combining-mark sequences), then maps cedilla/comma-below
+    s and t variants onto the forms the ``facebook/mms-tts-ron``
+    checkpoint was trained on, so no diacritic is silently dropped
+    by the tokenizer.
+    """
+    return unicodedata.normalize("NFC", text).translate(_RO_DIACRITICS_TRANSLATION)
+
+
+class MMSTTSBackend:
+    """Meta MMS-TTS backend — per-language VITS checkpoints, single preset voice."""
+
+    def __init__(self):
+        self._model = None
+        self._tokenizer = None
+        self._device: str | None = None
+        self.model_size = "default"
+
+    @property
+    def device(self) -> str:
+        if self._device is None:
+            # CPU is realtime for a ~100M-param VITS; skip MPS like Kokoro.
+            self._device = get_torch_device(allow_mps=False)
+        return self._device
+
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def _get_model_path(self, model_size: str) -> str:
+        return MMS_HF_REPOS[MMS_DEFAULT_LANGUAGE]
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        """Check if MMS model files are cached locally."""
+        return is_model_cached(MMS_HF_REPOS[MMS_DEFAULT_LANGUAGE])
+
+    async def load_model(self, model_size: str = "default") -> None:
+        """Load the MMS model and tokenizer."""
+        if self._model is not None:
+            return
+        await asyncio.to_thread(self._load_model_sync)
+
+    def _load_model_sync(self):
+        """Synchronous model loading."""
+        model_name = "mms-tts-ron"
+        is_cached = self._is_model_cached()
+
+        with model_load_progress(model_name, is_cached):
+            from transformers import AutoTokenizer, VitsModel  # lazy: heavy import
+
+            repo = MMS_HF_REPOS[MMS_DEFAULT_LANGUAGE]
+            device = self.device
+            logger.info("Loading MMS-TTS (%s) on %s...", repo, device)
+
+            self._tokenizer = AutoTokenizer.from_pretrained(repo)
+            self._model = VitsModel.from_pretrained(repo).to(device).eval()
+
+        logger.info("MMS-TTS loaded successfully")
+
+    def unload_model(self) -> None:
+        """Unload model to free memory."""
+        if self._model is not None:
+            del self._model
+            self._model = None
+            self._tokenizer = None
+            empty_device_cache(self.device)
+            logger.info("MMS-TTS unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> tuple[dict, bool]:
+        """
+        Create voice prompt for MMS.
+
+        MMS doesn't do voice cloning — each checkpoint is one fixed speaker.
+        When called for a cloned profile (fallback), uses the default voice.
+        For preset profiles, the voice_prompt dict is built by the profile
+        service and bypasses this method entirely.
+        """
+        return {
+            "voice_type": "preset",
+            "preset_engine": "mms",
+            "preset_voice_id": MMS_DEFAULT_VOICE,
+        }, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
+        """Combine voice prompts — uses base implementation for audio concatenation."""
+        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=MMS_SAMPLE_RATE)
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "ro",
+        seed: int | None = None,
+        instruct: str | None = None,
+    ) -> tuple[np.ndarray, int]:
+        """
+        Generate audio from text using MMS-TTS.
+
+        Args:
+            text: Text to synthesize
+            voice_prompt: Preset voice dict (single speaker — informational only)
+            language: Language code
+            seed: Random seed for reproducibility (VITS sampling is stochastic)
+            instruct: Not supported by MMS (ignored)
+
+        Returns:
+            Tuple of (audio_array, sample_rate)
+        """
+        await self.load_model()
+
+        def _generate_sync():
+            import torch  # lazy: heavy import
+
+            if seed is not None:
+                manual_seed(seed, self.device)
+
+            normalized = normalize_romanian_text(text) if language == "ro" else unicodedata.normalize("NFC", text)
+
+            inputs = self._tokenizer(normalized, return_tensors="pt").to(self.device)
+            sample_rate = getattr(self._model.config, "sampling_rate", MMS_SAMPLE_RATE)
+
+            # Text made entirely of out-of-vocab characters tokenizes to an
+            # empty sequence — return 1 second of silence as fallback.
+            if inputs["input_ids"].shape[-1] == 0:
+                return np.zeros(sample_rate, dtype=np.float32), sample_rate
+
+            with torch.no_grad():
+                waveform = self._model(**inputs).waveform
+
+            audio = waveform.squeeze().detach().cpu().numpy().astype(np.float32)
+            return audio, sample_rate
+
+        return await asyncio.to_thread(_generate_sync)

--- a/backend/build_binary.py
+++ b/backend/build_binary.py
@@ -276,6 +276,10 @@ def build_server(cuda=False, rocm=False):
             "backend.backends.kokoro_backend",
             "--collect-all",
             "kokoro",
+            # MMS-TTS — pure transformers VITS; the transformers hook already
+            # bundles the model classes, only the backend module is needed.
+            "--hidden-import",
+            "backend.backends.mms_backend",
             # misaki ships G2P data files (dictionaries, phoneme tables)
             # that must be bundled for espeak/en/ja/zh G2P to work
             "--collect-all",

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,7 +18,7 @@ class VoiceProfileCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
     language: str = Field(
-        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$"
     )
     voice_type: Optional[str] = Field(default="cloned", pattern="^(cloned|preset|designed)$")
     preset_engine: Optional[str] = Field(None, max_length=50)
@@ -81,11 +81,11 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$")
+    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$")
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$")
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -317,7 +317,7 @@ class MCPClientBindingResponse(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
     )
     default_personality: bool = False
     last_seen_at: Optional[datetime] = None
@@ -336,7 +336,7 @@ class MCPClientBindingUpsert(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
     )
     default_personality: bool = False
 
@@ -355,7 +355,7 @@ class SpeakRequest(BaseModel):
     )
     engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
     )
     personality: Optional[bool] = Field(
         None,
@@ -363,7 +363,7 @@ class SpeakRequest(BaseModel):
     )
     language: Optional[str] = Field(
         None,
-        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
+        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$",
     )
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,15 +11,18 @@ from .utils.capture_chords import (
     default_toggle_to_talk_chord,
 )
 
+# Shared validation patterns for TTS requests. The Qwen-specific 10-language
+# patterns further down are intentionally separate — do not merge them.
+TTS_LANGUAGE_PATTERN = "^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$"
+TTS_ENGINE_PATTERN = "^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$"
+
 
 class VoiceProfileCreate(BaseModel):
     """Request model for creating a voice profile."""
 
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
-    language: str = Field(
-        default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$"
-    )
+    language: str = Field(default="en", pattern=TTS_LANGUAGE_PATTERN)
     voice_type: Optional[str] = Field(default="cloned", pattern="^(cloned|preset|designed)$")
     preset_engine: Optional[str] = Field(None, max_length=50)
     preset_voice_id: Optional[str] = Field(None, max_length=100)
@@ -81,11 +84,11 @@ class GenerationRequest(BaseModel):
 
     profile_id: str
     text: str = Field(..., min_length=1, max_length=50000)
-    language: str = Field(default="en", pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$")
+    language: str = Field(default="en", pattern=TTS_LANGUAGE_PATTERN)
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$")
+    engine: Optional[str] = Field(default="qwen", pattern=TTS_ENGINE_PATTERN)
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -317,7 +320,7 @@ class MCPClientBindingResponse(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
+        pattern=TTS_ENGINE_PATTERN,
     )
     default_personality: bool = False
     last_seen_at: Optional[datetime] = None
@@ -336,7 +339,7 @@ class MCPClientBindingUpsert(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
+        pattern=TTS_ENGINE_PATTERN,
     )
     default_personality: bool = False
 
@@ -355,7 +358,7 @@ class SpeakRequest(BaseModel):
     )
     engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|mms)$",
+        pattern=TTS_ENGINE_PATTERN,
     )
     personality: Optional[bool] = Field(
         None,
@@ -363,7 +366,7 @@ class SpeakRequest(BaseModel):
     )
     language: Optional[str] = Field(
         None,
-        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr|ro)$",
+        pattern=TTS_LANGUAGE_PATTERN,
     )
 
 

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -104,6 +104,21 @@ async def list_preset_voices(engine: str):
                 for speaker_id, display_name, gender, lang, _desc in QWEN_CUSTOM_VOICES
             ],
         }
+    if engine == "mms":
+        from ..backends.mms_backend import MMS_VOICES
+
+        return {
+            "engine": engine,
+            "voices": [
+                {
+                    "voice_id": vid,
+                    "name": name,
+                    "gender": gender,
+                    "language": lang,
+                }
+                for vid, name, gender, lang in MMS_VOICES
+            ],
+        }
     return {"engine": engine, "voices": []}
 
 @router.get("/profiles/{profile_id}", response_model=models.VoiceProfileResponse)

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -73,6 +73,11 @@ def _get_preset_voice_ids(engine: str) -> set[str]:
 
         return {voice_id for voice_id, _name, _gender, _lang, _desc in QWEN_CUSTOM_VOICES}
 
+    if engine == "mms":
+        from ..backends.mms_backend import MMS_VOICES
+
+        return {voice_id for voice_id, _name, _gender, _lang in MMS_VOICES}
+
     return set()
 
 

--- a/backend/tests/test_mms_backend.py
+++ b/backend/tests/test_mms_backend.py
@@ -1,0 +1,287 @@
+"""
+Tests for the MMS-TTS backend (Romanian).
+
+Unit tests cover the Romanian diacritics normalization (the mms-tts-ron
+vocab mixes comma-below ș with cedilla ţ, and the character-level
+VitsTokenizer silently drops out-of-vocab characters) and the engine
+registration surfaces (model config registry, backend factory, request
+model regexes, preset voice endpoints).
+
+The end-to-end generation test downloads the ~150MB model on first run
+and is opt-in:
+
+    VOICEBOX_MMS_E2E=1 python -m pytest backend/tests/test_mms_backend.py -v
+"""
+
+import os
+import sys
+import unicodedata
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.backends import (
+    TTS_ENGINES,
+    get_model_config,
+    get_tts_backend_for_engine,
+    reset_backends,
+)
+from backend.backends.mms_backend import (
+    MMS_DEFAULT_VOICE,
+    MMS_HF_REPOS,
+    MMS_SAMPLE_RATE,
+    MMS_VOICES,
+    MMSTTSBackend,
+    normalize_romanian_text,
+)
+
+S_CEDILLA = "ş"  # ş — not in the mms-tts-ron vocab
+S_CEDILLA_UPPER = "Ş"  # Ş
+S_COMMA = "ș"  # ș — in vocab
+S_COMMA_UPPER = "Ș"  # Ș
+T_CEDILLA = "ţ"  # ţ — in vocab
+T_CEDILLA_UPPER = "Ţ"  # Ţ
+T_COMMA = "ț"  # ț — not in vocab
+T_COMMA_UPPER = "Ț"  # Ț
+COMBINING_COMMA_BELOW = "̦"
+COMBINING_BREVE = "̆"
+
+MMS_PRESET_PROMPT = {
+    "voice_type": "preset",
+    "preset_engine": "mms",
+    "preset_voice_id": MMS_DEFAULT_VOICE,
+}
+
+
+class TestRomanianDiacriticsNormalization:
+    """The tokenizer drops unknown chars silently — every real-world
+    diacritic variant must be mapped onto the form in the vocab."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (S_CEDILLA, S_COMMA),
+            (S_CEDILLA_UPPER, S_COMMA_UPPER),
+            (T_COMMA, T_CEDILLA),
+            (T_COMMA_UPPER, T_CEDILLA_UPPER),
+        ],
+    )
+    def test_wrong_variant_mapped_to_vocab_form(self, raw, expected):
+        assert normalize_romanian_text(raw) == expected
+
+    @pytest.mark.parametrize("char", [S_COMMA, T_CEDILLA, "ă", "â", "î", "a", "b", " "])
+    def test_vocab_forms_pass_through_unchanged(self, char):
+        assert normalize_romanian_text(char) == char
+
+    def test_nfd_sequences_are_composed(self):
+        # s/t + combining comma below compose (via NFC) to the comma-below
+        # letters, which then go through the same variant mapping.
+        assert normalize_romanian_text("s" + COMBINING_COMMA_BELOW) == S_COMMA
+        assert normalize_romanian_text("t" + COMBINING_COMMA_BELOW) == T_CEDILLA
+        assert normalize_romanian_text("a" + COMBINING_BREVE) == "ă"
+
+    def test_mixed_sentence_contains_only_vocab_diacritics(self):
+        # Both variant families in one string, as found in the wild.
+        text = f"{S_CEDILLA_UPPER}tii c{S_CEDILLA} {T_COMMA}ara {T_CEDILLA}ine pa{S_COMMA}ii"
+        normalized = normalize_romanian_text(text)
+        lowered = normalized.lower()
+        assert S_CEDILLA not in lowered
+        assert T_COMMA not in lowered
+        assert lowered.count(S_COMMA) == 3
+        assert lowered.count(T_CEDILLA) == 2
+
+    def test_plain_text_untouched(self):
+        text = "Salut, ce mai faci? 1-2!"
+        assert normalize_romanian_text(text) == text
+
+    def test_unknown_chars_are_preserved(self):
+        # Normalization is not lossy — dropping out-of-vocab characters is
+        # the tokenizer's job, not ours.
+        text = "kiwi & yoga 42"
+        assert normalize_romanian_text(text) == text
+
+    def test_output_is_nfc(self):
+        decomposed = unicodedata.normalize("NFD", "Bună ziua, țară")
+        assert unicodedata.is_normalized("NFC", normalize_romanian_text(decomposed))
+
+
+class TestMMSRegistration:
+    def test_engine_listed(self):
+        assert "mms" in TTS_ENGINES
+
+    def test_model_config_resolves(self):
+        cfg = get_model_config("mms-tts-ron")
+        assert cfg is not None
+        assert cfg.engine == "mms"
+        assert cfg.hf_repo_id == "facebook/mms-tts-ron"
+        assert cfg.languages == ["ro"]
+        assert cfg.size_mb == 150
+        assert cfg.supports_instruct is False
+        assert cfg.needs_trim is False
+
+    def test_backend_factory_returns_mms_backend(self):
+        try:
+            backend = get_tts_backend_for_engine("mms")
+            assert isinstance(backend, MMSTTSBackend)
+            # Factory caches instances per engine
+            assert get_tts_backend_for_engine("mms") is backend
+        finally:
+            reset_backends()
+
+    def test_voice_catalog_shape(self):
+        # Same tuple shape as KOKORO_VOICES: (voice_id, name, gender, lang)
+        for voice_id, name, gender, lang in MMS_VOICES:
+            assert voice_id
+            assert name
+            assert gender in ("male", "female")
+            assert lang in MMS_HF_REPOS
+        assert MMS_DEFAULT_VOICE in {v[0] for v in MMS_VOICES}
+
+    def test_preset_voice_ids_service(self):
+        from backend.services.profiles import _get_preset_voice_ids
+
+        assert _get_preset_voice_ids("mms") == {MMS_DEFAULT_VOICE}
+
+    async def test_preset_voices_route(self):
+        # routes/profiles imports ..app at module scope; importing the app
+        # first (the normal boot order) avoids a circular import.
+        import backend.app  # noqa: F401 -- side-effect import initializes routers
+        from backend.routes.profiles import list_preset_voices
+
+        result = await list_preset_voices("mms")
+        assert result["engine"] == "mms"
+        assert result["voices"] == [
+            {
+                "voice_id": MMS_DEFAULT_VOICE,
+                "name": "Romanian (MMS)",
+                "gender": "male",
+                "language": "ro",
+            }
+        ]
+
+
+class TestRequestModelRegexes:
+    def test_generation_request_accepts_ro_and_mms(self):
+        from backend.models import GenerationRequest
+
+        req = GenerationRequest(profile_id="p1", text="Bună ziua", language="ro", engine="mms")
+        assert req.language == "ro"
+        assert req.engine == "mms"
+
+    def test_generation_request_rejects_unknown_engine(self):
+        from pydantic import ValidationError
+
+        from backend.models import GenerationRequest
+
+        with pytest.raises(ValidationError):
+            GenerationRequest(profile_id="p1", text="hi", engine="mms2")
+
+    def test_profile_create_accepts_ro(self):
+        from backend.models import VoiceProfileCreate
+
+        profile = VoiceProfileCreate(
+            name="Vocea",
+            language="ro",
+            voice_type="preset",
+            preset_engine="mms",
+            preset_voice_id=MMS_DEFAULT_VOICE,
+            default_engine="mms",
+        )
+        assert profile.language == "ro"
+        assert profile.default_engine == "mms"
+
+    def test_speak_request_accepts_ro_and_mms(self):
+        from backend.models import SpeakRequest
+
+        req = SpeakRequest(text="Bună", engine="mms", language="ro")
+        assert req.engine == "mms"
+        assert req.language == "ro"
+
+    def test_mcp_binding_accepts_mms(self):
+        from backend.models import MCPClientBindingUpsert
+
+        binding = MCPClientBindingUpsert(client_id="client-1", default_engine="mms")
+        assert binding.default_engine == "mms"
+
+
+class TestMMSBackendUnit:
+    def test_initial_state(self):
+        backend = MMSTTSBackend()
+        assert not backend.is_loaded()
+        assert backend._get_model_path("default") == "facebook/mms-tts-ron"
+
+    async def test_create_voice_prompt_returns_preset_fallback(self):
+        backend = MMSTTSBackend()
+        prompt, was_cached = await backend.create_voice_prompt("/tmp/none.wav", "text")
+        assert prompt == MMS_PRESET_PROMPT
+        assert was_cached is False
+
+    def test_unload_without_load_is_noop(self):
+        backend = MMSTTSBackend()
+        backend.unload_model()
+        assert not backend.is_loaded()
+
+
+RUN_MMS_E2E = os.environ.get("VOICEBOX_MMS_E2E") == "1"
+
+
+@pytest.mark.skipif(not RUN_MMS_E2E, reason="set VOICEBOX_MMS_E2E=1 to run (downloads ~150MB model)")
+class TestMMSGenerationE2E:
+    """Full generation through the real model — both diacritic conventions
+    must produce identical tokens and valid audio at 16kHz."""
+
+    async def test_generate_romanian_with_both_diacritic_variants(self):
+        backend = MMSTTSBackend()
+        try:
+            text = (
+                "Bună ziua! Ce mai faceți? Știți că țara noastră e frumoasă? "
+                f"{S_CEDILLA_UPPER}i {T_CEDILLA}ine{T_COMMA}i minte pa{S_CEDILLA}ii."
+            )
+            audio, sample_rate = await backend.generate(text, MMS_PRESET_PROMPT, "ro")
+
+            assert sample_rate == MMS_SAMPLE_RATE == 16000
+            assert isinstance(audio, np.ndarray)
+            assert audio.dtype == np.float32
+            assert audio.ndim == 1
+            assert len(audio) > sample_rate, "expected more than 1s of audio"
+            assert not np.isnan(audio).any()
+            assert float(np.abs(audio).max()) > 0.01, "audio should not be silence"
+        finally:
+            backend.unload_model()
+
+    async def test_diacritic_variants_tokenize_identically(self):
+        backend = MMSTTSBackend()
+        try:
+            await backend.load_model()
+            tokenizer = backend._tokenizer
+
+            cedilla_ids = tokenizer(normalize_romanian_text("ştiţi paşii ţară"))["input_ids"]
+            comma_ids = tokenizer(normalize_romanian_text("știți pașii țară"))["input_ids"]
+            assert cedilla_ids == comma_ids
+            # Nothing was dropped: with add_blank the tokenizer interleaves a
+            # blank between characters -> 2 * len(text) + 1 tokens.
+            assert len(comma_ids) == 2 * len("știți pașii țară") + 1
+        finally:
+            backend.unload_model()
+
+    async def test_seeded_generation_is_deterministic(self):
+        backend = MMSTTSBackend()
+        try:
+            first, _ = await backend.generate("Bună ziua!", MMS_PRESET_PROMPT, "ro", seed=42)
+            second, _ = await backend.generate("Bună ziua!", MMS_PRESET_PROMPT, "ro", seed=42)
+            np.testing.assert_allclose(first, second)
+        finally:
+            backend.unload_model()
+
+    async def test_fully_out_of_vocab_text_returns_silence(self):
+        backend = MMSTTSBackend()
+        try:
+            audio, sample_rate = await backend.generate("!!!", MMS_PRESET_PROMPT, "ro")
+            assert sample_rate == MMS_SAMPLE_RATE
+            assert len(audio) == sample_rate
+            assert not audio.any()
+        finally:
+            backend.unload_model()

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -23,7 +23,7 @@
 
 The backend exposes:
 
-- **`TTSBackend` Protocol** with seven concrete engine implementations:
+- **`TTSBackend` Protocol** with eight concrete engine implementations:
   - Qwen3-TTS (PyTorch or MLX depending on platform)
   - Qwen CustomVoice (predefined speakers with instruct)
   - LuxTTS (fast, CPU-friendly)
@@ -31,6 +31,7 @@ The backend exposes:
   - Chatterbox Turbo (English, paralinguistic tags)
   - TADA (1B English, 3B multilingual via HumeAI)
   - Kokoro 82M (pre-built voices, CPU realtime)
+  - MMS (Meta per-language VITS checkpoints — Romanian, preset voice, CPU realtime)
 - **`STTBackend` Protocol** for Whisper (PyTorch or MLX-Whisper)
 - **Profiles / History / Stories** services for persistence and timeline editing
 
@@ -49,6 +50,7 @@ The backend exposes:
 | Chatterbox Turbo | `backend/backends/chatterbox_turbo_backend.py` | Chatterbox Turbo — English, paralinguistic tags |
 | TADA | `backend/backends/hume_backend.py` | HumeAI TADA — 1B English + 3B Multilingual |
 | Kokoro | `backend/backends/kokoro_backend.py` | Kokoro 82M — CPU realtime, pre-built voices |
+| MMS | `backend/backends/mms_backend.py` | Meta MMS — Romanian VITS, preset voice, diacritics normalization |
 | Qwen CustomVoice | `backend/backends/qwen_custom_voice_backend.py` | Qwen CustomVoice — predefined speakers with instruct |
 | Platform detect | `backend/platform_detect.py` | Apple Silicon → MLX, else → PyTorch |
 | API types | `backend/models.py` | Pydantic request/response models |
@@ -156,6 +158,7 @@ Shipped 2026-04-25 (PR #544). Voicebox went from a voice-cloning studio to a ful
 - Chatterbox Turbo — paralinguistic tags, low latency English (PR #258)
 - HumeAI TADA — 1B English + 3B Multilingual (PR #296)
 - Kokoro 82M — CPU-realtime, 8 languages, Apache 2.0 (PR #325)
+- MMS (Meta) — Romanian preset voice, ~150MB VITS, CPU realtime, diacritics normalization
 - Multi-engine architecture with thread-safe backend registry (PR #254)
 - Chunked TTS generation — engine-agnostic, removes ~500 char limit (PR #266)
 - Async generation queue (PR #269)
@@ -255,12 +258,13 @@ Shipped 2026-04-25 (PR #544). Voicebox went from a voice-cloning studio to a ful
 | TADA 1B | `tada-1b` | Cloned | English | ~4 GB | HumeAI speech-language model, 700s+ coherent audio | None |
 | TADA 3B Multilingual | `tada-3b-ml` | Cloned | 10 (en, ar, zh, de, es, fr, it, ja, pl, pt) | ~8 GB | Multilingual, text-acoustic dual alignment | None |
 | Kokoro 82M | `kokoro` | Preset | 8 (en, es, fr, hi, it, pt, ja, zh) | ~350 MB | 82M params, CPU realtime, Apache 2.0, pre-built voices | None |
+| MMS Romanian | `mms-tts-ron` | Preset | Romanian (ro) | ~150 MB | Meta MMS VITS, 16 kHz, CPU realtime, cedilla/comma-below diacritics normalization | None |
 
 ### Multi-Engine Architecture (Shipped)
 
 - **Thread-safe backend registry** (`_tts_backends` dict + `_tts_backends_lock`) with double-checked locking
 - **Per-engine backend instances** — each engine gets its own singleton, loaded lazily
-- **Engine field on GenerationRequest** — frontend sends `engine: 'qwen' | 'qwen_custom_voice' | 'luxtts' | 'chatterbox' | 'chatterbox_turbo' | 'tada' | 'kokoro'`
+- **Engine field on GenerationRequest** — frontend sends `engine: 'qwen' | 'qwen_custom_voice' | 'luxtts' | 'chatterbox' | 'chatterbox_turbo' | 'tada' | 'kokoro' | 'mms'`
 - **Per-engine language filtering** — `ENGINE_LANGUAGES` map in frontend, backend regex accepts all languages
 - **Per-engine voice prompts** — `create_voice_prompt_for_profile()` dispatches to the correct backend
 - **Profile type system** — preset vs cloned profiles, UI grays out incompatible engines and auto-switches on selection
@@ -577,6 +581,7 @@ Notable:
 | **Chatterbox Turbo** | 5s zero-shot | Fast | 24 kHz | English | Low | Partial — inline tags | CPU/CUDA | **Shipped** (PR #258) |
 | **HumeAI TADA 1B/3B** | Zero-shot | 5x faster than LLM-TTS | 24 kHz | EN (1B), 10 (3B) | Medium | Partial — prosody | PyTorch | **Shipped** (PR #296) |
 | **Kokoro-82M** | Preset voices | CPU realtime | 24 kHz | 8 | Tiny (82M) | None | All | **Shipped** (PR #325) |
+| **MMS (Meta)** | Preset voice (1/lang) | CPU realtime | 16 kHz | Romanian (extensible per-checkpoint) | Tiny (~100M) | None | All | **Shipped** — zero new deps (transformers VITS) |
 | ~~**CosyVoice2-0.5B**~~ | 3-10s zero-shot | Very fast | 24 kHz | Multilingual | Low | **Yes** | — | **Abandoned** (PR #311) — poor output quality |
 | ~~**VoxCPM2**~~ | Zero-shot | ~0.15 RTF streaming | 48 kHz | 30 | Medium | Partial — parenthetical style | **CUDA-only in practice** | **Backlogged** (2026-04-18) — see notes above |
 | **Fish Speech** | 10-30s few-shot | Real-time | 24-44 kHz | 50+ | Medium | **Yes** — word-level inline | All | Candidate — license TBD |

--- a/docs/content/docs/overview/preset-voices.mdx
+++ b/docs/content/docs/overview/preset-voices.mdx
@@ -7,12 +7,13 @@ description: "Use built-in, ready-made voices without recording audio samples"
 
 Some Voicebox engines ship with a curated set of pre-built voices. Instead of cloning from your own audio sample, you pick a voice from a fixed catalog and the model speaks in that voice. No recording, no upload, no per-voice training required.
 
-Two engines in 0.4 ship preset voices:
+Three engines ship preset voices:
 
 | Engine                | Voices                  | Languages | Strengths                                               |
 | --------------------- | ----------------------- | --------- | ------------------------------------------------------- |
 | **Kokoro 82M**        | 50                      | 9         | Tiny model, CPU-friendly, lowest VRAM of any engine     |
 | **Qwen CustomVoice**  | 9 (premium curated)     | 4         | Natural-language style control over tone, emotion, pace |
+| **MMS (Meta)**        | 1 per language          | Romanian  | The only engine with Romanian — ~150MB, CPU realtime    |
 
 <Callout type="info">
   Looking for cloning a specific person's voice instead? See [Voice Cloning](/overview/voice-cloning).
@@ -42,7 +43,7 @@ Two engines in 0.4 ship preset voices:
     Same entry point as cloning profiles
   </Step>
   <Step title="Choose the engine">
-    Select **Kokoro** or **Qwen CustomVoice** from the engine dropdown
+    Select **Kokoro**, **Qwen CustomVoice**, or **MMS Romanian** from the engine dropdown
   </Step>
   <Step title="Pick a preset voice">
     The voice catalog for the chosen engine appears — preview each by clicking it
@@ -166,6 +167,29 @@ The full Generate page also surfaces the instruct field as a separate input.
 | VRAM            | ~3.5 GB (1.7B), ~1.2 GB (0.6B)                     |
 | Instruct        | Yes — natural-language style control               |
 | Cloning         | No — paired Base Qwen3-TTS engine handles cloning  |
+
+## MMS Romanian — Meta's Massively Multilingual Speech
+
+MMS wraps Meta's per-language VITS checkpoints (`facebook/mms-tts-{lang}`). Each checkpoint is a single fixed speaker, so there is exactly one preset voice per language. Voicebox ships the Romanian checkpoint — the only engine in the app that speaks Romanian.
+
+**Repository:** [`facebook/mms-tts-ron`](https://huggingface.co/facebook/mms-tts-ron) · CC-BY-NC 4.0 licensed
+
+| Voice           | Gender | Language        |
+| --------------- | ------ | --------------- |
+| Romanian (MMS)  | male   | Romanian (`ro`) |
+
+Romanian text in the wild mixes cedilla diacritics (ş/ţ) with the correct comma-below forms (ș/ț). Voicebox normalizes both conventions automatically before synthesis, so either spelling is pronounced correctly.
+
+### MMS at a Glance
+
+| Property        | Value                                          |
+| --------------- | ---------------------------------------------- |
+| Architecture    | VITS (~100M params per language)               |
+| Sample rate     | 16 kHz                                         |
+| Size on disk    | ~150 MB                                        |
+| Speed           | Realtime on CPU                                |
+| Instruct        | Not supported (single fixed speaker)           |
+| License         | CC-BY-NC 4.0                                   |
 
 ## Cloning vs Preset — Quick Decision
 


### PR DESCRIPTION
Closes #578

## What

New `mms` TTS engine wrapping [`facebook/mms-tts-ron`](https://huggingface.co/facebook/mms-tts-ron) (Meta MMS, VITS architecture), adding **Romanian** as Voicebox's 24th language. Single preset voice, no cloning — follows the existing Kokoro preset-engine pattern (`kokoro_backend.py` was the structural template).

**Zero new dependencies** — uses the already-pinned `transformers`. ~145 MB model, CPU-realtime, 16 kHz output, works on all platforms (no CUDA/platform gating needed).

## Notable: Romanian diacritics handling

The MMS Romanian tokenizer's vocab is *mixed*: it contains comma-below **ș** (U+0219) but cedilla **ţ** (U+0163), and silently drops the other two variants (ş U+015F, ț U+021B) — the tokenizer strips characters not in its vocab with no error. Real-world Romanian text freely mixes both spellings, so without handling this, letters silently vanish from the audio.

The backend NFC-normalizes input and maps each diacritic to the form the checkpoint was trained on (ş→ș, ț→ţ, uppercase included). An e2e test proves both spellings produce identical token ids with zero dropped characters.

## Extensible by design

`MMS_HF_REPOS` is a module-level `{language: checkpoint}` map — further MMS languages are one-line additions (e.g. Croatian `mms-tts-hrv`, requested in #549). Only Romanian ships in this PR to keep it reviewable.

## Changes

- `backend/backends/mms_backend.py` (new) — `MMSTTSBackend` implementing the `TTSBackend` protocol
- Registration: `TTS_ENGINES`, `ModelConfig`, factory branch in `backends/__init__.py`; `ro`/`mms` added to validation regexes in `models.py`; preset-voice branches in `routes/profiles.py` + `services/profiles.py`; PyInstaller hidden-import in `build_binary.py`
- Frontend: `ro` in `ALL_LANGUAGES`, `mms` in `ENGINE_LANGUAGES`, engine wired through the selector, profile forms, model management, and format/display maps
- Docs: README counts, `preset-voices.mdx`, `PROJECT_STATUS.md`, CHANGELOG

## Testing

- 31 unit tests (diacritic normalization both directions, NFC/NFD, registration, regexes, preset endpoint)
- 4 e2e tests gated behind `VOICEBOX_MMS_E2E=1` (real model download + generation: 16 kHz float32, no NaNs; token-identity proof for both diacritic spellings; seeded determinism)
- Full existing suite: green, zero regressions
- `bunx biome check` / `ruff check` clean on touched files (no new findings)
- Verified end-to-end in the web app: profile creation via Create Voice → Built-in → MMS Romanian, model download with progress, generation from the floating box, and language-dropdown gating (Romanian-only when the MMS engine is active; other engines unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **MMS (Meta) TTS** as an eighth voice-generation engine.
  * Added **Romanian (ro)** support with an **MMS Romanian** preset voice.
  * Added **Romanian diacritic normalization** to improve text handling for synthesis.
  * Updated engine/model selection, voice profiles, model management, and playback to support **mms**.

* **Documentation**
  * Updated feature claims, engine/language listings, and preset-voice documentation to include MMS Romanian.

* **Tests**
  * Added a dedicated MMS backend test suite (including Romanian diacritics and optional end-to-end generation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->