### PR TITLE
fix(setup): Completely exit from setup, if venv python != 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ just dev     # starts backend + desktop app
 
 Install [just](https://github.com/casey/just): `brew install just` or `cargo install just`. Run `just --list` to see all commands.
 
-**Prerequisites:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.11+](https://python.org), [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/), and [Xcode](https://developer.apple.com/xcode/) on macOS.
+**Prerequisites:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.12](https://python.org), [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/), and [Xcode](https://developer.apple.com/xcode/) on macOS.
 
 The repo ships a pre-wired `.mcp.json` at the root — running Claude Code inside this checkout picks up the Voicebox MCP tools automatically once the dev app is running.
 

--- a/justfile
+++ b/justfile
@@ -17,8 +17,8 @@ pip := if os() == "windows" { venv_bin / "pip.exe" } else { venv_bin / "pip" }
 # Shell selection: use powershell on Windows, bash elsewhere
 set windows-shell := ["powershell", "-NoProfile", "-Command"]
 
-# Detect best python for venv creation (platform-aware)
-system_python := if os() == "windows" { "python" } else { `command -v python3.12 2>/dev/null || command -v python3.13 2>/dev/null || echo python3` }
+# Detect Python 3.12 for venv creation (platform-aware)
+system_python := if os() == "windows" { "python" } else { `command -v python3.12 2>/dev/null || echo python3` }
 
 # ─── Setup ────────────────────────────────────────────────────────────
 
@@ -32,14 +32,23 @@ setup: setup-python setup-js
 setup-python:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [ -d "{{ venv }}" ]; then
+        PYTHON_CMD="{{ python }}"
+    else
+        PYTHON_CMD="{{ system_python }}"
+    fi
+    PY_VERSION=$($PYTHON_CMD -c "import platform; print(platform.python_version())")
+    case "$PY_VERSION" in
+        3.12.*) ;;
+        *)
+            echo "Error: Voicebox requires Python 3.12; found Python $PY_VERSION."
+            echo "kokoro>=0.9.4 requires Python <3.13. Recreate {{ venv }} with Python 3.12."
+            exit 1
+            ;;
+    esac
     if [ ! -d "{{ venv }}" ]; then
         echo "Creating Python virtual environment..."
-        PY_MINOR=$({{ system_python }} -c "import sys; print(sys.version_info[1])")
-        if [ "$PY_MINOR" -gt 13 ]; then
-            echo "Warning: Python 3.$PY_MINOR detected. ML packages may not be compatible."
-            echo "Recommended: brew install python@3.12"
-        fi
-        {{ system_python }} -m venv {{ venv }}
+        $PYTHON_CMD -m venv {{ venv }}
     fi
     echo "Installing Python dependencies..."
     {{ pip }} install --upgrade pip -q
@@ -85,13 +94,16 @@ setup-python:
 
 [windows]
 setup-python:
+    $pythonCmd = if (Test-Path "{{ venv }}") { "{{ python }}" } else { "{{ system_python }}" }; \
+    $pyVersion = & $pythonCmd -c "import platform; print(platform.python_version())"; \
+    if (-not $pyVersion.StartsWith("3.12.")) { \
+        Write-Error "Voicebox requires Python 3.12; found Python $pyVersion."; \
+        Write-Host "kokoro>=0.9.4 requires Python <3.13. Recreate {{ venv }} with Python 3.12."; \
+        exit 1; \
+    }; \
     if (-not (Test-Path "{{ venv }}")) { \
         Write-Host "Creating Python virtual environment..."; \
-        $pyMinor = & {{ system_python }} -c "import sys; print(sys.version_info[1])"; \
-        if ([int]$pyMinor -gt 13) { \
-            Write-Host "Warning: Python 3.$pyMinor detected. ML packages may not be compatible."; \
-        }; \
-        & {{ system_python }} -m venv {{ venv }}; \
+        & $pythonCmd -m venv {{ venv }}; \
     }
     Write-Host "Installing Python dependencies..."
     & "{{ python }}" -m pip install --upgrade pip -q


### PR DESCRIPTION
## Summary

Require Python 3.12 before creating or updating the backend virtual environment.

Kokoro 0.9.4 supports Python versions below 3.13, but the setup script previously fell back to Python 3.13 and only warned about newer versions. This allowed setup to continue until dependency installation failed later with an unrelated-looking pip error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Python environment setup now consistently enforces **Python 3.12.x** (including stricter handling on Windows).
  * Setup will now stop with a clear error if the detected Python version doesn’t match **3.12.\***.
  * Virtual environments are created using the validated interpreter to prevent version mismatches.
* **Documentation**
  * Updated README “Quick Start” prerequisites to require **Python 3.12** instead of **Python 3.11+**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->