### PR TITLE
fix(i18n): add Cloud login translations for es, it, ko

### DIFF
--- a/app/src/components/ServerTab/CloudSection.tsx
+++ b/app/src/components/ServerTab/CloudSection.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Cloud, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { apiClient } from '@/lib/api/client';
@@ -10,6 +11,7 @@ import { SettingRow, SettingSection } from './SettingRow';
 // and completes the code exchange; here we just kick it off and poll status
 // until the link goes live. The API key never touches the frontend.
 export function CloudSection() {
+  const { t } = useTranslation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [polling, setPolling] = useState(false);
@@ -27,11 +29,13 @@ export function CloudSection() {
     if (connected && polling) {
       setPolling(false);
       toast({
-        title: 'Connected to Voicebox Cloud',
-        description: `Linked as ${status?.device_name ?? 'this device'}.`,
+        title: t('settings.general.cloud.connectedToast.title'),
+        description: t('settings.general.cloud.connectedToast.description', {
+          name: status?.device_name ?? t('settings.general.cloud.account.thisDevice'),
+        }),
       });
     }
-  }, [connected, polling, status?.device_name, toast]);
+  }, [connected, polling, status?.device_name, toast, t]);
 
   // Give up after two minutes so an abandoned browser flow doesn't leave the
   // button stuck on "Waiting for browser…". The backend state stays valid for
@@ -41,26 +45,26 @@ export function CloudSection() {
     const timeoutId = window.setTimeout(() => {
       setPolling(false);
       toast({
-        title: 'Sign-in timed out',
-        description: 'The browser sign-in was not completed. Try again.',
+        title: t('settings.general.cloud.signInTimedOut.title'),
+        description: t('settings.general.cloud.signInTimedOut.description'),
         variant: 'destructive',
       });
     }, 120_000);
     return () => window.clearTimeout(timeoutId);
-  }, [polling, toast]);
+  }, [polling, toast, t]);
 
   const startLogin = useMutation({
     mutationFn: () => apiClient.startCloudLogin(),
     onSuccess: () => {
       setPolling(true);
       toast({
-        title: 'Continue in your browser',
-        description: 'Authorize this device, then return here.',
+        title: t('settings.general.cloud.continueInBrowser.title'),
+        description: t('settings.general.cloud.continueInBrowser.description'),
       });
     },
     onError: (error: Error) =>
       toast({
-        title: 'Could not start sign-in',
+        title: t('settings.general.cloud.signInFailedTitle'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -71,30 +75,38 @@ export function CloudSection() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cloud-status'] });
       toast({
-        title: 'Disconnected',
-        description:
-          'This device is no longer linked. The key stays valid until revoked in your account.',
+        title: t('settings.general.cloud.disconnectedToast.title'),
+        description: t('settings.general.cloud.disconnectedToast.description'),
       });
     },
     onError: (error: Error) =>
-      toast({ title: 'Could not disconnect', description: error.message, variant: 'destructive' }),
+      toast({
+        title: t('settings.general.cloud.disconnectFailedTitle'),
+        description: error.message,
+        variant: 'destructive',
+      }),
   });
 
   const busy = startLogin.isPending || polling;
 
   return (
     <SettingSection
-      title="Voicebox Cloud"
-      description="End-to-end encrypted backup & sync across your devices."
+      title={t('settings.general.cloud.title')}
+      description={t('settings.general.cloud.description')}
     >
       <SettingRow
-        title={connected ? 'Connected' : 'Account'}
+        title={
+          connected
+            ? t('settings.general.cloud.account.connected')
+            : t('settings.general.cloud.account.account')
+        }
         description={
           connected
-            ? `Linked as ${status?.device_name ?? 'this device'}${
-                status?.key_prefix ? ` · ${status.key_prefix}…` : ''
-              }`
-            : 'Log in to back up and sync your captures and generations.'
+            ? t('settings.general.cloud.account.linkedAs', {
+                name: status?.device_name ?? t('settings.general.cloud.account.thisDevice'),
+                keyPrefix: status?.key_prefix ? ` · ${status.key_prefix}…` : '',
+              })
+            : t('settings.general.cloud.account.logInHint')
         }
         action={
           connected ? (
@@ -107,10 +119,10 @@ export function CloudSection() {
               {disconnect.isPending ? (
                 <>
                   <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                  Disconnecting…
+                  {t('settings.general.cloud.actions.disconnecting')}
                 </>
               ) : (
-                'Disconnect'
+                t('settings.general.cloud.actions.disconnect')
               )}
             </Button>
           ) : (
@@ -118,12 +130,14 @@ export function CloudSection() {
               {busy ? (
                 <>
                   <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                  {polling ? 'Waiting for browser…' : 'Opening…'}
+                  {polling
+                    ? t('settings.general.cloud.actions.waitingForBrowser')
+                    : t('settings.general.cloud.actions.opening')}
                 </>
               ) : (
                 <>
                   <Cloud className="h-3.5 w-3.5 mr-1.5" />
-                  Log in with browser
+                  {t('settings.general.cloud.actions.logInWithBrowser')}
                 </>
               )}
             </Button>
@@ -133,8 +147,8 @@ export function CloudSection() {
 
       {connected && (
         <SettingRow
-          title="Manage"
-          description="Revoke this device, add API keys, or manage billing from your account."
+          title={t('settings.general.cloud.manage.title')}
+          description={t('settings.general.cloud.manage.description')}
         >
           <a
             className="text-sm text-accent hover:underline"
@@ -142,7 +156,7 @@ export function CloudSection() {
             rel="noopener noreferrer"
             target="_blank"
           >
-            Open account dashboard ↗
+            {t('settings.general.cloud.manage.openDashboard')}
           </a>
         </SettingRow>
       )}

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -832,6 +832,47 @@
           "profiles": "List voices",
           "history": "Past generations"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "End-to-end encrypted backup & sync across your devices.",
+        "connectedToast": {
+          "title": "Connected to Voicebox Cloud",
+          "description": "Linked as {{name}}."
+        },
+        "signInTimedOut": {
+          "title": "Sign-in timed out",
+          "description": "The browser sign-in was not completed. Try again."
+        },
+        "continueInBrowser": {
+          "title": "Continue in your browser",
+          "description": "Authorize this device, then return here."
+        },
+        "signInFailedTitle": "Could not start sign-in",
+        "disconnectedToast": {
+          "title": "Disconnected",
+          "description": "This device is no longer linked. The key stays valid until revoked in your account."
+        },
+        "disconnectFailedTitle": "Could not disconnect",
+        "account": {
+          "connected": "Connected",
+          "account": "Account",
+          "linkedAs": "Linked as {{name}}{{keyPrefix}}",
+          "thisDevice": "this device",
+          "logInHint": "Log in to back up and sync your captures and generations."
+        },
+        "actions": {
+          "disconnecting": "Disconnecting…",
+          "disconnect": "Disconnect",
+          "waitingForBrowser": "Waiting for browser…",
+          "opening": "Opening…",
+          "logInWithBrowser": "Log in with browser"
+        },
+        "manage": {
+          "title": "Manage",
+          "description": "Revoke this device, add API keys, or manage billing from your account.",
+          "openDashboard": "Open account dashboard ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/es/translation.json
+++ b/app/src/i18n/locales/es/translation.json
@@ -832,6 +832,47 @@
           "profiles": "Listar voces",
           "history": "Generaciones anteriores"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "Copia de seguridad y sincronización cifradas de extremo a extremo en todos tus dispositivos.",
+        "connectedToast": {
+          "title": "Conectado a Voicebox Cloud",
+          "description": "Vinculado como {{name}}."
+        },
+        "signInTimedOut": {
+          "title": "Tiempo de inicio de sesión agotado",
+          "description": "No se completó el inicio de sesión en el navegador. Inténtalo de nuevo."
+        },
+        "continueInBrowser": {
+          "title": "Continúa en tu navegador",
+          "description": "Autoriza este dispositivo y luego vuelve aquí."
+        },
+        "signInFailedTitle": "No se pudo iniciar el inicio de sesión",
+        "disconnectedToast": {
+          "title": "Desconectado",
+          "description": "Este dispositivo ya no está vinculado. La clave sigue siendo válida hasta que la revoques en tu cuenta."
+        },
+        "disconnectFailedTitle": "No se pudo desconectar",
+        "account": {
+          "connected": "Conectado",
+          "account": "Cuenta",
+          "linkedAs": "Vinculado como {{name}}{{keyPrefix}}",
+          "thisDevice": "este dispositivo",
+          "logInHint": "Inicia sesión para hacer copia de seguridad y sincronizar tus capturas y generaciones."
+        },
+        "actions": {
+          "disconnecting": "Desconectando…",
+          "disconnect": "Desconectar",
+          "waitingForBrowser": "Esperando al navegador…",
+          "opening": "Abriendo…",
+          "logInWithBrowser": "Iniciar sesión con el navegador"
+        },
+        "manage": {
+          "title": "Gestionar",
+          "description": "Revoca este dispositivo, añade claves de API o gestiona la facturación desde tu cuenta.",
+          "openDashboard": "Abrir panel de la cuenta ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/fr/translation.json
+++ b/app/src/i18n/locales/fr/translation.json
@@ -1132,10 +1132,14 @@
       "active": "Actif",
       "cuda": {
         "title": "Backend CUDA",
+        "activeTitle": "Backend CUDA actif",
         "description": "Accélération GPU NVIDIA via un backend CUDA téléchargeable.",
         "downloading": "Téléchargement du backend CUDA…",
         "downloadingShort": "Téléchargement…",
         "updating": "Mise à jour…"
+      },
+      "activeBackend": {
+        "description": "L'accélération GPU est actuellement activée."
       },
       "restart": {
         "ready": "Serveur redémarré avec succès",
@@ -1167,9 +1171,33 @@
         "downloadStart": "Échec du démarrage du téléchargement",
         "restartFailed": "Échec du redémarrage",
         "switchCpu": "Échec du basculement vers CPU",
-        "deleteCuda": "Échec de la suppression du backend CUDA"
+        "deleteCuda": "Échec de la suppression du backend CUDA",
+        "deleteRocm": "Échec de la suppression du backend ROCm"
       },
-      "footer": "Voicebox détecte et utilise automatiquement le meilleur GPU disponible sur votre système. Sur les Mac Apple Silicon, le backend MLX fonctionne nativement sur le Neural Engine et le GPU via Metal Performance Shaders (MPS), sans configuration supplémentaire. Sur Windows et Linux avec GPU NVIDIA, vous pouvez télécharger un backend CUDA optionnel pour l'inférence accélérée par le matériel. AMD ROCm, Intel XPU et DirectML sont également pris en charge là où disponibles via PyTorch. Quand aucun GPU n'est détecté, Voicebox utilise le CPU — tous les moteurs fonctionnent, mais plus lentement."
+      "footer": "Voicebox détecte et utilise automatiquement le meilleur GPU disponible sur votre système. Sur les Mac Apple Silicon, le backend MLX fonctionne nativement sur le Neural Engine et le GPU via Metal Performance Shaders (MPS), sans configuration supplémentaire. Sur Windows, vous pouvez télécharger des backends optionnels CUDA (NVIDIA) ou ROCm (AMD) pour l'inférence accélérée par le matériel. Intel XPU et DirectML sont également pris en charge là où disponibles via PyTorch. Quand aucun GPU n'est détecté, Voicebox utilise le CPU — tous les moteurs fonctionnent, mais plus lentement.",
+      "rocm": {
+        "title": "Backend AMD ROCm",
+        "activeTitle": "Backend ROCm actif",
+        "description": "Accélération GPU AMD via un backend ROCm téléchargeable.",
+        "downloading": "Téléchargement du backend ROCm…",
+        "downloadingShort": "Téléchargement…",
+        "updating": "Mise à jour…"
+      },
+      "downloadRocm": {
+        "title": "Télécharger le backend AMD ROCm",
+        "description": "~2-3 Go à télécharger. Nécessite un GPU AMD Radeon avec support ROCm.",
+        "button": "Télécharger"
+      },
+      "switchToRocm": {
+        "title": "Passer au backend ROCm",
+        "description": "Le backend ROCm est téléchargé et prêt. Redémarrez pour activer.",
+        "button": "Redémarrer"
+      },
+      "removeRocm": {
+        "title": "Supprimer le backend ROCm",
+        "description": "Supprimez le binaire ROCm téléchargé pour libérer de l'espace disque.",
+        "button": "Supprimer"
+      }
     },
     "logs": {
       "title": "Journaux du serveur",

--- a/app/src/i18n/locales/fr/translation.json
+++ b/app/src/i18n/locales/fr/translation.json
@@ -827,6 +827,47 @@
           "profiles": "Lister les voix",
           "history": "Générations passées"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "Sauvegarde et synchronisation chiffrées de bout en bout sur tous vos appareils.",
+        "connectedToast": {
+          "title": "Connecté à Voicebox Cloud",
+          "description": "Lié en tant que {{name}}."
+        },
+        "signInTimedOut": {
+          "title": "Délai de connexion dépassé",
+          "description": "La connexion via le navigateur n'a pas abouti. Réessayez."
+        },
+        "continueInBrowser": {
+          "title": "Continuez dans votre navigateur",
+          "description": "Autorisez cet appareil, puis revenez ici."
+        },
+        "signInFailedTitle": "Impossible de démarrer la connexion",
+        "disconnectedToast": {
+          "title": "Déconnecté",
+          "description": "Cet appareil n'est plus lié. La clé reste valide jusqu'à ce qu'elle soit révoquée depuis votre compte."
+        },
+        "disconnectFailedTitle": "Impossible de se déconnecter",
+        "account": {
+          "connected": "Connecté",
+          "account": "Compte",
+          "linkedAs": "Lié en tant que {{name}}{{keyPrefix}}",
+          "thisDevice": "cet appareil",
+          "logInHint": "Connectez-vous pour sauvegarder et synchroniser vos captures et générations."
+        },
+        "actions": {
+          "disconnecting": "Déconnexion…",
+          "disconnect": "Déconnecter",
+          "waitingForBrowser": "En attente du navigateur…",
+          "opening": "Ouverture…",
+          "logInWithBrowser": "Se connecter via le navigateur"
+        },
+        "manage": {
+          "title": "Gérer",
+          "description": "Révoquez cet appareil, ajoutez des clés API ou gérez la facturation depuis votre compte.",
+          "openDashboard": "Ouvrir le tableau de bord du compte ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/it/translation.json
+++ b/app/src/i18n/locales/it/translation.json
@@ -832,6 +832,47 @@
           "profiles": "Elenca voci",
           "history": "Generazioni passate"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "Backup e sincronizzazione crittografati end-to-end su tutti i tuoi dispositivi.",
+        "connectedToast": {
+          "title": "Connesso a Voicebox Cloud",
+          "description": "Collegato come {{name}}."
+        },
+        "signInTimedOut": {
+          "title": "Accesso scaduto",
+          "description": "L'accesso dal browser non è stato completato. Riprova."
+        },
+        "continueInBrowser": {
+          "title": "Continua nel tuo browser",
+          "description": "Autorizza questo dispositivo, poi torna qui."
+        },
+        "signInFailedTitle": "Impossibile avviare l'accesso",
+        "disconnectedToast": {
+          "title": "Disconnesso",
+          "description": "Questo dispositivo non è più collegato. La chiave resta valida finché non la revochi dal tuo account."
+        },
+        "disconnectFailedTitle": "Impossibile disconnettersi",
+        "account": {
+          "connected": "Connesso",
+          "account": "Account",
+          "linkedAs": "Collegato come {{name}}{{keyPrefix}}",
+          "thisDevice": "questo dispositivo",
+          "logInHint": "Accedi per eseguire il backup e sincronizzare le tue registrazioni e generazioni."
+        },
+        "actions": {
+          "disconnecting": "Disconnessione…",
+          "disconnect": "Disconnetti",
+          "waitingForBrowser": "In attesa del browser…",
+          "opening": "Apertura…",
+          "logInWithBrowser": "Accedi tramite browser"
+        },
+        "manage": {
+          "title": "Gestisci",
+          "description": "Revoca questo dispositivo, aggiungi chiavi API o gestisci la fatturazione dal tuo account.",
+          "openDashboard": "Apri la dashboard dell'account ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/it/translation.json
+++ b/app/src/i18n/locales/it/translation.json
@@ -158,7 +158,7 @@
       "inputMonitoring": {
         "title": "Concedi il Monitoraggio input per attivare la scorciatoia globale",
         "body": "Voicebox richiede <path>Impostazioni di Sistema → Privacy e Sicurezza → Monitoraggio input</path> per rilevare la tua combinazione di dettatura. L'opzione è attiva, ma macOS sta bloccando gli eventi della tastiera finché non lo consenti.",
-        "openSettings": "Opzioni Impostazioni",
+        "openSettings": "Apri Impostazioni",
         "recheck": "L'ho abilitato",
         "rechecking": "Verifica in corso…",
         "stillMissing": "Non ancora rilevato. Di solito macOS richiede la chiusura e la riapertura di Voicebox dopo aver attivato il permesso."

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -827,6 +827,47 @@
           "profiles": "ボイス一覧",
           "history": "過去の生成"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "デバイス間でエンドツーエンド暗号化されたバックアップと同期。",
+        "connectedToast": {
+          "title": "Voicebox Cloud に接続しました",
+          "description": "{{name}} としてリンクされました。"
+        },
+        "signInTimedOut": {
+          "title": "サインインがタイムアウトしました",
+          "description": "ブラウザでのサインインが完了しませんでした。もう一度お試しください。"
+        },
+        "continueInBrowser": {
+          "title": "ブラウザで続行してください",
+          "description": "このデバイスを認証してから、ここに戻ってください。"
+        },
+        "signInFailedTitle": "サインインを開始できませんでした",
+        "disconnectedToast": {
+          "title": "切断されました",
+          "description": "このデバイスのリンクは解除されました。キーはアカウントで取り消すまで有効です。"
+        },
+        "disconnectFailedTitle": "切断できませんでした",
+        "account": {
+          "connected": "接続済み",
+          "account": "アカウント",
+          "linkedAs": "{{name}} としてリンク済み{{keyPrefix}}",
+          "thisDevice": "このデバイス",
+          "logInHint": "ログインしてキャプチャと生成をバックアップ・同期しましょう。"
+        },
+        "actions": {
+          "disconnecting": "切断中…",
+          "disconnect": "切断",
+          "waitingForBrowser": "ブラウザを待っています…",
+          "opening": "開いています…",
+          "logInWithBrowser": "ブラウザでログイン"
+        },
+        "manage": {
+          "title": "管理",
+          "description": "アカウントからこのデバイスを取り消したり、APIキーを追加したり、請求を管理したりできます。",
+          "openDashboard": "アカウントダッシュボードを開く ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -1132,10 +1132,14 @@
       "active": "有効",
       "cuda": {
         "title": "CUDA バックエンド",
+        "activeTitle": "CUDA バックエンドが有効",
         "description": "ダウンロード可能な CUDA バックエンドによる NVIDIA GPU アクセラレーション。",
         "downloading": "CUDA バックエンドをダウンロード中…",
         "downloadingShort": "ダウンロード中…",
         "updating": "更新中…"
+      },
+      "activeBackend": {
+        "description": "GPU アクセラレーションは現在有効です。"
       },
       "restart": {
         "ready": "サーバーを正常に再起動しました",
@@ -1167,9 +1171,33 @@
         "downloadStart": "ダウンロードを開始できませんでした",
         "restartFailed": "再起動に失敗しました",
         "switchCpu": "CPU への切り替えに失敗しました",
-        "deleteCuda": "CUDA バックエンドの削除に失敗しました"
+        "deleteCuda": "CUDA バックエンドの削除に失敗しました",
+        "deleteRocm": "ROCm バックエンドの削除に失敗しました"
       },
-      "footer": "Voicebox はシステムで利用可能な最適な GPU を自動で検出し使用します。Apple Silicon Mac では、MLX バックエンドが Metal Performance Shaders(MPS)を介して Neural Engine と GPU 上でネイティブに動作し、追加のセットアップは不要です。NVIDIA GPU 搭載の Windows および Linux では、オプションの CUDA バックエンドをダウンロードしてハードウェアアクセラレーションによる推論が可能です。AMD ROCm、Intel XPU、DirectML も PyTorch を通じて利用可能な環境でサポートされます。GPU が検出されない場合、Voicebox は CPU にフォールバックし、すべてのエンジンはそのまま動作しますが速度は低下します。"
+      "footer": "Voicebox はシステムで利用可能な最適な GPU を自動で検出し使用します。Apple Silicon Mac では、MLX バックエンドが Metal Performance Shaders(MPS)を介して Neural Engine と GPU 上でネイティブに動作し、追加のセットアップは不要です。Windows では、オプションの CUDA(NVIDIA)または ROCm(AMD)バックエンドをダウンロードしてハードウェアアクセラレーションによる推論が可能です。Intel XPU と DirectML も PyTorch を通じて利用可能な環境でサポートされます。GPU が検出されない場合、Voicebox は CPU にフォールバックし、すべてのエンジンはそのまま動作しますが速度は低下します。",
+      "rocm": {
+        "title": "AMD ROCm バックエンド",
+        "activeTitle": "ROCm バックエンドが有効",
+        "description": "ダウンロード可能な ROCm バックエンドによる AMD GPU アクセラレーション。",
+        "downloading": "ROCm バックエンドをダウンロード中…",
+        "downloadingShort": "ダウンロード中…",
+        "updating": "更新中…"
+      },
+      "downloadRocm": {
+        "title": "AMD ROCm バックエンドをダウンロード",
+        "description": "約 2〜3 GB のダウンロード。ROCm 対応の AMD Radeon GPU が必要です。",
+        "button": "ダウンロード"
+      },
+      "switchToRocm": {
+        "title": "ROCm バックエンドに切り替え",
+        "description": "ROCm バックエンドはダウンロード済みです。再起動して有効にします。",
+        "button": "再起動"
+      },
+      "removeRocm": {
+        "title": "ROCm バックエンドを削除",
+        "description": "ダウンロードした ROCm バイナリを削除してディスク容量を空けます。",
+        "button": "削除"
+      }
     },
     "logs": {
       "title": "サーバーログ",

--- a/app/src/i18n/locales/ko/translation.json
+++ b/app/src/i18n/locales/ko/translation.json
@@ -827,6 +827,47 @@
           "profiles": "음성 목록",
           "history": "과거 생성물"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "모든 기기에서 종단 간 암호화된 백업 및 동기화.",
+        "connectedToast": {
+          "title": "Voicebox Cloud에 연결됨",
+          "description": "{{name}}(으)로 연결됨."
+        },
+        "signInTimedOut": {
+          "title": "로그인 시간 초과",
+          "description": "브라우저 로그인이 완료되지 않았습니다. 다시 시도하세요."
+        },
+        "continueInBrowser": {
+          "title": "브라우저에서 계속하기",
+          "description": "이 기기를 승인한 후 돌아오세요."
+        },
+        "signInFailedTitle": "로그인을 시작할 수 없습니다",
+        "disconnectedToast": {
+          "title": "연결 해제됨",
+          "description": "이 기기의 연결이 해제되었습니다. 계정에서 취소하기 전까지 키는 계속 유효합니다."
+        },
+        "disconnectFailedTitle": "연결을 해제할 수 없습니다",
+        "account": {
+          "connected": "연결됨",
+          "account": "계정",
+          "linkedAs": "{{name}}{{keyPrefix}}(으)로 연결됨",
+          "thisDevice": "이 기기",
+          "logInHint": "캡처 및 생성물을 백업하고 동기화하려면 로그인하세요."
+        },
+        "actions": {
+          "disconnecting": "연결 해제 중…",
+          "disconnect": "연결 해제",
+          "waitingForBrowser": "브라우저 대기 중…",
+          "opening": "여는 중…",
+          "logInWithBrowser": "브라우저로 로그인"
+        },
+        "manage": {
+          "title": "관리",
+          "description": "계정에서 이 기기를 취소하거나, API 키를 추가하거나, 결제를 관리하세요.",
+          "openDashboard": "계정 대시보드 열기 ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/pt-BR/translation.json
+++ b/app/src/i18n/locales/pt-BR/translation.json
@@ -827,6 +827,47 @@
           "profiles": "Listar vozes",
           "history": "Gerações anteriores"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "Backup e sincronização com criptografia de ponta a ponta entre seus dispositivos.",
+        "connectedToast": {
+          "title": "Conectado ao Voicebox Cloud",
+          "description": "Vinculado como {{name}}."
+        },
+        "signInTimedOut": {
+          "title": "Tempo de login esgotado",
+          "description": "O login pelo navegador não foi concluído. Tente novamente."
+        },
+        "continueInBrowser": {
+          "title": "Continue no seu navegador",
+          "description": "Autorize este dispositivo e depois volte aqui."
+        },
+        "signInFailedTitle": "Não foi possível iniciar o login",
+        "disconnectedToast": {
+          "title": "Desconectado",
+          "description": "Este dispositivo não está mais vinculado. A chave continua válida até ser revogada na sua conta."
+        },
+        "disconnectFailedTitle": "Não foi possível desconectar",
+        "account": {
+          "connected": "Conectado",
+          "account": "Conta",
+          "linkedAs": "Vinculado como {{name}}{{keyPrefix}}",
+          "thisDevice": "este dispositivo",
+          "logInHint": "Faça login para fazer backup e sincronizar suas capturas e gerações."
+        },
+        "actions": {
+          "disconnecting": "Desconectando…",
+          "disconnect": "Desconectar",
+          "waitingForBrowser": "Aguardando o navegador…",
+          "opening": "Abrindo…",
+          "logInWithBrowser": "Entrar pelo navegador"
+        },
+        "manage": {
+          "title": "Gerenciar",
+          "description": "Revogue este dispositivo, adicione chaves de API ou gerencie a cobrança na sua conta.",
+          "openDashboard": "Abrir painel da conta ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/pt-BR/translation.json
+++ b/app/src/i18n/locales/pt-BR/translation.json
@@ -1132,10 +1132,14 @@
       "active": "Ativo",
       "cuda": {
         "title": "Backend CUDA",
+        "activeTitle": "Backend CUDA ativo",
         "description": "Aceleração por GPU NVIDIA via um backend CUDA baixável.",
         "downloading": "Baixando o backend CUDA…",
         "downloadingShort": "Baixando…",
         "updating": "Atualizando…"
+      },
+      "activeBackend": {
+        "description": "A aceleração por GPU está ativada no momento."
       },
       "restart": {
         "ready": "Servidor reiniciado com sucesso",
@@ -1167,9 +1171,33 @@
         "downloadStart": "Falha ao iniciar o download",
         "restartFailed": "Falha ao reiniciar",
         "switchCpu": "Falha ao mudar para CPU",
-        "deleteCuda": "Falha ao excluir o backend CUDA"
+        "deleteCuda": "Falha ao excluir o backend CUDA",
+        "deleteRocm": "Falha ao excluir o backend ROCm"
       },
-      "footer": "O Voicebox detecta e usa automaticamente a melhor GPU disponível no seu sistema. Em Macs com Apple Silicon, o backend MLX roda nativamente no Neural Engine e na GPU via Metal Performance Shaders (MPS), sem configuração adicional. No Windows e no Linux com GPUs NVIDIA, você pode baixar um backend CUDA opcional para inferência acelerada por hardware. AMD ROCm, Intel XPU e DirectML também são suportados quando disponíveis através do PyTorch. Quando nenhuma GPU é detectada, o Voicebox recorre à CPU — todos os motores ainda funcionam, só que mais devagar."
+      "footer": "O Voicebox detecta e usa automaticamente a melhor GPU disponível no seu sistema. Em Macs com Apple Silicon, o backend MLX roda nativamente no Neural Engine e na GPU via Metal Performance Shaders (MPS), sem configuração adicional. No Windows, você pode baixar backends opcionais de CUDA (NVIDIA) ou ROCm (AMD) para inferência acelerada por hardware. Intel XPU e DirectML também são suportados quando disponíveis através do PyTorch. Quando nenhuma GPU é detectada, o Voicebox recorre à CPU — todos os motores ainda funcionam, só que mais devagar.",
+      "rocm": {
+        "title": "Backend AMD ROCm",
+        "activeTitle": "Backend ROCm ativo",
+        "description": "Aceleração por GPU AMD via um backend ROCm baixável.",
+        "downloading": "Baixando o backend ROCm…",
+        "downloadingShort": "Baixando…",
+        "updating": "Atualizando…"
+      },
+      "downloadRocm": {
+        "title": "Baixar o backend AMD ROCm",
+        "description": "Download de ~2-3 GB. Requer uma GPU AMD Radeon com suporte a ROCm.",
+        "button": "Baixar"
+      },
+      "switchToRocm": {
+        "title": "Mudar para o backend ROCm",
+        "description": "O backend ROCm foi baixado e está pronto. Reinicie para ativar.",
+        "button": "Reiniciar"
+      },
+      "removeRocm": {
+        "title": "Remover o backend ROCm",
+        "description": "Exclui o binário ROCm baixado para liberar espaço em disco.",
+        "button": "Remover"
+      }
     },
     "logs": {
       "title": "Logs do Servidor",

--- a/app/src/i18n/locales/zh-CN/translation.json
+++ b/app/src/i18n/locales/zh-CN/translation.json
@@ -827,6 +827,47 @@
           "profiles": "声音列表",
           "history": "历史生成"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "跨设备端到端加密备份与同步。",
+        "connectedToast": {
+          "title": "已连接到 Voicebox Cloud",
+          "description": "已关联为 {{name}}。"
+        },
+        "signInTimedOut": {
+          "title": "登录超时",
+          "description": "浏览器登录未完成。请重试。"
+        },
+        "continueInBrowser": {
+          "title": "请在浏览器中继续",
+          "description": "授权此设备后返回此处。"
+        },
+        "signInFailedTitle": "无法开始登录",
+        "disconnectedToast": {
+          "title": "已断开连接",
+          "description": "此设备已取消关联。密钥在您的账户中撤销之前仍然有效。"
+        },
+        "disconnectFailedTitle": "无法断开连接",
+        "account": {
+          "connected": "已连接",
+          "account": "账户",
+          "linkedAs": "已关联为 {{name}}{{keyPrefix}}",
+          "thisDevice": "此设备",
+          "logInHint": "登录以备份和同步您的捕获内容与生成内容。"
+        },
+        "actions": {
+          "disconnecting": "正在断开连接…",
+          "disconnect": "断开连接",
+          "waitingForBrowser": "正在等待浏览器…",
+          "opening": "正在打开…",
+          "logInWithBrowser": "通过浏览器登录"
+        },
+        "manage": {
+          "title": "管理",
+          "description": "在您的账户中撤销此设备、添加 API 密钥或管理账单。",
+          "openDashboard": "打开账户面板 ↗"
+        }
       }
     },
     "generation": {

--- a/app/src/i18n/locales/zh-CN/translation.json
+++ b/app/src/i18n/locales/zh-CN/translation.json
@@ -1132,10 +1132,14 @@
       "active": "活动",
       "cuda": {
         "title": "CUDA 后端",
+        "activeTitle": "CUDA 后端已启用",
         "description": "通过可下载的 CUDA 后端实现 NVIDIA GPU 加速。",
         "downloading": "下载 CUDA 后端中…",
         "downloadingShort": "下载中…",
         "updating": "更新中…"
+      },
+      "activeBackend": {
+        "description": "GPU 加速当前已启用。"
       },
       "restart": {
         "ready": "服务器重启成功",
@@ -1167,9 +1171,33 @@
         "downloadStart": "启动下载失败",
         "restartFailed": "重启失败",
         "switchCpu": "切换到 CPU 失败",
-        "deleteCuda": "删除 CUDA 后端失败"
+        "deleteCuda": "删除 CUDA 后端失败",
+        "deleteRocm": "删除 ROCm 后端失败"
       },
-      "footer": "Voicebox 会自动检测并使用系统上可用的最佳 GPU。在 Apple Silicon Mac 上,MLX 后端通过 Metal Performance Shaders (MPS) 在神经引擎和 GPU 上原生运行,无需额外设置。在配备 NVIDIA GPU 的 Windows 和 Linux 上,您可以下载可选的 CUDA 后端以获得硬件加速推理。AMD ROCm、Intel XPU 和 DirectML 也通过 PyTorch 获得支持。未检测到 GPU 时,Voicebox 会退回到 CPU——所有引擎仍可工作,只是速度较慢。"
+      "footer": "Voicebox 会自动检测并使用系统上可用的最佳 GPU。在 Apple Silicon Mac 上,MLX 后端通过 Metal Performance Shaders (MPS) 在神经引擎和 GPU 上原生运行,无需额外设置。在 Windows 上,您可以下载可选的 CUDA(NVIDIA)或 ROCm(AMD)后端以获得硬件加速推理。Intel XPU 和 DirectML 也通过 PyTorch 获得支持。未检测到 GPU 时,Voicebox 会退回到 CPU——所有引擎仍可工作,只是速度较慢。",
+      "rocm": {
+        "title": "AMD ROCm 后端",
+        "activeTitle": "ROCm 后端已启用",
+        "description": "通过可下载的 ROCm 后端实现 AMD GPU 加速。",
+        "downloading": "下载 ROCm 后端中…",
+        "downloadingShort": "下载中…",
+        "updating": "更新中…"
+      },
+      "downloadRocm": {
+        "title": "下载 AMD ROCm 后端",
+        "description": "约 2-3 GB 下载。需要支持 ROCm 的 AMD Radeon GPU。",
+        "button": "下载"
+      },
+      "switchToRocm": {
+        "title": "切换到 ROCm 后端",
+        "description": "ROCm 后端已下载完成。重启以启用。",
+        "button": "重启"
+      },
+      "removeRocm": {
+        "title": "移除 ROCm 后端",
+        "description": "删除已下载的 ROCm 二进制文件以释放磁盘空间。",
+        "button": "移除"
+      }
     },
     "logs": {
       "title": "服务器日志",

--- a/app/src/i18n/locales/zh-TW/translation.json
+++ b/app/src/i18n/locales/zh-TW/translation.json
@@ -1132,10 +1132,14 @@
       "active": "啟用中",
       "cuda": {
         "title": "CUDA 後端",
+        "activeTitle": "CUDA 後端已啟用",
         "description": "透過可下載的 CUDA 後端實現 NVIDIA GPU 加速。",
         "downloading": "下載 CUDA 後端中…",
         "downloadingShort": "下載中…",
         "updating": "更新中…"
+      },
+      "activeBackend": {
+        "description": "GPU 加速目前已啟用。"
       },
       "restart": {
         "ready": "伺服器重新啟動成功",
@@ -1167,9 +1171,33 @@
         "downloadStart": "啟動下載失敗",
         "restartFailed": "重新啟動失敗",
         "switchCpu": "切換到 CPU 失敗",
-        "deleteCuda": "刪除 CUDA 後端失敗"
+        "deleteCuda": "刪除 CUDA 後端失敗",
+        "deleteRocm": "刪除 ROCm 後端失敗"
       },
-      "footer": "Voicebox 會自動偵測並使用系統上可用的最佳 GPU。在 Apple Silicon Mac 上,MLX 後端透過 Metal Performance Shaders (MPS) 在神經引擎與 GPU 上原生執行,無需額外設定。在配備 NVIDIA GPU 的 Windows 與 Linux 上,可以下載選用的 CUDA 後端以取得硬體加速推論。AMD ROCm、Intel XPU 與 DirectML 也透過 PyTorch 獲得支援。未偵測到 GPU 時,Voicebox 會退回到 CPU——所有引擎仍可運作,只是速度較慢。"
+      "footer": "Voicebox 會自動偵測並使用系統上可用的最佳 GPU。在 Apple Silicon Mac 上,MLX 後端透過 Metal Performance Shaders (MPS) 在神經引擎與 GPU 上原生執行,無需額外設定。在 Windows 上,可以下載選用的 CUDA(NVIDIA)或 ROCm(AMD)後端以取得硬體加速推論。Intel XPU 與 DirectML 也透過 PyTorch 獲得支援。未偵測到 GPU 時,Voicebox 會退回到 CPU——所有引擎仍可運作,只是速度較慢。",
+      "rocm": {
+        "title": "AMD ROCm 後端",
+        "activeTitle": "ROCm 後端已啟用",
+        "description": "透過可下載的 ROCm 後端實現 AMD GPU 加速。",
+        "downloading": "下載 ROCm 後端中…",
+        "downloadingShort": "下載中…",
+        "updating": "更新中…"
+      },
+      "downloadRocm": {
+        "title": "下載 AMD ROCm 後端",
+        "description": "約 2-3 GB 下載。需要支援 ROCm 的 AMD Radeon GPU。",
+        "button": "下載"
+      },
+      "switchToRocm": {
+        "title": "切換到 ROCm 後端",
+        "description": "ROCm 後端已下載完成。重新啟動以啟用。",
+        "button": "重新啟動"
+      },
+      "removeRocm": {
+        "title": "移除 ROCm 後端",
+        "description": "刪除已下載的 ROCm 二進位檔以釋放磁碟空間。",
+        "button": "移除"
+      }
     },
     "logs": {
       "title": "伺服器日誌",

--- a/app/src/i18n/locales/zh-TW/translation.json
+++ b/app/src/i18n/locales/zh-TW/translation.json
@@ -827,6 +827,47 @@
           "profiles": "聲音清單",
           "history": "歷史生成"
         }
+      },
+      "cloud": {
+        "title": "Voicebox Cloud",
+        "description": "跨裝置端對端加密備份與同步。",
+        "connectedToast": {
+          "title": "已連接到 Voicebox Cloud",
+          "description": "已關聯為 {{name}}。"
+        },
+        "signInTimedOut": {
+          "title": "登入逾時",
+          "description": "瀏覽器登入未完成。請再試一次。"
+        },
+        "continueInBrowser": {
+          "title": "請在瀏覽器中繼續",
+          "description": "授權此裝置後返回此處。"
+        },
+        "signInFailedTitle": "無法開始登入",
+        "disconnectedToast": {
+          "title": "已中斷連接",
+          "description": "此裝置已取消關聯。金鑰在您的帳戶中撤銷之前仍然有效。"
+        },
+        "disconnectFailedTitle": "無法中斷連接",
+        "account": {
+          "connected": "已連接",
+          "account": "帳戶",
+          "linkedAs": "已關聯為 {{name}}{{keyPrefix}}",
+          "thisDevice": "此裝置",
+          "logInHint": "登入以備份並同步您的擷取內容與生成內容。"
+        },
+        "actions": {
+          "disconnecting": "正在中斷連接…",
+          "disconnect": "中斷連接",
+          "waitingForBrowser": "正在等待瀏覽器…",
+          "opening": "正在開啟…",
+          "logInWithBrowser": "透過瀏覽器登入"
+        },
+        "manage": {
+          "title": "管理",
+          "description": "在您的帳戶中撤銷此裝置、新增 API 金鑰或管理帳單。",
+          "openDashboard": "開啟帳戶面板 ↗"
+        }
       }
     },
     "generation": {


### PR DESCRIPTION
## Summary
  Internationalize the Cloud login UI (added in #812) and fill in missing ROCm GPU translations, bringing all 8 non-English locales (es, fr, it, ja, ko, pt-BR, zh-CN, zh-TW) to full key parity with `en`.

  - `CloudSection.tsx` had zero `useTranslation`/`t()` calls — titles, toasts, and button labels were hardcoded English strings regardless of the user's selected language. Wired in 25 new `settings.general.cloud.*` keys and replaced the hardcoded strings
  with `t()` calls.
  - `fr`, `ja`, `pt-BR`, `zh-CN`, `zh-TW` were missing translations for the `settings.general.rocm.*` namespace (silently falling back to English).
  - Added the Cloud login translations to `es`, `it`, `ko` as well, so all locales stay consistent.

  Verified: key parity 875/875 across all 8 non-English locale files (no missing/extra keys vs `en`), JSON validates.

  ## Test plan
  - [x] Ran the app locally (`just dev-web`), switched language to es/it/ko/fr/ja/pt-BR/zh-CN/zh-TW, confirmed the Cloud login section (Settings → General) renders translated instead of falling back to English
  - [x] Scripted key-parity check confirms 875/875 keys across all locale files vs `en`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized Voicebox Cloud settings, including browser sign-in, connection status, account linking, disconnection, and dashboard management.
  - Added ROCm GPU backend settings with download, switching, active-status, update, and removal controls.
  - Added clearer CUDA active-backend status information.

- **Improvements**
  - Expanded GPU error messages and updated hardware support guidance.
  - Improved localized wording across supported languages, including a shortcut settings label correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->