### PR TITLE
feat(ui): show engine descriptions and mark incompatible engines in selector (fixes #671)

### DIFF
--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -30,13 +30,13 @@ const ENGINE_OPTIONS = [
 ] as const;
 
 const ENGINE_DESCRIPTIONS: Record<string, string> = {
-  qwen: 'Multi-language, two sizes',
-  qwen_custom_voice: '9 preset voices, instruct control',
-  luxtts: 'Fast, English-focused',
-  chatterbox: '23 languages, incl. Hebrew',
-  chatterbox_turbo: 'English, [laugh] [cough] tags',
-  tada: 'HumeAI, 700s+ coherent audio',
-  kokoro: '82M params, CPU realtime, 8 langs',
+  qwen: 'Multilingual · voice cloning · delivery instructions',
+  qwen_custom_voice: '9 preset voices · natural-language control',
+  luxtts: 'English · fast CPU · 48 kHz · lightweight',
+  chatterbox: '23 languages incl. Arabic, Hebrew, Swahili',
+  chatterbox_turbo: 'English · [laugh] [sigh] paralinguistic tags',
+  tada: 'HumeAI · expressive · 700 s+ coherent audio',
+  kokoro: '82 M params · 50 preset voices · CPU realtime',
 };
 
 /** Engines that only support English and should force language to 'en' on select. */
@@ -45,9 +45,8 @@ const ENGLISH_ONLY_ENGINES = new Set(['luxtts', 'chatterbox_turbo']);
 /** Engines that support cloned (reference audio) profiles. */
 const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'tada']);
 
-function getAvailableOptions(selectedProfile?: VoiceProfileResponse | null) {
-  if (!selectedProfile) return ENGINE_OPTIONS;
-  return ENGINE_OPTIONS.filter((opt) => isProfileCompatibleWithEngine(selectedProfile, opt.engine));
+function getAvailableOptions() {
+  return ENGINE_OPTIONS;
 }
 
 function getSelectValue(engine: string, modelSize?: string): string {
@@ -117,7 +116,7 @@ export function EngineModelSelector({ form, compact, selectedProfile }: EngineMo
   const engine = form.watch('engine') || 'qwen';
   const modelSize = form.watch('modelSize');
   const selectValue = getSelectValue(engine, modelSize);
-  const availableOptions = getAvailableOptions(selectedProfile);
+  const availableOptions = getAvailableOptions();
 
   const currentEngineAvailable = availableOptions.some((opt) => opt.value === selectValue);
 
@@ -139,12 +138,29 @@ export function EngineModelSelector({ form, compact, selectedProfile }: EngineMo
           <SelectValue />
         </SelectTrigger>
       </FormControl>
-      <SelectContent>
-        {availableOptions.map((opt) => (
-          <SelectItem key={opt.value} value={opt.value} className={itemClass}>
-            {opt.label}
-          </SelectItem>
-        ))}
+      <SelectContent side={compact ? 'top' : undefined}>
+        {availableOptions.map((opt) => {
+          const isDisabled =
+            selectedProfile != null &&
+            !isProfileCompatibleWithEngine(selectedProfile, opt.engine);
+          return (
+            <SelectItem
+              key={opt.value}
+              value={opt.value}
+              className={itemClass}
+              disabled={isDisabled}
+            >
+              <div className="flex flex-col">
+                <span>{opt.label}</span>
+                <span className="text-[10px] text-muted-foreground leading-tight">
+                  {isDisabled
+                    ? 'Incompatible with this profile'
+                    : (ENGINE_DESCRIPTIONS[opt.engine] ?? '')}
+                </span>
+              </div>
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
## Summary

Closes #671.

Previously, `getAvailableOptions()` silently filtered out engines that were incompatible with the selected voice profile. Users had no way to know which engines existed or why options disappeared when they picked a profile.

This PR makes the engine selector fully transparent:

- **All 10 engine options are always shown** — no silent filtering.
- **Incompatible engines are visually disabled** with a `"Incompatible with this profile"` hint rendered beneath the engine name, so users understand the constraint without confusion.
- **Compatible engines show a concise one-line description** (e.g. `"Multilingual · voice cloning · delivery instructions"` for Qwen) to help users choose the right engine at a glance.
- **`ENGINE_DESCRIPTIONS`** updated with accurate, consistent descriptions for all 7 engine keys (`qwen`, `qwen_custom_voice`, `luxtts`, `chatterbox`, `chatterbox_turbo`, `tada`, `kokoro`).

The `SelectItem` `disabled` prop prevents selection of incompatible engines while keeping them visible. The two-line layout uses `flex flex-col` with a `text-[10px] text-muted-foreground` subtitle — the `SelectTrigger` still shows only the selected value (one line), so compact mode is unaffected.

## Changes

- `app/src/components/Generation/EngineModelSelector.tsx` — only file changed.
  - `getAvailableOptions()` simplified to always return all `ENGINE_OPTIONS` (no profile parameter).
  - Render loop now computes `isDisabled` per item via `isProfileCompatibleWithEngine` and passes `disabled` + two-line JSX to `SelectItem`.
  - `ENGINE_DESCRIPTIONS` refreshed with precise, bullet-separated descriptions.
  - `SelectContent` gets `side={compact ? 'top' : undefined}` restored (was present in earlier version of the component).

## Test plan

- [ ] With no profile selected: all 10 options are enabled and show their description.
- [ ] With a cloned-voice profile selected: cloning engines (Qwen, LuxTTS, Chatterbox, Chatterbox Turbo, TADA) are enabled; preset-only engines (Qwen CustomVoice, Kokoro) are disabled with the incompatibility hint.
- [ ] With a preset-voice profile for e.g. `kokoro`: only `kokoro` options are enabled; all others are disabled.
- [ ] Compact mode trigger still shows a single line (selected engine label); dropdown items are taller but don't clip the trigger.
- [ ] Selecting a disabled item has no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Engine and model options now remain visible in the selector, including those incompatible with the selected voice profile.
  * Incompatible options are clearly marked as unavailable.
  * Added descriptive text for supported engines and improved dropdown placement in compact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->