### PR TITLE
feat: .voicebox bundle — portable voice profile export with full metadata

### DIFF
--- a/app/src/components/MainEditor/MainEditor.tsx
+++ b/app/src/components/MainEditor/MainEditor.tsx
@@ -39,7 +39,7 @@ export function MainEditor() {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      if (!file.name.endsWith('.voicebox.zip')) {
+      if (!file.name.endsWith('.voicebox') && !file.name.endsWith('.voicebox.zip')) {
         toast({
           title: t('main.import.invalidTitle'),
           description: t('main.import.invalidDescription'),
@@ -93,7 +93,7 @@ export function MainEditor() {
               <input
                 ref={fileInputRef}
                 type="file"
-                accept=".voicebox.zip"
+                accept=".voicebox,.voicebox.zip"
                 onChange={handleFileChange}
                 className="hidden"
               />

--- a/app/src/lib/hooks/useProfiles.ts
+++ b/app/src/lib/hooks/useProfiles.ts
@@ -126,12 +126,12 @@ export function useExportProfile() {
       // Get profile name for filename
       const profile = await apiClient.getProfile(profileId);
       const safeName = profile.name.replace(/[^a-z0-9]/gi, '-').toLowerCase();
-      const filename = `profile-${safeName}.voicebox.zip`;
+      const filename = `profile-${safeName}.voicebox`;
 
       await platform.filesystem.saveFile(filename, blob, [
         {
           name: 'Voicebox Profile',
-          extensions: ['zip'],
+          extensions: ['voicebox'],
         },
       ]);
 

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -294,11 +294,11 @@ async def export_profile(
         safe_name = "".join(c for c in profile.name if c.isalnum() or c in (" ", "-", "_")).strip()
         if not safe_name:
             safe_name = "profile"
-        filename = f"profile-{safe_name}.voicebox.zip"
+        filename = f"profile-{safe_name}.voicebox"
 
         return StreamingResponse(
             io.BytesIO(zip_bytes),
-            media_type="application/zip",
+            media_type="application/octet-stream",
             headers={"Content-Disposition": safe_content_disposition("attachment", filename)},
         )
     except ValueError as e:

--- a/backend/services/export_import.py
+++ b/backend/services/export_import.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from ..models import VoiceProfileResponse
 from ..database import VoiceProfile as DBVoiceProfile, ProfileSample as DBProfileSample, Generation as DBGeneration, GenerationVersion as DBGenerationVersion
-from .profiles import create_profile, add_profile_sample
+from .profiles import create_profile, add_profile_sample, _profile_to_response
 from ..models import VoiceProfileCreate
 from .. import config
 
@@ -82,11 +82,18 @@ def export_profile_to_zip(profile_id: str, db: Session) -> bytes:
 
         # Create manifest.json
         manifest = {
-            "version": "1.0",
+            "version": "1.1",
             "profile": {
                 "name": profile.name,
                 "description": profile.description,
                 "language": profile.language,
+                "voice_type": profile.voice_type or "cloned",
+                "preset_engine": profile.preset_engine,
+                "preset_voice_id": profile.preset_voice_id,
+                "design_prompt": profile.design_prompt,
+                "default_engine": profile.default_engine,
+                "personality": profile.personality,
+                "effects_chain": json.loads(profile.effects_chain) if profile.effects_chain else None,
             },
             "has_avatar": has_avatar,
         }
@@ -173,8 +180,14 @@ async def import_profile_from_zip(file_bytes: bytes, db: Session) -> VoiceProfil
                 name=unique_name,
                 description=profile_data.get("description"),
                 language=profile_data.get("language", "en"),
+                voice_type=profile_data.get("voice_type", "cloned"),
+                preset_engine=profile_data.get("preset_engine"),
+                preset_voice_id=profile_data.get("preset_voice_id"),
+                design_prompt=profile_data.get("design_prompt"),
+                default_engine=profile_data.get("default_engine"),
+                personality=profile_data.get("personality"),
             )
-            
+
             profile = await create_profile(profile_create, db)
 
             # Extract and add samples
@@ -200,6 +213,16 @@ async def import_profile_from_zip(file_bytes: bytes, db: Session) -> VoiceProfil
                 except Exception as e:
                     # Avatar import is optional - continue even if it fails
                     pass
+
+            # Restore effects_chain (not settable via VoiceProfileCreate)
+            effects_chain = profile_data.get("effects_chain")
+            if effects_chain is not None:
+                db_profile = db.query(DBVoiceProfile).filter_by(id=profile.id).first()
+                if db_profile:
+                    db_profile.effects_chain = json.dumps(effects_chain)
+                    db.commit()
+                    db.refresh(db_profile)
+                    profile = _profile_to_response(db_profile)
 
             for filename, reference_text in samples_data.items():
                 # Validate filename


### PR DESCRIPTION
## Problem

Voicebox's export has always been crippled compared to cloud TTS tools: the downloaded archive only contained `name`, `description`, and `language`. Every other piece of configuration — `voice_type`, `preset_engine`, `preset_voice_id`, `design_prompt`, `default_engine`, `personality`, and the `effects_chain` — was silently discarded on export and lost on import. Practically speaking this made voice-profile portability useless: cloned voices could not be moved to a new machine, shared with teammates, or restored from a backup without manually re-entering all settings.

## Solution

Introduces the `.voicebox` bundle format (a ZIP archive under the hood, renamed to signal intent). The manifest is bumped to **version `1.1`** and now serialises the full profile metadata.

### Changes

**`backend/services/export_import.py`**
- `export_profile_to_zip()` writes manifest v1.1, adding `voice_type`, `preset_engine`, `preset_voice_id`, `design_prompt`, `default_engine`, `personality`, and `effects_chain` (deserialized from JSON before embedding).
- `import_profile_from_zip()` reads every new field and passes them into `VoiceProfileCreate`; after the profile is created, `effects_chain` is written back directly (it is not exposed by `VoiceProfileCreate`) with a db commit + refresh.
- Version `"1.0"` bundles still import cleanly — missing fields default to `None`.

**`backend/routes/profiles.py`**
- Export filename changed from `profile-<name>.voicebox.zip` → `profile-<name>.voicebox`.
- `Content-Type` changed from `application/zip` → `application/octet-stream` so browsers don't handle the file as a generic ZIP.

**`app/src/lib/hooks/useProfiles.ts`**
- `useExportProfile` saves with the `.voicebox` extension and uses the `'Voicebox Profile / voicebox'` file filter in the native save dialog.

**`app/src/components/MainEditor/MainEditor.tsx`**
- File input `accept` attribute updated to `.voicebox,.voicebox.zip` (backward compat with bundles exported by older versions).
- Validation guard updated to accept both extensions.

## Backward compatibility

| Bundle version | Export | Import |
|---|---|---|
| `1.0` (old `.voicebox.zip`) | — | ✅ imports, extra fields default to `None` |
| `1.1` (new `.voicebox`) | ✅ full metadata | ✅ full round-trip |

## Test plan

- [ ] Export a **cloned** profile (with samples, personality prompt, effects chain set) → file downloads as `profile-<name>.voicebox`
- [ ] Import the `.voicebox` file on a fresh install → all fields restored: name, description, language, voice_type, personality, effects_chain
- [ ] Export a **preset** profile (kokoro / qwen_custom_voice) → `preset_engine` and `preset_voice_id` round-trip correctly
- [ ] Import an old `.voicebox.zip` bundle → still works, no crash, missing fields default gracefully
- [ ] Export a profile with no effects chain → `effects_chain: null` in manifest, no error on import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Voice profiles can now be exported and imported using `.voicebox` files.
  - Profile exports retain additional settings, including voice type, engine selections, personality, design prompts, and effects chains.
  - Updated export metadata reflects the new `.voicebox` format.

- **Bug Fixes**
  - Import file selection now recognizes both `.voicebox` and `.voicebox.zip` files.
  - Imported profiles more accurately restore their saved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->