### PR TITLE
fix(offline): remove process-global offline guard from Qwen3 LLM loads

### DIFF
--- a/backend/backends/qwen_llm_backend.py
+++ b/backend/backends/qwen_llm_backend.py
@@ -19,7 +19,6 @@ from .base import (
     manual_seed,
     model_load_progress,
 )
-from ..utils.hf_offline_patch import force_offline_if_cached
 
 logger = logging.getLogger(__name__)
 
@@ -103,15 +102,19 @@ class PyTorchQwenLLMBackend:
 
         with model_load_progress(progress_model_name, is_cached):
             logger.info("Loading Qwen3 %s on %s...", model_size, self.device)
-            with force_offline_if_cached(is_cached, progress_model_name):
-                self.tokenizer = AutoTokenizer.from_pretrained(repo)
-                dtype = torch.float16 if self.device in ("cuda", "mps") else torch.float32
-                self.model = AutoModelForCausalLM.from_pretrained(
-                    repo,
-                    dtype=dtype,
-                )
-                self.model.to(self.device)
-                self.model.eval()
+            # Loads run with the process's default HF_HUB_OFFLINE state.
+            # Forcing offline for cached models flips process-global state
+            # and silently switches every concurrent download/load on other
+            # threads to offline mode (issue #841) — the same regression
+            # removed app-wide in #524/#530.
+            self.tokenizer = AutoTokenizer.from_pretrained(repo)
+            dtype = torch.float16 if self.device in ("cuda", "mps") else torch.float32
+            self.model = AutoModelForCausalLM.from_pretrained(
+                repo,
+                dtype=dtype,
+            )
+            self.model.to(self.device)
+            self.model.eval()
 
         self._current_model_size = model_size
         self.model_size = model_size
@@ -223,8 +226,8 @@ class MLXQwenLLMBackend:
 
         with model_load_progress(progress_model_name, is_cached):
             logger.info("Loading Qwen3 %s via MLX...", model_size)
-            with force_offline_if_cached(is_cached, progress_model_name):
-                loaded = mlx_load(repo)
+            # See the PyTorch loader comment — no offline forcing (issue #841).
+            loaded = mlx_load(repo)
 
         # mlx_lm.load returns (model, tokenizer) by default and
         # (model, tokenizer, config) when return_config=True.


### PR DESCRIPTION
## Summary

`force_offline_if_cached` flips **process-global** offline state — `HF_HUB_OFFLINE` env var, `huggingface_hub.constants.HF_HUB_OFFLINE`, and `transformers.utils.hub._is_offline_mode` — for the duration of a cached Qwen3 LLM load (`qwen_llm_backend.py`, both the PyTorch and MLX loaders). Any *other* model operation running concurrently on another thread (whisper download, TTS load, Kokoro voice fetch — none of which have guards) is silently switched to offline for that window.

These are the **last two call sites** of the guard in the codebase. The identical pattern was deliberately removed app-wide in #524/#530 after causing "offline mode is enabled" failures (#526), and the 0.5.0 LLM backend reintroduced it. This PR removes it the same way, with a comment matching the existing issue-#462 precedent comments in `pytorch_backend.py` so it doesn't come back a third time.

Fixes #841.

## Why this hits first-run users so often

Default capture settings are `stt_model="turbo"`, `llm_model="0.6B"`, `auto_refine=True` (`backend/database/models.py`). A new user's first dictation therefore downloads whisper-large-v3-turbo and a Qwen3 LLM **concurrently**. As soon as either Qwen3 LLM load runs with `is_cached=True` while anything else is still fetching, the concurrent fetch is poisoned — and because the transformers error surfaced is *not* an offline error (see below), users and bug reports never connect it to offline mode.

## The two error signatures this explains (verified)

Both reproduced **verbatim** against the versions the Windows CUDA backend actually bundles (transformers 4.57.3 / huggingface_hub 0.36.2; also confirmed on 4.57.6):

1. **`Can't load feature extractor for 'openai/whisper-large-v3-turbo'...`** — with offline force active and `preprocessor_config.json` not yet cached, `get_feature_extractor_dict` resolves `[preprocessor_config.json, processor_config.json]` via `cached_file(..., _raise_exceptions_for_missing_entries=False)`; the offline `LocalEntryNotFoundError` falls through both raise branches and returns `None` for both candidates → empty list → `IndexError` → transformers' blanket `except Exception` produces exactly this generic message with no mention of offline mode.
2. **`Unrecognized model in Qwen/Qwen3-4B. Should have a `model_type` key in its config.json...`** — fires only when `cached_file(config.json)` returns `None` so `config_dict == {}` (the on-disk config.json is never opened; a valid cached config is fully consistent with this error). The name fallback then fails because matching is case-sensitive: `"qwen3" in "Qwen/Qwen3-4B"` is `False`.

Likely-related open reports with these signatures: #304, #551, #731, #878; #883 (closed — "restarted my PC and it worked", consistent with in-process-only corruption); ancestor #526 shows the `[offline-guard] ... forcing offline mode` log line immediately preceding the failure.

## Environment where this was diagnosed

- Windows 11 Pro (build 26200), Intel i9-11900K, 128 GB RAM, NVIDIA RTX 4090 24 GB (driver 32.0.15.8157), 1 Gbps ethernet, NVMe storage
- Voicebox 0.5.0 desktop (Tauri), CUDA backend `cu128-v1`, **fresh install** — backend extracted minutes before the failures; single-version `_internal` (transformers 4.57.3, huggingface_hub 0.36.2, torch 2.11.0+cu128, tokenizers 0.22.2, safetensors 0.7.0)
- Both whisper-turbo and qwen3-4b failed with the errors above on first in-app download; HF reachable (HTTP 200), no proxy, no HF env vars, default cache location
- Isolation: a clean venv with the **exact bundled versions** (`transformers==4.57.3`, `huggingface_hub==0.36.2`) loaded both models fine from the same machine/cache → app-code cause, not machine/network/library
- Confirmed working after taking the buggy window out of the equation: pre-seeding the cache via `snapshot_download` + app restart → both models detect, load, and run in-app (whisper-turbo transcription and Qwen3-4B `/llm/generate` verified end-to-end)

## What the guard was protecting against, and why removal is safe

The guard's purpose (from #318) was avoiding HF metadata-lookup hangs when loading cached models offline. Since then:

- 0.4.5 (#530) added the `_patch_mistral_regex` wrapper, which already swallows the transformers 4.57.x unconditional `model_info()` call — the main hang source.
- `huggingface_hub` falls back to cache on unreachable metadata (`HF_HUB_ETAG_TIMEOUT`, 10 s default), so a fully-cached load still succeeds offline — at worst with a bounded delay, instead of process-wide breakage while online.
- Every other backend already runs loads/inference with the process's default offline state (the issue-#462 revert comments in `pytorch_backend.py`).

`force_offline_if_cached` itself and its unit tests (`test_offline_guard.py`) are left in place — the helper is now unused by production code. Happy to delete both in this PR if you prefer.

## Test plan

- [x] `python -m py_compile` on the touched module
- [x] `backend/tests/test_offline_guard.py` unaffected (tests the helper, not the call sites)
- [x] Behavior equivalent to the pre-#544 state of every other backend (no guard); `model_load_progress` handling of `is_cached` unchanged
- [ ] Would appreciate a maintainer smoke of MLX LLM load on Apple Silicon (I verified the PyTorch path on Windows/CUDA; the reporter of #841 offered to test the MLX path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iwL9AyeAWgz2jpgcHxJpC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3 model loading reliability when multiple operations run concurrently.
  * Prevented cached-model loading from causing unintended offline-state changes that could affect other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->