### PR TITLE
feat: add custom system prompt for transcript refinement

### DIFF
--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronDown, FolderOpen, Info, Keyboard, Laptop, Lock, Volume2 } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AccessibilityNotice } from '@/components/AccessibilityGate/AccessibilityGate';
 import { InputMonitoringNotice } from '@/components/InputMonitoringGate/InputMonitoringGate';
@@ -7,6 +7,7 @@ import { CapturePill, type PillState } from '@/components/CapturePill/CapturePil
 import { DictationReadinessChecklist } from '@/components/CapturesTab/DictationReadinessChecklist';
 import { ChordPicker } from '@/components/ChordPicker/ChordPicker';
 import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -117,6 +118,48 @@ function HotkeyPillPreview({ enabled }: { enabled: boolean }) {
         <CapturePill state={state} elapsedMs={elapsedMs} />
       </div>
     </div>
+  );
+}
+
+function CustomPromptField({
+  value,
+  disabled,
+  onSave,
+  placeholder,
+  title,
+  description,
+}: {
+  value: string;
+  disabled: boolean;
+  onSave: (v: string) => void;
+  placeholder: string;
+  title: string;
+  description: string;
+}) {
+  const [draft, setDraft] = useState(value);
+  const changedRef = useRef(false);
+
+  useEffect(() => {
+    setDraft(value);
+    changedRef.current = false;
+  }, [value]);
+
+  return (
+    <SettingRow title={title} description={description}>
+      <Textarea
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          changedRef.current = true;
+        }}
+        onBlur={() => {
+          if (changedRef.current) onSave(draft);
+        }}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="min-h-[120px] resize-y"
+      />
+    </SettingRow>
   );
 }
 
@@ -452,6 +495,15 @@ export function CapturesPage() {
               disabled={!autoRefine}
             />
           }
+        />
+
+        <CustomPromptField
+          value={settings?.system_prompt ?? ''}
+          disabled={!autoRefine}
+          onSave={(v) => update({ system_prompt: v || null })}
+          placeholder={t('settings.captures.refinement.customPrompt.placeholder')}
+          title={t('settings.captures.refinement.customPrompt.title')}
+          description={t('settings.captures.refinement.customPrompt.description')}
         />
       </SettingSection>
 

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -982,6 +982,11 @@
         "preserveTechnical": {
           "title": "Preserve technical terms",
           "description": "Keep code identifiers, command names, and acronyms exactly as spoken. Turn on when you dictate into a code prompt."
+        },
+        "customPrompt": {
+          "title": "Custom system prompt",
+          "description": "Replace the built-in instruction with your own. Leave empty to use the default prompt with the toggles above.",
+          "placeholder": "You are a text filter. Transform raw speech-to-text transcripts into clean, readable text..."
         }
       },
       "playback": {

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -157,6 +157,7 @@ export interface RefinementFlags {
   smart_cleanup: boolean;
   self_correction: boolean;
   preserve_technical: boolean;
+  system_prompt?: string | null;
 }
 
 export interface CaptureResponse {
@@ -208,6 +209,7 @@ export interface CaptureSettings {
   smart_cleanup: boolean;
   self_correction: boolean;
   preserve_technical: boolean;
+  system_prompt: string | null;
   allow_auto_paste: boolean;
   default_playback_voice_id: string | null;
   /** Whether the global keyboard hotkey is armed. Off by default — turning

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -243,6 +243,13 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "hotkey_enabled BOOLEAN NOT NULL DEFAULT 0",
             "hotkey_enabled",
         )
+    if "system_prompt" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "system_prompt TEXT",
+            "system_prompt",
+        )
 
 
 def _migrate_mcp_bindings(engine, inspector, tables: set[str]) -> None:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -210,6 +210,7 @@ class CaptureSettings(Base):
     # "Voicebox would like to receive keystrokes from any application" dialog
     # before they've even opened the Captures tab.
     hotkey_enabled = Column(Boolean, nullable=False, default=False)
+    system_prompt = Column(Text, nullable=True, default=None)
     # Lists of keytap key names (e.g. "MetaRight", "ControlRight"). Right-hand
     # modifiers by default so they don't collide with left-hand shortcuts.
     chord_push_to_talk_keys = Column(

--- a/backend/models.py
+++ b/backend/models.py
@@ -188,6 +188,7 @@ class RefinementFlagsModel(BaseModel):
     smart_cleanup: bool = True
     self_correction: bool = True
     preserve_technical: bool = True
+    system_prompt: Optional[str] = None
 
 
 class CaptureResponse(BaseModel):
@@ -255,6 +256,7 @@ class CaptureSettingsResponse(BaseModel):
     smart_cleanup: bool = True
     self_correction: bool = True
     preserve_technical: bool = True
+    system_prompt: Optional[str] = None
     allow_auto_paste: bool = True
     default_playback_voice_id: Optional[str] = None
     hotkey_enabled: bool = False
@@ -279,6 +281,7 @@ class CaptureSettingsUpdate(BaseModel):
     smart_cleanup: Optional[bool] = None
     self_correction: Optional[bool] = None
     preserve_technical: Optional[bool] = None
+    system_prompt: Optional[str] = None
     allow_auto_paste: Optional[bool] = None
     default_playback_voice_id: Optional[str] = None
     hotkey_enabled: Optional[bool] = None

--- a/backend/routes/captures.py
+++ b/backend/routes/captures.py
@@ -128,12 +128,14 @@ async def refine_capture_endpoint(
             smart_cleanup=request.flags.smart_cleanup,
             self_correction=request.flags.self_correction,
             preserve_technical=request.flags.preserve_technical,
+            system_prompt=request.flags.system_prompt,
         )
     else:
         flags = RefinementFlags(
             smart_cleanup=saved.smart_cleanup,
             self_correction=saved.self_correction,
             preserve_technical=saved.preserve_technical,
+            system_prompt=getattr(saved, "system_prompt", None),
         )
 
     resolved_model = request.model_size or saved.llm_model

--- a/backend/services/refinement.py
+++ b/backend/services/refinement.py
@@ -118,13 +118,17 @@ class RefinementFlags:
     smart_cleanup: bool = True
     self_correction: bool = True
     preserve_technical: bool = True
+    system_prompt: str | None = None
 
     def to_dict(self) -> dict:
-        return {
+        d: dict = {
             "smart_cleanup": self.smart_cleanup,
             "self_correction": self.self_correction,
             "preserve_technical": self.preserve_technical,
         }
+        if self.system_prompt is not None:
+            d["system_prompt"] = self.system_prompt
+        return d
 
     @classmethod
     def from_dict(cls, data: dict | None) -> "RefinementFlags":
@@ -134,6 +138,7 @@ class RefinementFlags:
             smart_cleanup=bool(data.get("smart_cleanup", True)),
             self_correction=bool(data.get("self_correction", True)),
             preserve_technical=bool(data.get("preserve_technical", True)),
+            system_prompt=data.get("system_prompt"),
         )
 
 
@@ -184,7 +189,14 @@ For example, "run npm install then cd into src slash components and edit index d
 
 
 def build_refinement_prompt(flags: RefinementFlags) -> str:
-    """Assemble the system prompt for a given flag combination."""
+    """Assemble the system prompt for a given flag combination.
+
+    If ``flags.system_prompt`` is set, it is used verbatim instead of the
+    built-in prompt — giving users full control over refinement behaviour.
+    """
+    if flags.system_prompt:
+        return flags.system_prompt
+
     sections = [_BASE_INSTRUCTIONS]
 
     if flags.smart_cleanup:


### PR DESCRIPTION
Adds a configurable system_prompt field to capture settings that users can set to override the built-in refinement prompt. When custom prompt is empty/null the existing toggle-driven prompt behaviour is preserved.

Changes:
- New `system_prompt` TEXT column on `capture_settings` table with migration
- `RefinementFlags` dataclass/Pydantic model extended with `system_prompt`
- `build_refinement_prompt()` returns custom prompt verbatim when set
- Frontend textarea with local draft state + save-on-blur
- i18n strings for the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a custom system prompt option to transcript refinement settings.
  - Users can edit and save a custom prompt directly from the Captures refinement settings.
  - Custom prompts override the default refinement instructions when enabled.
  - Added supporting settings and API handling for storing and applying custom prompts.
- **Bug Fixes**
  - Preserved compatibility with existing capture settings that do not yet include a custom prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->