### PR TITLE
docs: add libasound2-dev Linux prerequisite for Tauri build (fixes #872)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ just dev     # starts backend + desktop app
 
 Install [just](https://github.com/casey/just): `brew install just` or `cargo install just`. Run `just --list` to see all commands.
 
-**Prerequisites:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.11+](https://python.org), [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/), and [Xcode](https://developer.apple.com/xcode/) on macOS.
+**Prerequisites:** [Bun](https://bun.sh), [Rust](https://rustup.rs), [Python 3.11+](https://python.org), [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/), and [Xcode](https://developer.apple.com/xcode/) on macOS. On Ubuntu/Debian Linux, also install `libasound2-dev` (`sudo apt-get install -y libasound2-dev`) before running `just setup` — the `alsa-sys` Rust crate requires it.
 
 The repo ships a pre-wired `.mcp.json` at the root — running Claude Code inside this checkout picks up the Voicebox MCP tools automatically once the dev app is running.
 

--- a/docs/content/docs/developer/setup.mdx
+++ b/docs/content/docs/developer/setup.mdx
@@ -283,7 +283,23 @@ bun run tauri dev
     - Check if port 17493 is available
   </Accordion>
 
-  <Accordion title="Tauri build fails">
+  <Accordion title="Tauri build fails on Linux (alsa-sys / libasound not found)">
+    The `alsa-sys` crate requires the ALSA development headers, which are not installed by default on Ubuntu/Debian. Install them before running `just setup`:
+
+    ```bash
+    sudo apt-get install -y libasound2-dev
+    ```
+
+    On Fedora/RHEL:
+
+    ```bash
+    sudo dnf install -y alsa-lib-devel
+    ```
+
+    After installing, re-run `just setup` and `just dev`.
+  </Accordion>
+
+  <Accordion title="Tauri build fails (general)">
     - Ensure Rust is installed: `rustc --version`
     - Clean the build: `cd tauri/src-tauri && cargo clean`
     - Try rebuilding: `just dev`


### PR DESCRIPTION
## Summary

Closes #872.

- Add a dedicated troubleshooting accordion in `docs/content/docs/developer/setup.mdx` for the `alsa-sys / libasound not found` build error on Ubuntu/Debian and Fedora/RHEL
- Add a one-liner note in `README.md` next to the Tauri Prerequisites link so Linux contributors hit the hint before they hit the error

## Root cause

`just setup` triggers a Rust build that includes the `alsa-sys` crate. That crate requires the ALSA development headers (`libasound2-dev` on Debian/Ubuntu, `alsa-lib-devel` on Fedora/RHEL), which are not installed by default. The existing docs link to `https://v2.tauri.app/start/prerequisites/` but that page doesn't surface the ALSA dep prominently enough to prevent the error.

## Test plan

- [x] Verified the `apt-get install` command resolves the `alsa.pc` / `alsa-sys` build failure on a fresh Ubuntu 22.04 container
- [x] Doc changes render correctly in the MDX accordion structure used by the docs site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ubuntu/Debian setup guidance for installing `libasound2-dev` before running project setup.
  * Added Linux troubleshooting instructions for missing ALSA development headers, including Fedora/RHEL guidance.
  * Clarified general Tauri build troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->