### PR TITLE
fix(docker): CPU inference broken by unpinned torch; root-owned ~/.cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,21 @@ RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
         --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
         torch torchaudio && \
       printf '[global]\nindex-url = https://download.pytorch.org/whl/rocm%s\nextra-index-url = https://pypi.org/simple\n' "$ROCM_VERSION" > /etc/pip.conf; \
+    else \
+      pip install --no-cache-dir --prefix=/install torch==2.7.1 torchaudio==2.7.1; \
     fi
+# ^ CPU builds pin torch: 2.8+ breaks CPU inference in every engine tested
+#   (Kokoro/LuxTTS: "Cannot copy out of meta tensor"; Qwen: "unsupported
+#   scalarType" in torch.autocast). 2.7.1 is the newest that works and matches
+#   hume-tada's torch>=2.7,<2.8. Installed before requirements.txt so the open
+#   torch range there keeps this version instead of resolving to latest.
 
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 RUN pip install --no-cache-dir --prefix=/install --no-deps chatterbox-tts
 RUN pip install --no-cache-dir --prefix=/install --no-deps hume-tada
-RUN pip install --no-cache-dir --prefix=/install \
+# --no-deps: Qwen3-TTS's dependency list would re-resolve torch/transformers
+# and undo the versions installed above; everything it needs is already here.
+RUN pip install --no-cache-dir --prefix=/install --no-deps \
     git+https://github.com/QwenLM/Qwen3-TTS.git
 
 

--- a/scripts/rocm-entrypoint.sh
+++ b/scripts/rocm-entrypoint.sh
@@ -12,4 +12,10 @@ for dev in /dev/kfd /dev/dri/render*; do
     }
     usermod -aG "$grp" voicebox
 done
+# Docker creates the HF volume mountpoint's parent (~/.cache) as root on every
+# container create, and a fresh volume is root-owned too — without this the app
+# user can't write any cache (torch, spacy) outside the HF mount.
+mkdir -p /home/voicebox/.cache/huggingface
+chown voicebox:voicebox /home/voicebox/.cache /home/voicebox/.cache/huggingface
+
 exec gosu voicebox "$@"


### PR DESCRIPTION
## Summary

Two independent Docker fixes, found while running the CPU image in production for ~a week:

### 1. CPU builds: pin torch 2.7.1 (unpinned torch → 2.13 → CPU inference broken)

With `torch>=2.2.0` unpinned, pip resolves the latest release. On torch 2.13 CPU inference fails in every engine we tested:

- **Kokoro / LuxTTS**: `Cannot copy out of meta tensor; no data!`
- **Qwen3-TTS**: `unsupported scalarType` inside `torch.autocast`

2.7.1 is the newest version that works, and it matches hume-tada's declared range (`torch>=2.7,<2.8` — currently unenforced since it's installed with `--no-deps`).

The pin lives in the Dockerfile's CPU branch (the `else` of the existing ROCm conditional), **not** in `requirements.txt`, so ROCm builds keep resolving torch from the ROCm wheel index for both `ROCM_VERSION=6.3` and `7.2` — a hard pin in requirements would have no matching wheel on the 7.2 index.

Qwen3-TTS is now installed with `--no-deps` (same as chatterbox-tts and hume-tada) so its dependency list can't re-resolve torch/transformers and silently undo the pin.

### 2. Entrypoint: chown `~/.cache` (root-owned on every container create)

Docker creates `/home/voicebox/.cache` — the parent of the `huggingface-cache` volume mountpoint — as **root** on every container create, and a fresh named volume is root-owned too. The app runs as `voicebox` (uid 999), so any cache write outside the HF mount (torch hub, spacy, …) fails with `Permission denied`, and on a fresh volume even HF model downloads fail.

The entrypoint already runs as root before `gosu`, so a non-recursive `mkdir -p` + `chown` there fixes both cases at zero cost.

## Testing

- CPU image built from scratch and run in production (Compose, named volumes): Kokoro, LuxTTS and Qwen3-TTS all generate correctly on torch 2.7.1; all fail on 2.13 with the errors above.
- Container recreated from a clean state: `~/.cache` and the HF mountpoint come up owned by `voicebox`, writable by uid 999.
- ROCm path untouched by the cache fix's placement in the shared entrypoint (chown is filesystem-only, runs before the existing GPU group logic's `gosu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU container builds by consistently installing compatible, pinned PyTorch versions.
  * Prevented later package installations from overriding the selected PyTorch version.
  * Fixed runtime access to Hugging Face model and tokenizer caches by creating the cache directory with appropriate permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->