### PR TITLE
fix(models): stop reporting errored downloads as still downloading in /models/status

### DIFF
--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -231,7 +231,10 @@ async def get_model_status():
     backend_type = get_backend_type()
     task_manager = get_task_manager()
 
-    active_download_names = {task.model_name for task in task_manager.get_active_downloads()}
+    # Pending only — an errored task stays in the active list for the
+    # error/retry UI, but reporting it as "downloading" here would mask
+    # the model's real cache state until the app restarts (issue #925).
+    active_download_names = {task.model_name for task in task_manager.get_pending_downloads()}
 
     try:
         from huggingface_hub import scan_cache_dir

--- a/backend/tests/test_model_status_pending_downloads.py
+++ b/backend/tests/test_model_status_pending_downloads.py
@@ -1,0 +1,51 @@
+"""Errored downloads must not be reported as still downloading.
+
+A failed download intentionally stays in the TaskManager with
+``status="error"`` so ``/tasks/active`` can surface the error and retry
+UI — but ``/models/status`` derives its ``downloading`` flag from the
+same list. Without a status filter, one failed download shows the model
+as "downloading" forever and masks its real cache state until the app
+restarts (issue #925, symptom reports like #181).
+"""
+
+from backend.utils.tasks import TaskManager
+
+
+def test_errored_download_is_not_pending():
+    tm = TaskManager()
+    tm.start_download("whisper-turbo")
+    assert [t.model_name for t in tm.get_pending_downloads()] == ["whisper-turbo"]
+
+    tm.error_download("whisper-turbo", "boom")
+
+    assert tm.get_pending_downloads() == []
+    # Still visible to /tasks/active for the error/retry UI.
+    active = tm.get_active_downloads()
+    assert [t.model_name for t in active] == ["whisper-turbo"]
+    assert active[0].status == "error"
+    assert active[0].error == "boom"
+
+
+def test_retry_after_error_is_pending_again():
+    tm = TaskManager()
+    tm.start_download("qwen3-4b")
+    tm.error_download("qwen3-4b", "boom")
+    tm.start_download("qwen3-4b")
+    assert [t.model_name for t in tm.get_pending_downloads()] == ["qwen3-4b"]
+
+
+def test_completed_download_is_removed_everywhere():
+    tm = TaskManager()
+    tm.start_download("whisper-turbo")
+    tm.complete_download("whisper-turbo")
+    assert tm.get_pending_downloads() == []
+    assert tm.get_active_downloads() == []
+
+
+def test_cancel_dismisses_errored_download():
+    tm = TaskManager()
+    tm.start_download("whisper-turbo")
+    tm.error_download("whisper-turbo", "boom")
+    assert tm.cancel_download("whisper-turbo") is True
+    assert tm.get_active_downloads() == []
+    assert tm.get_pending_downloads() == []

--- a/backend/utils/tasks.py
+++ b/backend/utils/tasks.py
@@ -67,6 +67,19 @@ class TaskManager:
     def get_active_downloads(self) -> List[DownloadTask]:
         """Get all active downloads."""
         return list(self._active_downloads.values())
+
+    def get_pending_downloads(self) -> List[DownloadTask]:
+        """Get downloads that are still in flight.
+
+        Excludes errored tasks, which stay in the active list so the
+        error/retry UI can show them but must not be reported as
+        "downloading" by /models/status.
+        """
+        return [
+            task
+            for task in self._active_downloads.values()
+            if task.status in ("downloading", "extracting")
+        ]
     
     def get_active_generations(self) -> List[GenerationTask]:
         """Get all active generations."""


### PR DESCRIPTION
## Summary

Once any model download fails, `GET /models/status` reports that model as `"downloading": true` and forces `"downloaded": false` **for the life of the process** — even when the files are actually fully cached on disk — until the app restarts or the task list is cleared. Fixes #925; very likely behind endless-spinner reports like #181 (spinner, no error shown) and the "restarted my PC and it worked" resolution pattern in #883.

## Root cause

`TaskManager.error_download()` intentionally keeps a failed task in `_active_downloads` with `status="error"` (`backend/utils/tasks.py`) so `/tasks/active` can surface the error + retry UI. But `/models/status` derived its `downloading` flag from that same list with **no status filter** (`backend/routes/models.py:234`), then used it to override the cache scan:

```python
is_downloading = config["hf_repo_id"] in active_download_repos
if is_downloading:
    downloaded = False
    size_mb = None
```

One transient failure ⇒ permanent `downloading: true` + masked cache state.

## Fix

- New `TaskManager.get_pending_downloads()` — only tasks with `status in ("downloading", "extracting")`.
- `/models/status` now uses it. `/tasks/active` is unchanged (errored tasks still visible for the error/retry UI).

## Observed live (environment)

- Windows 11 Pro (build 26200), i9-11900K, 128 GB RAM, RTX 4090 24 GB (driver 32.0.15.8157), 1 Gbps ethernet; Voicebox 0.5.0 desktop, CUDA backend `cu128-v1` (transformers 4.57.3 / huggingface_hub 0.36.2 / torch 2.11.0+cu128)
- Two first-run downloads failed (via the offline-guard collision addressed in #924); `/models/status` reported both models `downloading: true, downloaded: false` for 20+ minutes with no recovery.
- Fully populating the HF cache out-of-band (`snapshot_download`) changed nothing — the errored tasks kept masking the cache scan.
- App restart with the identical on-disk cache → both models immediately `downloaded: true`, loaded, and ran (whisper-turbo transcription + Qwen3-4B generation verified end-to-end).

## Test plan

- [x] New `backend/tests/test_model_status_pending_downloads.py`: errored task is not pending but stays visible to `/tasks/active`; retry after error is pending again; complete removes everywhere; cancel dismisses an errored task. **4/4 pass** (and fail against the unfixed code by inspection: `get_pending_downloads` did not exist; the route consumed the unfiltered list).
- [x] `python -m py_compile` on both touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iwL9AyeAWgz2jpgcHxJpC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model download status reporting by excluding failed downloads from the active “downloading” state.
  * Failed downloads remain visible for retry actions and can be retried, completed, or cancelled correctly.
  * Completed and cancelled downloads are removed from download status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->