### PR TITLE
Add custom OpenAI-compatible LLM endpoint for refinement and personality

### DIFF
--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -143,7 +143,10 @@ export function CapturesPage() {
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
   const customLlmEndpointSaved = settings?.custom_llm_endpoint ?? '';
   const customLlmModelSaved = settings?.custom_llm_model ?? '';
-  const customLlmApiKeySaved = settings?.custom_llm_api_key ?? '';
+  // The server no longer returns the API key value; it reports whether one
+  // is stored via ``custom_llm_api_key_configured``. Anything sitting in
+  // React state below is a freshly-typed key that hasn't been sent yet.
+  const customLlmApiKeyConfigured = Boolean(settings?.custom_llm_api_key_configured);
   const customLlmActive = Boolean(customLlmEndpointSaved && customLlmModelSaved);
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
@@ -153,7 +156,10 @@ export function CapturesPage() {
   // re-render on every keystroke while the user types out a URL or token.
   const [customLlmEndpointDraft, setCustomLlmEndpointDraft] = useState(customLlmEndpointSaved);
   const [customLlmModelDraft, setCustomLlmModelDraft] = useState(customLlmModelSaved);
-  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState(customLlmApiKeySaved);
+  // Write-only field: the input is blank on load even when a key is stored,
+  // and clears itself after a successful save so the raw value never lingers
+  // in React state where a browser cache or dev-tools inspection could grab it.
+  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState('');
 
   useEffect(() => {
     setCustomLlmEndpointDraft(customLlmEndpointSaved);
@@ -161,9 +167,6 @@ export function CapturesPage() {
   useEffect(() => {
     setCustomLlmModelDraft(customLlmModelSaved);
   }, [customLlmModelSaved]);
-  useEffect(() => {
-    setCustomLlmApiKeyDraft(customLlmApiKeySaved);
-  }, [customLlmApiKeySaved]);
 
   const commitCustomLlmEndpoint = useCallback(() => {
     const next = customLlmEndpointDraft.trim();
@@ -178,14 +181,18 @@ export function CapturesPage() {
     }
   }, [customLlmModelDraft, customLlmModelSaved, update]);
   const commitCustomLlmApiKey = useCallback(() => {
-    // The API key can legitimately contain leading/trailing punctuation for
-    // some providers, so we only trim when the whole field is whitespace.
     const trimmed = customLlmApiKeyDraft.trim();
-    const next = trimmed ? customLlmApiKeyDraft : '';
-    if (next !== customLlmApiKeySaved) {
-      update({ custom_llm_api_key: next || null });
-    }
-  }, [customLlmApiKeyDraft, customLlmApiKeySaved, update]);
+    if (!trimmed) return;
+    // Fire-and-forget the key, then wipe it from state so nothing else in
+    // the tree can read it back. The server flag flips to `configured=true`
+    // on the next settings query.
+    update({ custom_llm_api_key: customLlmApiKeyDraft });
+    setCustomLlmApiKeyDraft('');
+  }, [customLlmApiKeyDraft, update]);
+  const clearCustomLlmApiKey = useCallback(() => {
+    setCustomLlmApiKeyDraft('');
+    update({ custom_llm_api_key: null });
+  }, [update]);
 
   useEffect(() => {
     fetch(`${serverUrl}/health/filesystem`)
@@ -501,6 +508,9 @@ export function CapturesPage() {
           description={t('settings.captures.refinement.customEndpoint.description')}
         >
           <div className="space-y-2 max-w-lg">
+            <label htmlFor="customLlmEndpoint" className="block text-xs font-medium text-muted-foreground">
+              {t('settings.captures.refinement.customEndpoint.endpointLabel')}
+            </label>
             <Input
               id="customLlmEndpoint"
               type="url"
@@ -511,7 +521,11 @@ export function CapturesPage() {
               disabled={!autoRefine}
               autoComplete="off"
               spellCheck={false}
+              aria-label={t('settings.captures.refinement.customEndpoint.endpointLabel')}
             />
+            <label htmlFor="customLlmModel" className="block text-xs font-medium text-muted-foreground pt-1">
+              {t('settings.captures.refinement.customEndpoint.modelLabel')}
+            </label>
             <Input
               id="customLlmModel"
               type="text"
@@ -522,18 +536,45 @@ export function CapturesPage() {
               disabled={!autoRefine || !customLlmEndpointDraft}
               autoComplete="off"
               spellCheck={false}
+              aria-label={t('settings.captures.refinement.customEndpoint.modelLabel')}
             />
-            <Input
-              id="customLlmApiKey"
-              type="password"
-              placeholder={t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')}
-              value={customLlmApiKeyDraft}
-              onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
-              onBlur={commitCustomLlmApiKey}
-              disabled={!autoRefine || !customLlmEndpointDraft}
-              autoComplete="off"
-              spellCheck={false}
-            />
+            <label htmlFor="customLlmApiKey" className="block text-xs font-medium text-muted-foreground pt-1">
+              {t('settings.captures.refinement.customEndpoint.apiKeyLabel')}
+              {customLlmApiKeyConfigured ? (
+                <span className="ml-2 text-[10px] uppercase tracking-wide text-emerald-600">
+                  {t('settings.captures.refinement.customEndpoint.apiKeyConfigured')}
+                </span>
+              ) : null}
+            </label>
+            <div className="flex gap-2">
+              <Input
+                id="customLlmApiKey"
+                type="password"
+                placeholder={
+                  customLlmApiKeyConfigured
+                    ? t('settings.captures.refinement.customEndpoint.apiKeyPlaceholderReplace')
+                    : t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')
+                }
+                value={customLlmApiKeyDraft}
+                onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
+                onBlur={commitCustomLlmApiKey}
+                disabled={!autoRefine || !customLlmEndpointDraft}
+                autoComplete="new-password"
+                spellCheck={false}
+                aria-label={t('settings.captures.refinement.customEndpoint.apiKeyLabel')}
+                className="flex-1"
+              />
+              {customLlmApiKeyConfigured && (
+                <button
+                  type="button"
+                  onClick={clearCustomLlmApiKey}
+                  className="text-xs text-muted-foreground hover:text-destructive px-2 py-1 border border-border rounded-md"
+                  aria-label={t('settings.captures.refinement.customEndpoint.apiKeyClear')}
+                >
+                  {t('settings.captures.refinement.customEndpoint.apiKeyClear')}
+                </button>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground">
               {customLlmActive
                 ? t('settings.captures.refinement.customEndpoint.statusRemote', {
@@ -639,8 +680,14 @@ export function CapturesPage() {
             <li className="flex gap-2.5">
               <Lock className="h-4 w-4 shrink-0 mt-0.5 text-accent" />
               <span className="leading-relaxed">
-                <span className="text-foreground font-medium">{t('settings.captures.sidebar.local.title')}</span>{' '}
-                {t('settings.captures.sidebar.local.body')}
+                <span className="text-foreground font-medium">
+                  {customLlmActive
+                    ? t('settings.captures.sidebar.remote.title')
+                    : t('settings.captures.sidebar.local.title')}
+                </span>{' '}
+                {customLlmActive
+                  ? t('settings.captures.sidebar.remote.body', { endpoint: customLlmEndpointSaved })
+                  : t('settings.captures.sidebar.local.body')}
               </span>
             </li>
             <li className="flex gap-2.5">

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -183,10 +183,12 @@ export function CapturesPage() {
   const commitCustomLlmApiKey = useCallback(() => {
     const trimmed = customLlmApiKeyDraft.trim();
     if (!trimmed) return;
-    // Fire-and-forget the key, then wipe it from state so nothing else in
-    // the tree can read it back. The server flag flips to `configured=true`
-    // on the next settings query.
-    update({ custom_llm_api_key: customLlmApiKeyDraft });
+    // Send the trimmed value — surrounding whitespace in a bearer token
+    // makes the remote reject it with 401, which surfaces as a confusing
+    // "auth failed" toast when the raw pasted key is fine. Then wipe the
+    // draft so nothing else in the tree can read it back; the server flag
+    // flips to `configured=true` on the next settings query.
+    update({ custom_llm_api_key: trimmed });
     setCustomLlmApiKeyDraft('');
   }, [customLlmApiKeyDraft, update]);
   const clearCustomLlmApiKey = useCallback(() => {

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -140,10 +141,51 @@ export function CapturesPage() {
   const hotkeyEnabled = settings?.hotkey_enabled ?? false;
   const pushToTalkKeys = settings?.chord_push_to_talk_keys ?? defaultChordKeys('push');
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
+  const customLlmEndpointSaved = settings?.custom_llm_endpoint ?? '';
+  const customLlmModelSaved = settings?.custom_llm_model ?? '';
+  const customLlmApiKeySaved = settings?.custom_llm_api_key ?? '';
+  const customLlmActive = Boolean(customLlmEndpointSaved && customLlmModelSaved);
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
   const [opening, setOpening] = useState(false);
   const [capturesPath, setCapturesPath] = useState<string | null>(null);
+  // Drafts persist to the server on blur so we don't fire a PUT + optimistic
+  // re-render on every keystroke while the user types out a URL or token.
+  const [customLlmEndpointDraft, setCustomLlmEndpointDraft] = useState(customLlmEndpointSaved);
+  const [customLlmModelDraft, setCustomLlmModelDraft] = useState(customLlmModelSaved);
+  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState(customLlmApiKeySaved);
+
+  useEffect(() => {
+    setCustomLlmEndpointDraft(customLlmEndpointSaved);
+  }, [customLlmEndpointSaved]);
+  useEffect(() => {
+    setCustomLlmModelDraft(customLlmModelSaved);
+  }, [customLlmModelSaved]);
+  useEffect(() => {
+    setCustomLlmApiKeyDraft(customLlmApiKeySaved);
+  }, [customLlmApiKeySaved]);
+
+  const commitCustomLlmEndpoint = useCallback(() => {
+    const next = customLlmEndpointDraft.trim();
+    if (next !== customLlmEndpointSaved) {
+      update({ custom_llm_endpoint: next || null });
+    }
+  }, [customLlmEndpointDraft, customLlmEndpointSaved, update]);
+  const commitCustomLlmModel = useCallback(() => {
+    const next = customLlmModelDraft.trim();
+    if (next !== customLlmModelSaved) {
+      update({ custom_llm_model: next || null });
+    }
+  }, [customLlmModelDraft, customLlmModelSaved, update]);
+  const commitCustomLlmApiKey = useCallback(() => {
+    // The API key can legitimately contain leading/trailing punctuation for
+    // some providers, so we only trim when the whole field is whitespace.
+    const trimmed = customLlmApiKeyDraft.trim();
+    const next = trimmed ? customLlmApiKeyDraft : '';
+    if (next !== customLlmApiKeySaved) {
+      update({ custom_llm_api_key: next || null });
+    }
+  }, [customLlmApiKeyDraft, customLlmApiKeySaved, update]);
 
   useEffect(() => {
     fetch(`${serverUrl}/health/filesystem`)
@@ -453,6 +495,54 @@ export function CapturesPage() {
             />
           }
         />
+
+        <SettingRow
+          title={t('settings.captures.refinement.customEndpoint.title')}
+          description={t('settings.captures.refinement.customEndpoint.description')}
+        >
+          <div className="space-y-2 max-w-lg">
+            <Input
+              id="customLlmEndpoint"
+              type="url"
+              placeholder={t('settings.captures.refinement.customEndpoint.endpointPlaceholder')}
+              value={customLlmEndpointDraft}
+              onChange={(e) => setCustomLlmEndpointDraft(e.target.value)}
+              onBlur={commitCustomLlmEndpoint}
+              disabled={!autoRefine}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Input
+              id="customLlmModel"
+              type="text"
+              placeholder={t('settings.captures.refinement.customEndpoint.modelPlaceholder')}
+              value={customLlmModelDraft}
+              onChange={(e) => setCustomLlmModelDraft(e.target.value)}
+              onBlur={commitCustomLlmModel}
+              disabled={!autoRefine || !customLlmEndpointDraft}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Input
+              id="customLlmApiKey"
+              type="password"
+              placeholder={t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')}
+              value={customLlmApiKeyDraft}
+              onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
+              onBlur={commitCustomLlmApiKey}
+              disabled={!autoRefine || !customLlmEndpointDraft}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              {customLlmActive
+                ? t('settings.captures.refinement.customEndpoint.statusRemote', {
+                    endpoint: customLlmEndpointSaved,
+                  })
+                : t('settings.captures.refinement.customEndpoint.statusBuiltin')}
+            </p>
+          </div>
+        </SettingRow>
       </SettingSection>
 
       <SettingSection

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -986,11 +986,17 @@
         "customEndpoint": {
           "title": "Custom LLM endpoint (advanced)",
           "description": "Delegate refinement and personality rewrites to any OpenAI-compatible server — llama.cpp, vLLM, LM Studio, LocalAI, Ollama's shim, or the OpenAI API itself. Leave blank to use the built-in Qwen3.",
+          "endpointLabel": "Endpoint URL",
           "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelLabel": "Model name",
           "modelPlaceholder": "Model name (e.g. qwen3-4b)",
+          "apiKeyLabel": "API key",
           "apiKeyPlaceholder": "API key (optional)",
+          "apiKeyPlaceholderReplace": "Enter a new key to replace the stored one",
+          "apiKeyConfigured": "Stored",
+          "apiKeyClear": "Clear",
           "statusBuiltin": "Using the built-in Qwen3 model selected above.",
-          "statusRemote": "Sending every refinement to {{endpoint}}."
+          "statusRemote": "Sending every refinement and personality rewrite to {{endpoint}}."
         }
       },
       "playback": {
@@ -1028,6 +1034,10 @@
         "local": {
           "title": "Fully local.",
           "body": "Whisper and the refinement LLM run on your hardware. No cloud, no accounts, your voice never leaves the machine."
+        },
+        "remote": {
+          "title": "Refinement runs remotely.",
+          "body": "Whisper still transcribes on your hardware, but refined transcripts and personality rewrites are sent to {{endpoint}}. Voice audio itself never leaves the machine."
         },
         "playAs": {
           "title": "Play as any voice.",

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -982,6 +982,15 @@
         "preserveTechnical": {
           "title": "Preserve technical terms",
           "description": "Keep code identifiers, command names, and acronyms exactly as spoken. Turn on when you dictate into a code prompt."
+        },
+        "customEndpoint": {
+          "title": "Custom LLM endpoint (advanced)",
+          "description": "Delegate refinement and personality rewrites to any OpenAI-compatible server — llama.cpp, vLLM, LM Studio, LocalAI, Ollama's shim, or the OpenAI API itself. Leave blank to use the built-in Qwen3.",
+          "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelPlaceholder": "Model name (e.g. qwen3-4b)",
+          "apiKeyPlaceholder": "API key (optional)",
+          "statusBuiltin": "Using the built-in Qwen3 model selected above.",
+          "statusRemote": "Sending every refinement to {{endpoint}}."
         }
       },
       "playback": {

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -977,6 +977,15 @@
         "preserveTechnical": {
           "title": "専門用語を保持",
           "description": "コードの識別子、コマンド名、頭字語を発話どおりに保持します。コード入力欄にディクテーションするときに有効にしてください。"
+        },
+        "customEndpoint": {
+          "title": "カスタム LLM エンドポイント (上級)",
+          "description": "リファインとパーソナリティの書き換えを、任意の OpenAI 互換サーバー (llama.cpp、vLLM、LM Studio、LocalAI、Ollama の互換 API、OpenAI API 自体など) に委譲します。空欄のままなら内蔵の Qwen3 を使います。",
+          "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelPlaceholder": "モデル名 (例: qwen3-4b)",
+          "apiKeyPlaceholder": "API キー (任意)",
+          "statusBuiltin": "上で選んだ内蔵 Qwen3 モデルを使用しています",
+          "statusRemote": "リファインを {{endpoint}} に送信しています"
         }
       },
       "playback": {

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -981,11 +981,17 @@
         "customEndpoint": {
           "title": "カスタム LLM エンドポイント (上級)",
           "description": "リファインとパーソナリティの書き換えを、任意の OpenAI 互換サーバー (llama.cpp、vLLM、LM Studio、LocalAI、Ollama の互換 API、OpenAI API 自体など) に委譲します。空欄のままなら内蔵の Qwen3 を使います。",
+          "endpointLabel": "エンドポイント URL",
           "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelLabel": "モデル名",
           "modelPlaceholder": "モデル名 (例: qwen3-4b)",
+          "apiKeyLabel": "API キー",
           "apiKeyPlaceholder": "API キー (任意)",
+          "apiKeyPlaceholderReplace": "上書きする新しいキーを入力",
+          "apiKeyConfigured": "保存済",
+          "apiKeyClear": "クリア",
           "statusBuiltin": "上で選んだ内蔵 Qwen3 モデルを使用しています",
-          "statusRemote": "リファインを {{endpoint}} に送信しています"
+          "statusRemote": "リファインとパーソナリティの書き換えを {{endpoint}} に送信しています"
         }
       },
       "playback": {
@@ -1023,6 +1029,10 @@
         "local": {
           "title": "完全にローカル。",
           "body": "Whisper と整形用 LLM はあなたのハードウェア上で動作します。クラウドもアカウントも不要で、声がマシンの外に出ることはありません。"
+        },
+        "remote": {
+          "title": "整形処理はリモート実行中。",
+          "body": "Whisper はハードウェア上で書き起こしを続けますが、整形された文字起こしとパーソナリティ書き換えは {{endpoint}} に送られます。音声そのものはマシンから出ません。"
         },
         "playAs": {
           "title": "どのボイスでも再生。",

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -217,6 +217,15 @@ export interface CaptureSettings {
   chord_push_to_talk_keys: string[];
   /** keytap key names. Toggle adds Space to the platform-specific PTT chord. */
   chord_toggle_to_talk_keys: string[];
+  /**
+   * Optional OpenAI-compatible endpoint that overrides the built-in Qwen3
+   * LLM for refinement / personality rewriting. When set, backend calls hit
+   * `POST {custom_llm_endpoint}/chat/completions` with the model named by
+   * ``custom_llm_model``; leaving it null keeps the on-device Qwen path.
+   */
+  custom_llm_endpoint: string | null;
+  custom_llm_model: string | null;
+  custom_llm_api_key: string | null;
 }
 
 export type CaptureSettingsUpdate = Partial<CaptureSettings>;

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -225,10 +225,22 @@ export interface CaptureSettings {
    */
   custom_llm_endpoint: string | null;
   custom_llm_model: string | null;
-  custom_llm_api_key: string | null;
+  /**
+   * Whether a custom LLM API key is currently stored on the server. The raw
+   * key value never rides the response — this flag replaces it — so the
+   * settings UI can show a "Configured" indicator without letting the
+   * frontend rehydrate the secret into state or leak it to a browser cache.
+   * Writes still go through ``CaptureSettingsUpdate.custom_llm_api_key``.
+   */
+  custom_llm_api_key_configured: boolean;
 }
 
-export type CaptureSettingsUpdate = Partial<CaptureSettings>;
+export type CaptureSettingsUpdate = Partial<
+  Omit<CaptureSettings, 'custom_llm_api_key_configured'>
+> & {
+  /** Write-only: setting this to a non-empty string stores it, ``null`` clears it. */
+  custom_llm_api_key?: string | null;
+};
 
 /**
  * One row in the dictation readiness checklist. ``model_name`` is the

--- a/backend/app.py
+++ b/backend/app.py
@@ -322,6 +322,20 @@ async def _run_startup(application: FastAPI) -> None:
     finally:
         db.close()
 
+    # Seed the LLM backend dispatch from the persisted capture settings so
+    # the very first refinement / personality call after startup honours a
+    # user-configured custom OpenAI-compatible endpoint without needing a
+    # settings-write to flip the module state first.
+    db = next(get_db())
+    try:
+        from .services.settings import bootstrap_llm_backend_config
+
+        bootstrap_llm_backend_config(db)
+    except Exception as e:
+        logger.warning("Could not bootstrap custom LLM config: %s", e)
+    finally:
+        db.close()
+
     backend_type = get_backend_type()
     logger.info("Backend: %s", backend_type.upper())
     logger.info("GPU: %s", _get_gpu_status())

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -213,6 +213,11 @@ _custom_llm_endpoint: Optional[str] = None
 _custom_llm_model: Optional[str] = None
 _custom_llm_api_key: Optional[str] = None
 
+# ``_llm_backends`` key for the singleton OpenAI-compat backend. Extracted
+# so ``set_llm_config`` (cache invalidation) and ``get_llm_backend`` (cache
+# lookup + on-miss install) can't drift on the string literal.
+_OPENAI_COMPAT_CACHE_KEY = "openai_compat"
+
 # Supported TTS engines — keyed by engine name, value is the backend class import path.
 # The factory function uses this for the if/elif chain; the model configs live on the backend classes.
 TTS_ENGINES = {
@@ -779,7 +784,7 @@ def set_llm_config(
         _custom_llm_model = model
         _custom_llm_api_key = api_key
         if changed:
-            _llm_backends.pop("openai_compat", None)
+            _llm_backends.pop(_OPENAI_COMPAT_CACHE_KEY, None)
 
 
 def get_llm_backend() -> LLMBackend:
@@ -802,7 +807,7 @@ def get_llm_backend() -> LLMBackend:
         model = _custom_llm_model
         api_key = _custom_llm_api_key
         if endpoint and model:
-            cached = _llm_backends.get("openai_compat")
+            cached = _llm_backends.get(_OPENAI_COMPAT_CACHE_KEY)
             if cached is not None:
                 return cached
             backend = OpenAICompatLLMBackend(
@@ -810,13 +815,15 @@ def get_llm_backend() -> LLMBackend:
                 model=model,
                 api_key=api_key,
             )
-            _llm_backends["openai_compat"] = backend
+            _llm_backends[_OPENAI_COMPAT_CACHE_KEY] = backend
             return backend
 
-    # No custom config — hand off to the Qwen dispatch, which has its own
-    # lock and can take multiple seconds to load a model. Do that outside
-    # ``_llm_backends_lock`` so a slow model load doesn't block concurrent
-    # ``set_llm_config()`` writes.
+    # No custom config — hand off to the Qwen dispatch. ``get_llm_backend_for_engine``
+    # reuses this exact ``_llm_backends_lock`` (see its body below), and
+    # ``threading.Lock`` is non-reentrant, so this call MUST run after the
+    # ``with`` block above has released the lock — nesting it inside would
+    # self-deadlock the calling thread. Doing it here also means a slow
+    # model load doesn't block concurrent ``set_llm_config()`` writes.
     return get_llm_backend_for_engine("qwen_llm")
 
 

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -752,7 +752,7 @@ def set_llm_config(
     model: Optional[str],
     api_key: Optional[str],
 ) -> None:
-    """Update the runtime custom-LLM endpoint config.
+    """Update the runtime custom-LLM endpoint config atomically.
 
     Called from the settings service whenever the user writes to the
     ``custom_llm_endpoint`` / ``custom_llm_model`` / ``custom_llm_api_key``
@@ -760,23 +760,25 @@ def set_llm_config(
     strings or ``None`` clears the config and reverts subsequent
     ``get_llm_backend()`` calls to the built-in Qwen3 path.
 
-    A change drops any cached OpenAI-compat backend so the next call
-    rebuilds against the new URL / model rather than reusing a stale one.
+    The write, the change detection, and the cache invalidation all run
+    under ``_llm_backends_lock`` so a concurrent ``get_llm_backend()``
+    can't sample the endpoint/model/key mid-update and end up talking
+    to a stale URL with fresh credentials (or vice versa).
     """
     global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
     endpoint = endpoint or None
     model = model or None
     api_key = api_key or None
-    changed = (
-        endpoint != _custom_llm_endpoint
-        or model != _custom_llm_model
-        or api_key != _custom_llm_api_key
-    )
-    _custom_llm_endpoint = endpoint
-    _custom_llm_model = model
-    _custom_llm_api_key = api_key
-    if changed:
-        with _llm_backends_lock:
+    with _llm_backends_lock:
+        changed = (
+            endpoint != _custom_llm_endpoint
+            or model != _custom_llm_model
+            or api_key != _custom_llm_api_key
+        )
+        _custom_llm_endpoint = endpoint
+        _custom_llm_model = model
+        _custom_llm_api_key = api_key
+        if changed:
             _llm_backends.pop("openai_compat", None)
 
 
@@ -787,30 +789,35 @@ def get_llm_backend() -> LLMBackend:
     ``set_llm_config()``, returns an ``OpenAICompatLLMBackend`` targeting
     that endpoint; otherwise falls back to the platform-specific Qwen3
     backend (MLX on Apple Silicon, PyTorch elsewhere).
+
+    The config snapshot, cache lookup, and (if needed) backend
+    construction all happen inside ``_llm_backends_lock`` so a request
+    can't race a ``set_llm_config()`` write and end up talking to a
+    prior endpoint using fresh credentials, or the reverse.
     """
-    if _custom_llm_endpoint and _custom_llm_model:
-        return _get_openai_compat_backend()
-    return get_llm_backend_for_engine("qwen_llm")
+    from .openai_compat_backend import OpenAICompatLLMBackend
 
-
-def _get_openai_compat_backend() -> LLMBackend:
-    """Return the cached OpenAI-compat backend, creating it on first call."""
-    cached = _llm_backends.get("openai_compat")
-    if cached is not None:
-        return cached
     with _llm_backends_lock:
-        cached = _llm_backends.get("openai_compat")
-        if cached is not None:
-            return cached
-        from .openai_compat_backend import OpenAICompatLLMBackend
+        endpoint = _custom_llm_endpoint
+        model = _custom_llm_model
+        api_key = _custom_llm_api_key
+        if endpoint and model:
+            cached = _llm_backends.get("openai_compat")
+            if cached is not None:
+                return cached
+            backend = OpenAICompatLLMBackend(
+                endpoint=endpoint,
+                model=model,
+                api_key=api_key,
+            )
+            _llm_backends["openai_compat"] = backend
+            return backend
 
-        backend = OpenAICompatLLMBackend(
-            endpoint=_custom_llm_endpoint,
-            model=_custom_llm_model,
-            api_key=_custom_llm_api_key,
-        )
-        _llm_backends["openai_compat"] = backend
-        return backend
+    # No custom config — hand off to the Qwen dispatch, which has its own
+    # lock and can take multiple seconds to load a model. Do that outside
+    # ``_llm_backends_lock`` so a slow model load doesn't block concurrent
+    # ``set_llm_config()`` writes.
+    return get_llm_backend_for_engine("qwen_llm")
 
 
 def get_llm_backend_for_engine(engine: str) -> LLMBackend:

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -205,6 +205,14 @@ _stt_backend: Optional[STTBackend] = None
 _llm_backends: dict[str, LLMBackend] = {}
 _llm_backends_lock = threading.Lock()
 
+# Custom OpenAI-compatible LLM endpoint config, seeded from persisted
+# capture settings on startup and refreshed whenever the settings service
+# writes an update. Empty strings and None both mean "unset" and fall back
+# to the built-in Qwen3 backend.
+_custom_llm_endpoint: Optional[str] = None
+_custom_llm_model: Optional[str] = None
+_custom_llm_api_key: Optional[str] = None
+
 # Supported TTS engines — keyed by engine name, value is the backend class import path.
 # The factory function uses this for the if/elif chain; the model configs live on the backend classes.
 TTS_ENGINES = {
@@ -739,9 +747,70 @@ def get_stt_backend() -> STTBackend:
     return _stt_backend
 
 
+def set_llm_config(
+    endpoint: Optional[str],
+    model: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    """Update the runtime custom-LLM endpoint config.
+
+    Called from the settings service whenever the user writes to the
+    ``custom_llm_endpoint`` / ``custom_llm_model`` / ``custom_llm_api_key``
+    fields, and once on startup with the persisted row. Passing empty
+    strings or ``None`` clears the config and reverts subsequent
+    ``get_llm_backend()`` calls to the built-in Qwen3 path.
+
+    A change drops any cached OpenAI-compat backend so the next call
+    rebuilds against the new URL / model rather than reusing a stale one.
+    """
+    global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
+    endpoint = endpoint or None
+    model = model or None
+    api_key = api_key or None
+    changed = (
+        endpoint != _custom_llm_endpoint
+        or model != _custom_llm_model
+        or api_key != _custom_llm_api_key
+    )
+    _custom_llm_endpoint = endpoint
+    _custom_llm_model = model
+    _custom_llm_api_key = api_key
+    if changed:
+        with _llm_backends_lock:
+            _llm_backends.pop("openai_compat", None)
+
+
 def get_llm_backend() -> LLMBackend:
-    """Get or create the default Qwen3 LLM backend based on platform."""
+    """Get or create the active LLM backend.
+
+    When a custom OpenAI-compatible endpoint has been configured via
+    ``set_llm_config()``, returns an ``OpenAICompatLLMBackend`` targeting
+    that endpoint; otherwise falls back to the platform-specific Qwen3
+    backend (MLX on Apple Silicon, PyTorch elsewhere).
+    """
+    if _custom_llm_endpoint and _custom_llm_model:
+        return _get_openai_compat_backend()
     return get_llm_backend_for_engine("qwen_llm")
+
+
+def _get_openai_compat_backend() -> LLMBackend:
+    """Return the cached OpenAI-compat backend, creating it on first call."""
+    cached = _llm_backends.get("openai_compat")
+    if cached is not None:
+        return cached
+    with _llm_backends_lock:
+        cached = _llm_backends.get("openai_compat")
+        if cached is not None:
+            return cached
+        from .openai_compat_backend import OpenAICompatLLMBackend
+
+        backend = OpenAICompatLLMBackend(
+            endpoint=_custom_llm_endpoint,
+            model=_custom_llm_model,
+            api_key=_custom_llm_api_key,
+        )
+        _llm_backends["openai_compat"] = backend
+        return backend
 
 
 def get_llm_backend_for_engine(engine: str) -> LLMBackend:
@@ -775,7 +844,11 @@ def get_llm_backend_for_engine(engine: str) -> LLMBackend:
 def reset_backends():
     """Reset backend instances (useful for testing)."""
     global _tts_backend, _tts_backends, _stt_backend, _llm_backends
+    global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
     _tts_backend = None
     _tts_backends.clear()
     _stt_backend = None
     _llm_backends.clear()
+    _custom_llm_endpoint = None
+    _custom_llm_model = None
+    _custom_llm_api_key = None

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -185,4 +185,13 @@ def _extract_content(data: dict, url: str) -> str:
         content = first.get("text")
     if content is None:
         raise ValueError(f"No content in response from {url}: {data!r}")
+    if not isinstance(content, str):
+        # Vision-capable and tool-use servers sometimes return the content as
+        # an array of typed parts instead of a bare string. Refinement /
+        # personality are text-only paths, so surface a clear error instead
+        # of tripping ``AttributeError`` on ``.strip()`` and burying the
+        # shape mismatch.
+        raise ValueError(
+            f"Unexpected content type {type(content).__name__} in response from {url}: {data!r}"
+        )
     return content.strip()

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -1,0 +1,141 @@
+"""
+OpenAI-compatible LLM backend.
+
+Delegates chat completion to any HTTP endpoint that speaks the OpenAI
+``/v1/chat/completions`` protocol — llama.cpp server, vLLM, LocalAI,
+LM Studio, Ollama's OpenAI-compat shim, or the OpenAI API itself.
+Skips the on-device download / model-load path because the remote
+server is expected to serve the model.
+
+The user configures ``custom_llm_endpoint`` / ``custom_llm_model`` /
+``custom_llm_api_key`` in capture settings; when the endpoint is set,
+``get_llm_backend()`` returns an instance of this class instead of the
+built-in Qwen3 backend.
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from . import DEFAULT_LLM_MAX_TOKENS, DEFAULT_LLM_TEMPERATURE
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 120.0
+
+
+class OpenAICompatLLMBackend:
+    """LLM backend that delegates to an OpenAI-compatible chat endpoint."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        model: str,
+        api_key: Optional[str] = None,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ):
+        # Strip a trailing slash so callers can pass either
+        # ``http://host:port/v1`` or ``http://host:port/v1/``.
+        self.endpoint = endpoint.rstrip("/")
+        self.model = model
+        # Empty string means "no auth" — the app UI stores an empty field
+        # the same way an unset field looks in the DB.
+        self.api_key = api_key or None
+        self.timeout = timeout
+        # ``model_size`` / ``_current_model_size`` are read by the shared
+        # download-progress / unload plumbing on other backends. Report the
+        # remote model name so the routes layer can echo it back to clients.
+        self.model_size = model
+        self._current_model_size = model
+
+    def is_loaded(self) -> bool:
+        # A remote endpoint is always "loaded" from this process's point of
+        # view — no local weights to page in.
+        return True
+
+    async def load_model(self, model_size: Optional[str] = None) -> None:  # noqa: ARG002
+        """No-op — remote endpoint holds the model."""
+        return
+
+    def unload_model(self) -> None:
+        """No-op — nothing to unload locally."""
+        return
+
+    async def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,  # noqa: ARG002 — kept for protocol parity
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> str:
+        messages = _build_messages(prompt, system, examples)
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        url = f"{self.endpoint}/chat/completions"
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Truncate the body — some servers echo the whole prompt in
+                # error responses, and log files fill up fast otherwise.
+                body_preview = exc.response.text[:500]
+                logger.error(
+                    "OpenAI-compat endpoint %s returned %d: %s",
+                    url,
+                    exc.response.status_code,
+                    body_preview,
+                )
+                raise
+            except httpx.RequestError as exc:
+                logger.error("OpenAI-compat endpoint %s request failed: %s", url, exc)
+                raise
+
+            data = response.json()
+
+        return _extract_content(data, url)
+
+
+def _build_messages(
+    prompt: str,
+    system: Optional[str],
+    examples: Optional[list[tuple[str, str]]],
+) -> list[dict]:
+    messages: list[dict] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    if examples:
+        for user_text, assistant_text in examples:
+            messages.append({"role": "user", "content": user_text})
+            messages.append({"role": "assistant", "content": assistant_text})
+    messages.append({"role": "user", "content": prompt})
+    return messages
+
+
+def _extract_content(data: dict, url: str) -> str:
+    choices = data.get("choices") or []
+    if not choices:
+        raise ValueError(f"No choices in response from {url}: {data!r}")
+
+    first = choices[0]
+    message = first.get("message") or {}
+    content = message.get("content")
+    if content is None:
+        # Fallback: some servers still return the legacy text-completion
+        # shape (``choices[0].text``) even from the chat endpoint.
+        content = first.get("text")
+    if content is None:
+        raise ValueError(f"No content in response from {url}: {data!r}")
+    return content.strip()

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -35,6 +35,18 @@ class OpenAICompatLLMBackend:
         api_key: Optional[str] = None,
         timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     ):
+        """Configure the backend for a specific remote endpoint.
+
+        Args:
+            endpoint: Full base URL up to and including the ``/v1``
+                segment (trailing slash tolerated).
+            model: Model name to send in every request's ``model`` field.
+            api_key: Optional bearer token; empty string treated the same
+                as ``None`` so a blank UI field disables auth.
+            timeout: Per-request timeout in seconds. Defaults to two
+                minutes so slow remote hosts don't cut off long
+                generations.
+        """
         # Strip a trailing slash so callers can pass either
         # ``http://host:port/v1`` or ``http://host:port/v1/``.
         self.endpoint = endpoint.rstrip("/")
@@ -50,8 +62,13 @@ class OpenAICompatLLMBackend:
         self._current_model_size = model
 
     def is_loaded(self) -> bool:
-        # A remote endpoint is always "loaded" from this process's point of
-        # view — no local weights to page in.
+        """Return ``True`` unconditionally — the remote server owns model state.
+
+        Voicebox's shared plumbing polls ``is_loaded`` to decide whether
+        to show a "downloading model…" progress bar; since a remote
+        endpoint has nothing to page in from this process's point of
+        view, the answer is always yes.
+        """
         return True
 
     async def load_model(self, model_size: Optional[str] = None) -> None:  # noqa: ARG002
@@ -71,6 +88,20 @@ class OpenAICompatLLMBackend:
         model_size: Optional[str] = None,  # noqa: ARG002 — kept for protocol parity
         examples: Optional[list[tuple[str, str]]] = None,
     ) -> str:
+        """Post one non-streaming chat completion and return the assistant text.
+
+        Mirrors ``LLMBackend.generate`` — the same call signature the
+        built-in Qwen backends use — so refinement and personality
+        services can swap between local and remote transparently.
+        ``model_size`` is accepted for protocol parity but ignored:
+        remote model selection is pinned at construction time.
+
+        Raises:
+            httpx.HTTPStatusError: The remote returned a non-2xx status.
+            httpx.RequestError: Transport failure (timeout, DNS, TLS).
+            ValueError: The response was well-formed HTTP but carried no
+                content in either the chat or legacy completion shapes.
+        """
         messages = _build_messages(prompt, system, examples)
         payload = {
             "model": self.model,
@@ -113,6 +144,14 @@ def _build_messages(
     system: Optional[str],
     examples: Optional[list[tuple[str, str]]],
 ) -> list[dict]:
+    """Assemble the ``messages`` array for a chat completion request.
+
+    Optional system prompt and few-shot ``(user, assistant)`` pairs are
+    laid out in the order the OpenAI protocol expects: system first,
+    then example turns, then the fresh user prompt. Small models pattern-
+    match on inline examples in the system prompt but generalise from
+    structured turns, so refinement passes examples through this path.
+    """
     messages: list[dict] = []
     if system:
         messages.append({"role": "system", "content": system})
@@ -125,6 +164,14 @@ def _build_messages(
 
 
 def _extract_content(data: dict, url: str) -> str:
+    """Pull the assistant text out of a parsed chat-completion response.
+
+    Prefers the modern ``choices[0].message.content`` field but falls
+    back to the legacy ``choices[0].text`` layout for servers that still
+    return the text-completion shape from the chat endpoint. Raises
+    ``ValueError`` when neither field is present so the failure surfaces
+    with the offending URL and payload for debugging.
+    """
     choices = data.get("choices") or []
     if not choices:
         raise ValueError(f"No choices in response from {url}: {data!r}")

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -243,6 +243,27 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "hotkey_enabled BOOLEAN NOT NULL DEFAULT 0",
             "hotkey_enabled",
         )
+    if "custom_llm_endpoint" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_endpoint VARCHAR",
+            "custom_llm_endpoint",
+        )
+    if "custom_llm_model" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_model VARCHAR",
+            "custom_llm_model",
+        )
+    if "custom_llm_api_key" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_api_key VARCHAR",
+            "custom_llm_api_key",
+        )
 
 
 def _migrate_mcp_bindings(engine, inspector, tables: set[str]) -> None:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -218,6 +218,14 @@ class CaptureSettings(Base):
     chord_toggle_to_talk_keys = Column(
         JSON, nullable=False, default=default_toggle_to_talk_chord
     )
+    # Optional OpenAI-compatible endpoint that overrides the built-in Qwen3
+    # LLM for refinement / personality rewriting. When ``custom_llm_endpoint``
+    # is set, the backend layer delegates every LLM call to this URL instead
+    # of running Qwen locally; leaving it null keeps the on-device path and
+    # the ``llm_model`` size selector above.
+    custom_llm_endpoint = Column(String, nullable=True)
+    custom_llm_model = Column(String, nullable=True)
+    custom_llm_api_key = Column(String, nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,8 +2,8 @@
 Pydantic models for request/response validation.
 """
 
-from pydantic import BaseModel, Field
-from typing import Optional, List
+from pydantic import BaseModel, Field, model_validator
+from typing import Any, Optional, List
 from datetime import datetime
 
 from .utils.capture_chords import (
@@ -266,7 +266,36 @@ class CaptureSettingsResponse(BaseModel):
     )
     custom_llm_endpoint: Optional[str] = None
     custom_llm_model: Optional[str] = None
-    custom_llm_api_key: Optional[str] = None
+    # Provider credential — write-only. The response reports whether one is
+    # configured but never echoes the value, so the settings API can't be
+    # used to exfiltrate stored keys and the frontend can't rehydrate them
+    # into React state where a browser cache could pick them up.
+    custom_llm_api_key_configured: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _mask_custom_llm_api_key(cls, data: Any) -> Any:
+        """Replace the raw ``custom_llm_api_key`` with a boolean ``_configured`` flag.
+
+        Runs before field validation so the stored credential is never
+        materialised on a Response instance, even in memory. Accepts both
+        SQLAlchemy ORM rows (``from_attributes=True`` path) and plain dicts
+        so tests that construct the model directly get the same treatment.
+        """
+        if isinstance(data, dict):
+            raw_key = data.pop("custom_llm_api_key", None)
+            data.setdefault("custom_llm_api_key_configured", bool(raw_key))
+            return data
+        # ORM row — build a snapshot dict, drop the secret, and hand the
+        # rest to Pydantic. ``from_attributes`` won't reach the raw
+        # attribute anymore because the returned dict wins.
+        columns = getattr(getattr(data, "__table__", None), "columns", None)
+        if columns is None:
+            return data
+        snapshot = {c.name: getattr(data, c.name, None) for c in columns}
+        raw_key = snapshot.pop("custom_llm_api_key", None)
+        snapshot["custom_llm_api_key_configured"] = bool(raw_key)
+        return snapshot
 
     class Config:
         from_attributes = True

--- a/backend/models.py
+++ b/backend/models.py
@@ -264,6 +264,9 @@ class CaptureSettingsResponse(BaseModel):
     chord_toggle_to_talk_keys: List[str] = Field(
         default_factory=default_toggle_to_talk_chord
     )
+    custom_llm_endpoint: Optional[str] = None
+    custom_llm_model: Optional[str] = None
+    custom_llm_api_key: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -284,6 +287,9 @@ class CaptureSettingsUpdate(BaseModel):
     hotkey_enabled: Optional[bool] = None
     chord_push_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
     chord_toggle_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
+    custom_llm_endpoint: Optional[str] = None
+    custom_llm_model: Optional[str] = None
+    custom_llm_api_key: Optional[str] = None
 
 
 class GenerationSettingsResponse(BaseModel):

--- a/backend/routes/llm.py
+++ b/backend/routes/llm.py
@@ -18,40 +18,54 @@ router = APIRouter()
 
 @router.post("/llm/generate", response_model=models.LLMGenerateResponse)
 async def llm_generate(request: models.LLMGenerateRequest):
-    """Run a single-turn Qwen3 completion."""
+    """Run a single-turn chat completion via the active LLM backend.
+
+    Routes to the built-in Qwen3 backend by default. If the user has
+    configured a custom OpenAI-compatible endpoint under capture settings,
+    ``get_llm_model()`` returns that backend and the Qwen-specific size
+    validation / download-progress plumbing below is skipped.
+    """
+    from ..backends.openai_compat_backend import OpenAICompatLLMBackend
+
     backend = llm.get_llm_model()
-    model_size = request.model_size or backend.model_size
 
-    valid_sizes = {cfg.model_size for cfg in get_llm_model_configs()}
-    if model_size not in valid_sizes:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid LLM size '{model_size}'. Must be one of: {sorted(valid_sizes)}",
-        )
+    if isinstance(backend, OpenAICompatLLMBackend):
+        # Custom endpoint owns model selection. The remote server validates
+        # its own model name and there's nothing to download locally.
+        model_size = backend.model_size
+    else:
+        model_size = request.model_size or backend.model_size
 
-    already_loaded = backend.is_loaded() and backend.model_size == model_size
-    if not already_loaded and not backend._is_model_cached(model_size):
-        progress_model_name = f"qwen3-{model_size.lower()}"
-        task_manager = get_task_manager()
+        valid_sizes = {cfg.model_size for cfg in get_llm_model_configs()}
+        if model_size not in valid_sizes:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid LLM size '{model_size}'. Must be one of: {sorted(valid_sizes)}",
+            )
 
-        async def download_llm_background():
-            try:
-                await backend.load_model(model_size)
-                task_manager.complete_download(progress_model_name)
-            except Exception as e:
-                task_manager.error_download(progress_model_name, str(e))
+        already_loaded = backend.is_loaded() and backend.model_size == model_size
+        if not already_loaded and not backend._is_model_cached(model_size):
+            progress_model_name = f"qwen3-{model_size.lower()}"
+            task_manager = get_task_manager()
 
-        task_manager.start_download(progress_model_name)
-        create_background_task(download_llm_background())
+            async def download_llm_background():
+                try:
+                    await backend.load_model(model_size)
+                    task_manager.complete_download(progress_model_name)
+                except Exception as e:
+                    task_manager.error_download(progress_model_name, str(e))
 
-        return JSONResponse(
-            status_code=202,
-            content={
-                "message": f"Qwen3 {model_size} is being downloaded. Please wait and try again.",
-                "model_name": progress_model_name,
-                "downloading": True,
-            },
-        )
+            task_manager.start_download(progress_model_name)
+            create_background_task(download_llm_background())
+
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "message": f"Qwen3 {model_size} is being downloaded. Please wait and try again.",
+                    "model_name": progress_model_name,
+                    "downloading": True,
+                },
+            )
 
     examples: list[tuple[str, str]] | None = None
     if request.examples:

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -74,7 +74,34 @@ def update_capture_settings(db: Session, patch: dict[str, Any]) -> DBCaptureSett
     _apply_patch(row, patch)
     db.commit()
     db.refresh(row)
+    _sync_llm_backend_config(row)
     return row
+
+
+def _sync_llm_backend_config(row: DBCaptureSettings) -> None:
+    """Push the persisted custom-LLM endpoint into the backend module state.
+
+    Called after every capture-settings write and once on startup from
+    ``bootstrap_llm_backend_config``. Keeps the runtime dispatch in
+    ``backends.get_llm_backend()`` in sync with what the DB row holds so
+    the user's next refinement / personality call routes to the new URL
+    without a restart.
+    """
+    # Imported inline to avoid a circular import at module load — the
+    # backends package pulls in HF patches that in turn import services.
+    from .. import backends
+
+    backends.set_llm_config(
+        endpoint=row.custom_llm_endpoint,
+        model=row.custom_llm_model,
+        api_key=row.custom_llm_api_key,
+    )
+
+
+def bootstrap_llm_backend_config(db: Session) -> None:
+    """Seed the backend LLM config from the persisted row on server startup."""
+    row = _get_or_create_capture_row(db)
+    _sync_llm_backend_config(row)
 
 
 def get_generation_settings(db: Session) -> DBGenerationSettings:

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -23,6 +23,12 @@ SINGLETON_ID = 1
 
 
 def _get_or_create_capture_row(db: Session) -> DBCaptureSettings:
+    """Fetch the singleton capture-settings row, lazily creating it on first read.
+
+    Every setter path is a partial update against this row, so callers
+    can assume the returned object exists and holds the schema defaults
+    for any field the user hasn't customised yet.
+    """
     row = db.query(DBCaptureSettings).filter(DBCaptureSettings.id == SINGLETON_ID).first()
     if row is None:
         row = DBCaptureSettings(
@@ -37,6 +43,11 @@ def _get_or_create_capture_row(db: Session) -> DBCaptureSettings:
 
 
 def _get_or_create_generation_row(db: Session) -> DBGenerationSettings:
+    """Fetch the singleton generation-settings row, lazily creating it on first read.
+
+    Symmetric counterpart to :func:`_get_or_create_capture_row` for the
+    long-form generation defaults (chunk sizer, crossfade, normalize).
+    """
     row = db.query(DBGenerationSettings).filter(DBGenerationSettings.id == SINGLETON_ID).first()
     if row is None:
         row = DBGenerationSettings(id=SINGLETON_ID)
@@ -70,6 +81,13 @@ def get_capture_settings(db: Session) -> DBCaptureSettings:
 
 
 def update_capture_settings(db: Session, patch: dict[str, Any]) -> DBCaptureSettings:
+    """Apply a partial update to the capture-settings singleton and persist it.
+
+    After the commit, propagates the (possibly changed) custom-LLM
+    endpoint into the backend module state via
+    :func:`_sync_llm_backend_config` so subsequent refinement /
+    personality calls route to the new URL without needing a restart.
+    """
     row = _get_or_create_capture_row(db)
     _apply_patch(row, patch)
     db.commit()
@@ -110,6 +128,13 @@ def get_generation_settings(db: Session) -> DBGenerationSettings:
 
 
 def update_generation_settings(db: Session, patch: dict[str, Any]) -> DBGenerationSettings:
+    """Apply a partial update to the generation-settings singleton and persist it.
+
+    Unlike :func:`update_capture_settings`, no runtime state depends on
+    these values — the fields flow directly into the next
+    ``run_generation`` invocation via ``GenerationSettings`` — so the
+    commit is enough.
+    """
     row = _get_or_create_generation_row(db)
     _apply_patch(row, patch)
     db.commit()

--- a/backend/tests/test_openai_compat_integration.py
+++ b/backend/tests/test_openai_compat_integration.py
@@ -110,26 +110,40 @@ async def test_backend_generates_non_empty_response():
 
 
 async def test_backend_respects_examples_history():
-    """Few-shot examples reach the endpoint as proper user/assistant turns."""
+    """Few-shot examples reach the endpoint as proper user/assistant turns.
+
+    Uses an arbitrary mapping (``ping → PONG``, ``foo → BAR``) so a passing
+    assertion actually proves the examples were serialised into the
+    request. A non-empty translation would still pass if ``examples``
+    were silently dropped; the model has to have seen the pattern to
+    return the mapped token on a novel input.
+    """
     backend = OpenAICompatLLMBackend(
         endpoint=_endpoint(),
         model=_model(),
         api_key=_api_key(),
     )
     reply = await backend.generate(
-        prompt="hola",
+        prompt="baz",
         system=(
-            "You are a translation bot. Reply with the single-word English "
-            "translation of the user's message and nothing else."
+            "You are a lookup function. Respond with exactly one uppercase word "
+            "matching the mapping shown in the examples and nothing else."
         ),
-        max_tokens=16,
+        max_tokens=8,
         temperature=0.0,
         examples=[
-            ("bonjour", "hello"),
-            ("guten tag", "hello"),
+            ("ping", "PONG"),
+            ("foo", "BAR"),
         ],
     )
-    assert reply.strip(), "Endpoint returned an empty translation"
+    stripped = reply.strip().upper()
+    # The model may add punctuation; check that the mapped-shape token
+    # ("QUX" is the natural next entry after PONG/BAR) leads the reply.
+    assert stripped, "Endpoint returned an empty response to a few-shot prompt"
+    assert stripped.startswith(("QUX", "BAZ")), (
+        f"Reply {reply!r} doesn't look like it followed the example mapping — "
+        "the ``examples`` field may have been dropped in transit."
+    )
 
 
 async def test_dispatch_returns_openai_compat_when_config_set():

--- a/backend/tests/test_openai_compat_integration.py
+++ b/backend/tests/test_openai_compat_integration.py
@@ -1,0 +1,182 @@
+"""
+Integration tests for the OpenAI-compatible LLM backend.
+
+These tests hit a **real** endpoint — no HTTP mocks — because the whole
+point of the backend is to survive whatever quirks a real server's
+response shape has. They are skipped automatically when no reachable
+endpoint is configured, so ``pytest`` on a fresh clone still returns
+green.
+
+To run them, boot any OpenAI-compatible server (llama.cpp,
+vLLM, LM Studio, LocalAI, ALICE-LLM's ``server`` binary, or the OpenAI
+API itself), then:
+
+    export VOICEBOX_TEST_OPENAI_COMPAT_URL=http://localhost:8090/v1
+    export VOICEBOX_TEST_OPENAI_COMPAT_MODEL=<the model the server serves>
+    # optional if the endpoint requires bearer auth
+    export VOICEBOX_TEST_OPENAI_COMPAT_API_KEY=<token>
+    pytest backend/tests/test_openai_compat_integration.py -v
+"""
+
+import os
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+from backend.backends import (
+    get_llm_backend,
+    reset_backends,
+    set_llm_config,
+)
+from backend.backends.openai_compat_backend import OpenAICompatLLMBackend
+
+
+ENDPOINT_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_URL"
+MODEL_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_MODEL"
+API_KEY_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_API_KEY"
+
+
+def _endpoint() -> str | None:
+    return os.environ.get(ENDPOINT_ENV) or None
+
+
+def _model() -> str | None:
+    return os.environ.get(MODEL_ENV) or None
+
+
+def _api_key() -> str | None:
+    return os.environ.get(API_KEY_ENV) or None
+
+
+def _endpoint_reachable(url: str) -> bool:
+    """Cheap TCP probe so we skip cleanly when nothing is listening.
+
+    A full HTTP GET would work too, but that couples the skip to whichever
+    path (``/v1``, ``/health``, ``/models``…) the local server happens to
+    expose. TCP handshake to the ``host:port`` from the URL is enough to
+    tell us "run the test" vs "user hasn't started their server".
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except OSError:
+        return False
+
+
+def _endpoint_ready() -> bool:
+    url = _endpoint()
+    model = _model()
+    if not url or not model:
+        return False
+    return _endpoint_reachable(url)
+
+
+pytestmark = pytest.mark.skipif(
+    not _endpoint_ready(),
+    reason=(
+        f"OpenAI-compatible endpoint not configured or unreachable. Set "
+        f"{ENDPOINT_ENV} and {MODEL_ENV} and start the server to run "
+        "these integration tests."
+    ),
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_backends_between_tests():
+    reset_backends()
+    yield
+    reset_backends()
+
+
+async def test_backend_generates_non_empty_response():
+    """One real round trip against the configured endpoint."""
+    backend = OpenAICompatLLMBackend(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    reply = await backend.generate(
+        prompt="Reply with exactly the word: pong",
+        system="You are a terse test harness. Follow the instruction literally.",
+        max_tokens=16,
+        temperature=0.0,
+    )
+    assert isinstance(reply, str)
+    assert reply.strip(), "Endpoint returned an empty string"
+
+
+async def test_backend_respects_examples_history():
+    """Few-shot examples reach the endpoint as proper user/assistant turns."""
+    backend = OpenAICompatLLMBackend(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    reply = await backend.generate(
+        prompt="hola",
+        system=(
+            "You are a translation bot. Reply with the single-word English "
+            "translation of the user's message and nothing else."
+        ),
+        max_tokens=16,
+        temperature=0.0,
+        examples=[
+            ("bonjour", "hello"),
+            ("guten tag", "hello"),
+        ],
+    )
+    assert reply.strip(), "Endpoint returned an empty translation"
+
+
+async def test_dispatch_returns_openai_compat_when_config_set():
+    """``get_llm_backend()`` routes to the custom backend once config is on."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    backend = get_llm_backend()
+    assert isinstance(backend, OpenAICompatLLMBackend)
+    assert backend.endpoint == _endpoint().rstrip("/")
+    assert backend.model == _model()
+
+
+async def test_dispatch_reverts_when_config_cleared():
+    """Clearing the endpoint falls back to the on-device Qwen path."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    assert isinstance(get_llm_backend(), OpenAICompatLLMBackend)
+
+    set_llm_config(endpoint=None, model=None, api_key=None)
+    fallback = get_llm_backend()
+    assert not isinstance(fallback, OpenAICompatLLMBackend)
+
+
+async def test_dispatch_rebuilds_when_endpoint_changes():
+    """A URL swap drops the cached backend so the next call rebuilds."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    first = get_llm_backend()
+
+    # Point at a syntactically different URL. We're testing the cache
+    # invalidation path — the second URL doesn't need to be reachable.
+    set_llm_config(
+        endpoint=_endpoint() + "/alt",
+        model=_model(),
+        api_key=_api_key(),
+    )
+    second = get_llm_backend()
+
+    assert first is not second
+    assert isinstance(second, OpenAICompatLLMBackend)
+    assert second.endpoint.endswith("/alt")


### PR DESCRIPTION
Closes #857 (partial — LLM cloud fallback path).

Adds a settings-driven way to swap the built-in Qwen3 LLM for any endpoint that speaks OpenAI's `/v1/chat/completions` protocol: OpenAI itself, OpenRouter, Anthropic-via-proxy, llama.cpp server, vLLM, LM Studio, LocalAI, Ollama's OpenAI shim, or a self-hosted engine. An empty endpoint field keeps refinement and personality-speak running on Qwen exactly like before.

## Design

- New `OpenAICompatLLMBackend` implementing the existing `LLMBackend` protocol. Uses `httpx.AsyncClient`; non-streaming for this PR (a streaming variant lands in #948).
- Module-level `set_llm_config()` + a `get_llm_backend()` dispatch that reroutes to the remote backend when the endpoint is configured. Config changes drop the cached backend so URL / model swaps take effect without a restart.
- Three new `capture_settings` columns (`custom_llm_endpoint`, `custom_llm_model`, `custom_llm_api_key`) with an idempotent column-add migration matching the existing `_migrate_capture_settings` style, and matching `CaptureSettingsResponse` / `CaptureSettingsUpdate` fields.
- Startup bootstrap seeds `set_llm_config()` from the persisted row before the first LLM call; every `PUT /settings/captures` re-syncs.
- `/llm/generate` route skips the Qwen size validation and download-progress branch when the custom endpoint is active — the remote server owns model selection.
- Frontend adds a **Custom LLM endpoint (advanced)** section under Refinement in Captures settings with three inputs (endpoint URL, model name, API key) that persist on blur. A status footnote reports whether the built-in Qwen3 or the remote endpoint is currently active. en / ja translations included; other locales fall back to English until a native pass lands.

## Testing

- `backend/tests/test_openai_compat_integration.py` — real HTTP round-trip (no mocks) against a caller-configured endpoint (`VOICEBOX_TEST_OPENAI_COMPAT_URL` / `_MODEL` env vars), covering protocol compliance, few-shot history propagation, dispatch, cache invalidation, and Qwen fallback. Skips automatically when the endpoint isn't reachable so `pytest` on a fresh clone stays green.
- Manually verified end-to-end against a local llama.cpp-style OpenAI-compatible server: `PUT /settings/captures` persists the endpoint, `POST /llm/generate` reaches the remote model, coherent responses come back, and clearing the endpoint reverts to the on-device Qwen path.

## Relationship to #940

@andreolf's #940 (BYO-LLM conversational voice mode) targets a different UX — a new voice-chat surface with `ConversationSettings` + `ConversationPanel` — but lands on the same shared backend file (`backend/backends/openai_compat_backend.py` with an `OpenAICompatLLMBackend`). Feature scopes are cleanly independent (different DB tables, different frontend surfaces) but the backend class needs to be de-duplicated when both PRs land. Happy to rebase this one onto the shared class if #940 lands first, and posted the same note on that PR so we can coordinate.

## Breaking changes / migration

None. Existing installs get three new nullable columns and default to `null` — every existing behaviour test still passes on the on-device Qwen path.

## Follow-up

A streaming LLM → TTS pipeline that layers on top of this endpoint infrastructure lands in #948 (progressive audio playback, ~7 s first-audio-latency improvement measured against a mock TTS). Kept separate so this one stays reviewable in isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced custom OpenAI-compatible LLM configuration for capture refinement (endpoint URL, model, and a saved “API key configured” indicator).
  * Refinement/personality rewriting can now run remotely via the custom endpoint while transcription stays local.
* **Bug Fixes**
  * Improved switching between remote and built-in refinement by initializing and syncing the active LLM backend from saved settings.
  * Updated remote routing so model-size handling matches the selected backend.
* **Documentation**
  * Added English and Japanese translations for the new custom-endpoint UI and updated “remote vs local” wording.
* **Tests**
  * Added live integration coverage for the OpenAI-compatible backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->