### PR TITLE
fix(ui): open FloatingGenerateBox selects upward to prevent clipping (fixes #928)

### DIFF
--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -139,7 +139,7 @@ export function EngineModelSelector({ form, compact, selectedProfile }: EngineMo
           <SelectValue />
         </SelectTrigger>
       </FormControl>
-      <SelectContent>
+      <SelectContent side={compact ? 'top' : undefined}>
         {availableOptions.map((opt) => (
           <SelectItem key={opt.value} value={opt.value} className={itemClass}>
             {opt.label}

--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -555,7 +555,7 @@ export function FloatingGenerateBox({
                         <SelectTrigger className="h-8 text-xs bg-card border-border rounded-full hover:bg-background/50 transition-all w-full">
                           <SelectValue placeholder={t('generation.voiceSelector.placeholder')} />
                         </SelectTrigger>
-                        <SelectContent>
+                        <SelectContent side="top">
                           {profiles?.map((profile) => (
                             <SelectItem key={profile.id} value={profile.id} className="text-xs">
                               {profile.name}
@@ -582,7 +582,7 @@ export function FloatingGenerateBox({
                                 <SelectValue />
                               </SelectTrigger>
                             </FormControl>
-                            <SelectContent>
+                            <SelectContent side="top">
                               {engineLangs.map((lang) => (
                                 <SelectItem key={lang.value} value={lang.value} className="text-xs">
                                   {lang.label}
@@ -610,7 +610,7 @@ export function FloatingGenerateBox({
                       <SelectTrigger className="h-8 text-xs bg-card border-border rounded-full hover:bg-background/50 transition-all">
                         <SelectValue placeholder={t('generation.effects.none')} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent side="top">
                         <SelectItem value="none" className="text-xs">
                           {t('generation.effects.none')}
                         </SelectItem>


### PR DESCRIPTION
## Summary

Closes #928.

The `FloatingGenerateBox` is fixed at the **bottom** of the viewport, so all of its `Select` dropdowns (voice profile, language, engine/model, effects) were opening downward — into or beyond the window edge — making them inaccessible.

**Fix:** Add `side="top"` to each `SelectContent` in the floating box and propagate it through `EngineModelSelector` (which is only used in compact/bottom mode). All four menus now open upward above their trigger.

Files changed:
- `app/src/components/Generation/FloatingGenerateBox.tsx` — voice profile, language, and effects selects
- `app/src/components/Generation/EngineModelSelector.tsx` — engine/model select (uses `compact` prop to conditionally apply `side="top"`)

## Test plan

- [x] Open the Stories tab with a story selected so the floating box appears at the bottom
- [x] Click each dropdown (voice, language, engine, effects) — all open upward
- [x] Verify the same selects on the main generation view (non-Stories) still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generation dropdown menus to open upward in compact and floating layouts, improving visibility and preventing them from extending beyond the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->