### PR TITLE
Add streaming LLM→TTS pipeline with SSE audio to client

### DIFF
--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -508,7 +508,11 @@ export function FloatingGenerateBox({
                 </AnimatePresence>
 
                 <AnimatePresence>
-                  {streamingAvailable && (
+                  {/* Keep the button mounted while a stream is active — otherwise
+                      clearing the text field or switching to a profile without
+                      a personality would remove the only in-place way to stop
+                      audio that ``useStreamingSpeak`` has already scheduled. */}
+                  {(streamingAvailable || streamingActive) && (
                     <motion.div
                       initial={{ opacity: 0, scale: 0.8 }}
                       animate={{ opacity: 1, scale: 1 }}
@@ -520,7 +524,12 @@ export function FloatingGenerateBox({
                           type="button"
                           variant="ghost"
                           size="icon"
-                          disabled={!selectedProfileId || !form.watch('text')?.trim()}
+                          // Validation only matters when starting a new stream;
+                          // an active stream must always be abortable.
+                          disabled={
+                            !streamingActive &&
+                            (!selectedProfileId || !form.watch('text')?.trim())
+                          }
                           onClick={() => {
                             if (streamingActive) {
                               streamAbort();

--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -118,6 +118,19 @@ export function FloatingGenerateBox({
   const streamingActive =
     streamState.status === 'connecting' || streamState.status === 'streaming';
 
+  // Surface mid-stream faults through the shared toast — otherwise the
+  // streaming button just flips back to idle and the user has no idea
+  // whether their utterance failed or finished silently.
+  useEffect(() => {
+    if (streamState.status !== 'error') return;
+    toast({
+      title: t('generation.button.streamErrorTitle'),
+      description:
+        streamState.error ?? t('generation.button.streamErrorFallback'),
+      variant: 'destructive',
+    });
+  }, [streamState.status, streamState.error, toast, t]);
+
   // Click away handler to collapse the box
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useMatchRoute } from '@tanstack/react-router';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Dices, Loader2, SlidersHorizontal, Sparkles, Wand2 } from 'lucide-react';
+import { AudioLines, Dices, Loader2, SlidersHorizontal, Sparkles, Square, Wand2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -19,6 +19,8 @@ import { apiClient } from '@/lib/api/client';
 import { getLanguageOptionsForEngine, type LanguageCode } from '@/lib/constants/languages';
 import { useGenerationForm } from '@/lib/hooks/useGenerationForm';
 import { useProfile, useProfiles } from '@/lib/hooks/useProfiles';
+import { useStreamingSpeak } from '@/lib/hooks/useStreamingSpeak';
+import { useCaptureSettings } from '@/lib/hooks/useSettings';
 import { useStory } from '@/lib/hooks/useStories';
 import { cn } from '@/lib/utils/cn';
 import { useGenerationStore } from '@/stores/generationStore';
@@ -97,6 +99,24 @@ export function FloatingGenerateBox({
       return preset?.effects_chain;
     },
   });
+
+  // Streaming speak — SSE variant that ships audio as it renders. Only
+  // shown when the user has wired a custom OpenAI-compatible LLM endpoint
+  // AND the selected profile has a personality to rewrite through, since
+  // that's the only mode where the LLM+TTS overlap wins any latency.
+  const { settings: captureSettings } = useCaptureSettings();
+  const {
+    state: streamState,
+    speak: streamSpeak,
+    abort: streamAbort,
+  } = useStreamingSpeak();
+  const streamingConfigured = Boolean(
+    captureSettings?.custom_llm_endpoint && captureSettings?.custom_llm_model,
+  );
+  const streamingAvailable =
+    streamingConfigured && Boolean(selectedProfile?.personality?.trim());
+  const streamingActive =
+    streamState.status === 'connecting' || streamState.status === 'streaming';
 
   // Click away handler to collapse the box
   useEffect(() => {
@@ -468,6 +488,63 @@ export function FloatingGenerateBox({
                         </Button>
                         <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground border border-border opacity-0 transition-opacity group-hover:opacity-100 z-[9999]">
                           {t('generation.instruct.tooltip')}
+                        </span>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                <AnimatePresence>
+                  {streamingAvailable && (
+                    <motion.div
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.8 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <div className="group relative">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          disabled={!selectedProfileId || !form.watch('text')?.trim()}
+                          onClick={() => {
+                            if (streamingActive) {
+                              streamAbort();
+                              return;
+                            }
+                            const values = form.getValues();
+                            streamSpeak({
+                              text: values.text,
+                              profile: selectedProfileId ?? undefined,
+                              engine: values.engine,
+                              language: values.language,
+                              personality: true,
+                            });
+                          }}
+                          className={cn(
+                            'h-10 w-10 rounded-full transition-all duration-200',
+                            streamingActive
+                              ? 'bg-accent text-accent-foreground border border-accent hover:bg-accent/90'
+                              : 'bg-card border border-border hover:bg-background/50',
+                          )}
+                          aria-label={
+                            streamingActive
+                              ? t('generation.button.streamStop')
+                              : t('generation.button.streamSpeak')
+                          }
+                          aria-pressed={streamingActive}
+                        >
+                          {streamingActive ? (
+                            <Square className="h-4 w-4" />
+                          ) : (
+                            <AudioLines className="h-4 w-4" />
+                          )}
+                        </Button>
+                        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground border border-border opacity-0 transition-opacity group-hover:opacity-100 z-[9999]">
+                          {streamingActive
+                            ? t('generation.button.streamStop')
+                            : t('generation.button.streamSpeak')}
                         </span>
                       </div>
                     </motion.div>

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -143,7 +143,10 @@ export function CapturesPage() {
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
   const customLlmEndpointSaved = settings?.custom_llm_endpoint ?? '';
   const customLlmModelSaved = settings?.custom_llm_model ?? '';
-  const customLlmApiKeySaved = settings?.custom_llm_api_key ?? '';
+  // The server no longer returns the API key value; it reports whether one
+  // is stored via ``custom_llm_api_key_configured``. Anything sitting in
+  // React state below is a freshly-typed key that hasn't been sent yet.
+  const customLlmApiKeyConfigured = Boolean(settings?.custom_llm_api_key_configured);
   const customLlmActive = Boolean(customLlmEndpointSaved && customLlmModelSaved);
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
@@ -153,7 +156,10 @@ export function CapturesPage() {
   // re-render on every keystroke while the user types out a URL or token.
   const [customLlmEndpointDraft, setCustomLlmEndpointDraft] = useState(customLlmEndpointSaved);
   const [customLlmModelDraft, setCustomLlmModelDraft] = useState(customLlmModelSaved);
-  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState(customLlmApiKeySaved);
+  // Write-only field: the input is blank on load even when a key is stored,
+  // and clears itself after a successful save so the raw value never lingers
+  // in React state where a browser cache or dev-tools inspection could grab it.
+  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState('');
 
   useEffect(() => {
     setCustomLlmEndpointDraft(customLlmEndpointSaved);
@@ -161,9 +167,6 @@ export function CapturesPage() {
   useEffect(() => {
     setCustomLlmModelDraft(customLlmModelSaved);
   }, [customLlmModelSaved]);
-  useEffect(() => {
-    setCustomLlmApiKeyDraft(customLlmApiKeySaved);
-  }, [customLlmApiKeySaved]);
 
   const commitCustomLlmEndpoint = useCallback(() => {
     const next = customLlmEndpointDraft.trim();
@@ -178,14 +181,18 @@ export function CapturesPage() {
     }
   }, [customLlmModelDraft, customLlmModelSaved, update]);
   const commitCustomLlmApiKey = useCallback(() => {
-    // The API key can legitimately contain leading/trailing punctuation for
-    // some providers, so we only trim when the whole field is whitespace.
     const trimmed = customLlmApiKeyDraft.trim();
-    const next = trimmed ? customLlmApiKeyDraft : '';
-    if (next !== customLlmApiKeySaved) {
-      update({ custom_llm_api_key: next || null });
-    }
-  }, [customLlmApiKeyDraft, customLlmApiKeySaved, update]);
+    if (!trimmed) return;
+    // Fire-and-forget the key, then wipe it from state so nothing else in
+    // the tree can read it back. The server flag flips to `configured=true`
+    // on the next settings query.
+    update({ custom_llm_api_key: customLlmApiKeyDraft });
+    setCustomLlmApiKeyDraft('');
+  }, [customLlmApiKeyDraft, update]);
+  const clearCustomLlmApiKey = useCallback(() => {
+    setCustomLlmApiKeyDraft('');
+    update({ custom_llm_api_key: null });
+  }, [update]);
 
   useEffect(() => {
     fetch(`${serverUrl}/health/filesystem`)
@@ -501,6 +508,9 @@ export function CapturesPage() {
           description={t('settings.captures.refinement.customEndpoint.description')}
         >
           <div className="space-y-2 max-w-lg">
+            <label htmlFor="customLlmEndpoint" className="block text-xs font-medium text-muted-foreground">
+              {t('settings.captures.refinement.customEndpoint.endpointLabel')}
+            </label>
             <Input
               id="customLlmEndpoint"
               type="url"
@@ -511,7 +521,11 @@ export function CapturesPage() {
               disabled={!autoRefine}
               autoComplete="off"
               spellCheck={false}
+              aria-label={t('settings.captures.refinement.customEndpoint.endpointLabel')}
             />
+            <label htmlFor="customLlmModel" className="block text-xs font-medium text-muted-foreground pt-1">
+              {t('settings.captures.refinement.customEndpoint.modelLabel')}
+            </label>
             <Input
               id="customLlmModel"
               type="text"
@@ -522,18 +536,45 @@ export function CapturesPage() {
               disabled={!autoRefine || !customLlmEndpointDraft}
               autoComplete="off"
               spellCheck={false}
+              aria-label={t('settings.captures.refinement.customEndpoint.modelLabel')}
             />
-            <Input
-              id="customLlmApiKey"
-              type="password"
-              placeholder={t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')}
-              value={customLlmApiKeyDraft}
-              onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
-              onBlur={commitCustomLlmApiKey}
-              disabled={!autoRefine || !customLlmEndpointDraft}
-              autoComplete="off"
-              spellCheck={false}
-            />
+            <label htmlFor="customLlmApiKey" className="block text-xs font-medium text-muted-foreground pt-1">
+              {t('settings.captures.refinement.customEndpoint.apiKeyLabel')}
+              {customLlmApiKeyConfigured ? (
+                <span className="ml-2 text-[10px] uppercase tracking-wide text-emerald-600">
+                  {t('settings.captures.refinement.customEndpoint.apiKeyConfigured')}
+                </span>
+              ) : null}
+            </label>
+            <div className="flex gap-2">
+              <Input
+                id="customLlmApiKey"
+                type="password"
+                placeholder={
+                  customLlmApiKeyConfigured
+                    ? t('settings.captures.refinement.customEndpoint.apiKeyPlaceholderReplace')
+                    : t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')
+                }
+                value={customLlmApiKeyDraft}
+                onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
+                onBlur={commitCustomLlmApiKey}
+                disabled={!autoRefine || !customLlmEndpointDraft}
+                autoComplete="new-password"
+                spellCheck={false}
+                aria-label={t('settings.captures.refinement.customEndpoint.apiKeyLabel')}
+                className="flex-1"
+              />
+              {customLlmApiKeyConfigured && (
+                <button
+                  type="button"
+                  onClick={clearCustomLlmApiKey}
+                  className="text-xs text-muted-foreground hover:text-destructive px-2 py-1 border border-border rounded-md"
+                  aria-label={t('settings.captures.refinement.customEndpoint.apiKeyClear')}
+                >
+                  {t('settings.captures.refinement.customEndpoint.apiKeyClear')}
+                </button>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground">
               {customLlmActive
                 ? t('settings.captures.refinement.customEndpoint.statusRemote', {
@@ -639,8 +680,14 @@ export function CapturesPage() {
             <li className="flex gap-2.5">
               <Lock className="h-4 w-4 shrink-0 mt-0.5 text-accent" />
               <span className="leading-relaxed">
-                <span className="text-foreground font-medium">{t('settings.captures.sidebar.local.title')}</span>{' '}
-                {t('settings.captures.sidebar.local.body')}
+                <span className="text-foreground font-medium">
+                  {customLlmActive
+                    ? t('settings.captures.sidebar.remote.title')
+                    : t('settings.captures.sidebar.local.title')}
+                </span>{' '}
+                {customLlmActive
+                  ? t('settings.captures.sidebar.remote.body', { endpoint: customLlmEndpointSaved })
+                  : t('settings.captures.sidebar.local.body')}
               </span>
             </li>
             <li className="flex gap-2.5">

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -183,10 +183,12 @@ export function CapturesPage() {
   const commitCustomLlmApiKey = useCallback(() => {
     const trimmed = customLlmApiKeyDraft.trim();
     if (!trimmed) return;
-    // Fire-and-forget the key, then wipe it from state so nothing else in
-    // the tree can read it back. The server flag flips to `configured=true`
-    // on the next settings query.
-    update({ custom_llm_api_key: customLlmApiKeyDraft });
+    // Send the trimmed value — surrounding whitespace in a bearer token
+    // makes the remote reject it with 401, which surfaces as a confusing
+    // "auth failed" toast when the raw pasted key is fine. Then wipe the
+    // draft so nothing else in the tree can read it back; the server flag
+    // flips to `configured=true` on the next settings query.
+    update({ custom_llm_api_key: trimmed });
     setCustomLlmApiKeyDraft('');
   }, [customLlmApiKeyDraft, update]);
   const clearCustomLlmApiKey = useCallback(() => {

--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -140,10 +141,51 @@ export function CapturesPage() {
   const hotkeyEnabled = settings?.hotkey_enabled ?? false;
   const pushToTalkKeys = settings?.chord_push_to_talk_keys ?? defaultChordKeys('push');
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
+  const customLlmEndpointSaved = settings?.custom_llm_endpoint ?? '';
+  const customLlmModelSaved = settings?.custom_llm_model ?? '';
+  const customLlmApiKeySaved = settings?.custom_llm_api_key ?? '';
+  const customLlmActive = Boolean(customLlmEndpointSaved && customLlmModelSaved);
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
   const [opening, setOpening] = useState(false);
   const [capturesPath, setCapturesPath] = useState<string | null>(null);
+  // Drafts persist to the server on blur so we don't fire a PUT + optimistic
+  // re-render on every keystroke while the user types out a URL or token.
+  const [customLlmEndpointDraft, setCustomLlmEndpointDraft] = useState(customLlmEndpointSaved);
+  const [customLlmModelDraft, setCustomLlmModelDraft] = useState(customLlmModelSaved);
+  const [customLlmApiKeyDraft, setCustomLlmApiKeyDraft] = useState(customLlmApiKeySaved);
+
+  useEffect(() => {
+    setCustomLlmEndpointDraft(customLlmEndpointSaved);
+  }, [customLlmEndpointSaved]);
+  useEffect(() => {
+    setCustomLlmModelDraft(customLlmModelSaved);
+  }, [customLlmModelSaved]);
+  useEffect(() => {
+    setCustomLlmApiKeyDraft(customLlmApiKeySaved);
+  }, [customLlmApiKeySaved]);
+
+  const commitCustomLlmEndpoint = useCallback(() => {
+    const next = customLlmEndpointDraft.trim();
+    if (next !== customLlmEndpointSaved) {
+      update({ custom_llm_endpoint: next || null });
+    }
+  }, [customLlmEndpointDraft, customLlmEndpointSaved, update]);
+  const commitCustomLlmModel = useCallback(() => {
+    const next = customLlmModelDraft.trim();
+    if (next !== customLlmModelSaved) {
+      update({ custom_llm_model: next || null });
+    }
+  }, [customLlmModelDraft, customLlmModelSaved, update]);
+  const commitCustomLlmApiKey = useCallback(() => {
+    // The API key can legitimately contain leading/trailing punctuation for
+    // some providers, so we only trim when the whole field is whitespace.
+    const trimmed = customLlmApiKeyDraft.trim();
+    const next = trimmed ? customLlmApiKeyDraft : '';
+    if (next !== customLlmApiKeySaved) {
+      update({ custom_llm_api_key: next || null });
+    }
+  }, [customLlmApiKeyDraft, customLlmApiKeySaved, update]);
 
   useEffect(() => {
     fetch(`${serverUrl}/health/filesystem`)
@@ -453,6 +495,54 @@ export function CapturesPage() {
             />
           }
         />
+
+        <SettingRow
+          title={t('settings.captures.refinement.customEndpoint.title')}
+          description={t('settings.captures.refinement.customEndpoint.description')}
+        >
+          <div className="space-y-2 max-w-lg">
+            <Input
+              id="customLlmEndpoint"
+              type="url"
+              placeholder={t('settings.captures.refinement.customEndpoint.endpointPlaceholder')}
+              value={customLlmEndpointDraft}
+              onChange={(e) => setCustomLlmEndpointDraft(e.target.value)}
+              onBlur={commitCustomLlmEndpoint}
+              disabled={!autoRefine}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Input
+              id="customLlmModel"
+              type="text"
+              placeholder={t('settings.captures.refinement.customEndpoint.modelPlaceholder')}
+              value={customLlmModelDraft}
+              onChange={(e) => setCustomLlmModelDraft(e.target.value)}
+              onBlur={commitCustomLlmModel}
+              disabled={!autoRefine || !customLlmEndpointDraft}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Input
+              id="customLlmApiKey"
+              type="password"
+              placeholder={t('settings.captures.refinement.customEndpoint.apiKeyPlaceholder')}
+              value={customLlmApiKeyDraft}
+              onChange={(e) => setCustomLlmApiKeyDraft(e.target.value)}
+              onBlur={commitCustomLlmApiKey}
+              disabled={!autoRefine || !customLlmEndpointDraft}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              {customLlmActive
+                ? t('settings.captures.refinement.customEndpoint.statusRemote', {
+                    endpoint: customLlmEndpointSaved,
+                  })
+                : t('settings.captures.refinement.customEndpoint.statusBuiltin')}
+            </p>
+          </div>
+        </SettingRow>
       </SettingSection>
 
       <SettingSection

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -692,7 +692,9 @@
     "button": {
       "generate": "Generate speech",
       "generating": "Generating…",
-      "selectFirst": "Select a voice profile first"
+      "selectFirst": "Select a voice profile first",
+      "streamSpeak": "Speak with streaming (β)",
+      "streamStop": "Stop streaming"
     },
     "instruct": {
       "show": "Show delivery instructions",

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -694,7 +694,9 @@
       "generating": "Generating…",
       "selectFirst": "Select a voice profile first",
       "streamSpeak": "Speak with streaming (β)",
-      "streamStop": "Stop streaming"
+      "streamStop": "Stop streaming",
+      "streamErrorTitle": "Streaming speak failed",
+      "streamErrorFallback": "Something went wrong mid-stream."
     },
     "instruct": {
       "show": "Show delivery instructions",

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -986,11 +986,17 @@
         "customEndpoint": {
           "title": "Custom LLM endpoint (advanced)",
           "description": "Delegate refinement and personality rewrites to any OpenAI-compatible server — llama.cpp, vLLM, LM Studio, LocalAI, Ollama's shim, or the OpenAI API itself. Leave blank to use the built-in Qwen3.",
+          "endpointLabel": "Endpoint URL",
           "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelLabel": "Model name",
           "modelPlaceholder": "Model name (e.g. qwen3-4b)",
+          "apiKeyLabel": "API key",
           "apiKeyPlaceholder": "API key (optional)",
+          "apiKeyPlaceholderReplace": "Enter a new key to replace the stored one",
+          "apiKeyConfigured": "Stored",
+          "apiKeyClear": "Clear",
           "statusBuiltin": "Using the built-in Qwen3 model selected above.",
-          "statusRemote": "Sending every refinement to {{endpoint}}."
+          "statusRemote": "Sending every refinement and personality rewrite to {{endpoint}}."
         }
       },
       "playback": {
@@ -1028,6 +1034,10 @@
         "local": {
           "title": "Fully local.",
           "body": "Whisper and the refinement LLM run on your hardware. No cloud, no accounts, your voice never leaves the machine."
+        },
+        "remote": {
+          "title": "Refinement runs remotely.",
+          "body": "Whisper still transcribes on your hardware, but refined transcripts and personality rewrites are sent to {{endpoint}}. Voice audio itself never leaves the machine."
         },
         "playAs": {
           "title": "Play as any voice.",

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -982,6 +982,15 @@
         "preserveTechnical": {
           "title": "Preserve technical terms",
           "description": "Keep code identifiers, command names, and acronyms exactly as spoken. Turn on when you dictate into a code prompt."
+        },
+        "customEndpoint": {
+          "title": "Custom LLM endpoint (advanced)",
+          "description": "Delegate refinement and personality rewrites to any OpenAI-compatible server — llama.cpp, vLLM, LM Studio, LocalAI, Ollama's shim, or the OpenAI API itself. Leave blank to use the built-in Qwen3.",
+          "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelPlaceholder": "Model name (e.g. qwen3-4b)",
+          "apiKeyPlaceholder": "API key (optional)",
+          "statusBuiltin": "Using the built-in Qwen3 model selected above.",
+          "statusRemote": "Sending every refinement to {{endpoint}}."
         }
       },
       "playback": {

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -977,6 +977,15 @@
         "preserveTechnical": {
           "title": "専門用語を保持",
           "description": "コードの識別子、コマンド名、頭字語を発話どおりに保持します。コード入力欄にディクテーションするときに有効にしてください。"
+        },
+        "customEndpoint": {
+          "title": "カスタム LLM エンドポイント (上級)",
+          "description": "リファインとパーソナリティの書き換えを、任意の OpenAI 互換サーバー (llama.cpp、vLLM、LM Studio、LocalAI、Ollama の互換 API、OpenAI API 自体など) に委譲します。空欄のままなら内蔵の Qwen3 を使います。",
+          "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelPlaceholder": "モデル名 (例: qwen3-4b)",
+          "apiKeyPlaceholder": "API キー (任意)",
+          "statusBuiltin": "上で選んだ内蔵 Qwen3 モデルを使用しています",
+          "statusRemote": "リファインを {{endpoint}} に送信しています"
         }
       },
       "playback": {

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -692,7 +692,9 @@
     "button": {
       "generate": "音声を生成",
       "generating": "生成中…",
-      "selectFirst": "まずボイスプロファイルを選択してください"
+      "selectFirst": "まずボイスプロファイルを選択してください",
+      "streamSpeak": "ストリーミングで話す (β)",
+      "streamStop": "ストリーミング停止"
     },
     "instruct": {
       "show": "デリバリー指示を表示",

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -694,7 +694,9 @@
       "generating": "生成中…",
       "selectFirst": "まずボイスプロファイルを選択してください",
       "streamSpeak": "ストリーミングで話す (β)",
-      "streamStop": "ストリーミング停止"
+      "streamStop": "ストリーミング停止",
+      "streamErrorTitle": "ストリーミングでの発話に失敗",
+      "streamErrorFallback": "ストリーミング中に問題が発生しました"
     },
     "instruct": {
       "show": "デリバリー指示を表示",

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -981,11 +981,17 @@
         "customEndpoint": {
           "title": "カスタム LLM エンドポイント (上級)",
           "description": "リファインとパーソナリティの書き換えを、任意の OpenAI 互換サーバー (llama.cpp、vLLM、LM Studio、LocalAI、Ollama の互換 API、OpenAI API 自体など) に委譲します。空欄のままなら内蔵の Qwen3 を使います。",
+          "endpointLabel": "エンドポイント URL",
           "endpointPlaceholder": "http://localhost:8090/v1",
+          "modelLabel": "モデル名",
           "modelPlaceholder": "モデル名 (例: qwen3-4b)",
+          "apiKeyLabel": "API キー",
           "apiKeyPlaceholder": "API キー (任意)",
+          "apiKeyPlaceholderReplace": "上書きする新しいキーを入力",
+          "apiKeyConfigured": "保存済",
+          "apiKeyClear": "クリア",
           "statusBuiltin": "上で選んだ内蔵 Qwen3 モデルを使用しています",
-          "statusRemote": "リファインを {{endpoint}} に送信しています"
+          "statusRemote": "リファインとパーソナリティの書き換えを {{endpoint}} に送信しています"
         }
       },
       "playback": {
@@ -1023,6 +1029,10 @@
         "local": {
           "title": "完全にローカル。",
           "body": "Whisper と整形用 LLM はあなたのハードウェア上で動作します。クラウドもアカウントも不要で、声がマシンの外に出ることはありません。"
+        },
+        "remote": {
+          "title": "整形処理はリモート実行中。",
+          "body": "Whisper はハードウェア上で書き起こしを続けますが、整形された文字起こしとパーソナリティ書き換えは {{endpoint}} に送られます。音声そのものはマシンから出ません。"
         },
         "playAs": {
           "title": "どのボイスでも再生。",

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -21,6 +21,8 @@ import type {
   PersonalityTextResponse,
   ProfileSampleResponse,
   RocmStatus,
+  SpeakStreamEvent,
+  StreamingSpeakRequest,
   StoryCreate,
   StoryDetailResponse,
   StoryItemBatchUpdate,
@@ -54,6 +56,23 @@ import type {
   CloudLoginStartResponse,
   CloudStatus,
 } from './types';
+
+function _extractSseData(frame: string): string | null {
+  // Frames may carry multiple ``data:`` lines whose values concatenate per
+  // the SSE spec; we only need to handle the one-liner shape our server
+  // emits, but the join keeps us robust to future comment lines and
+  // multi-line payloads.
+  const lines = frame.split('\n');
+  const parts: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      parts.push(line.slice(5).trimStart());
+    }
+    // Comment lines (`:...`) and unknown fields are ignored.
+  }
+  return parts.length === 0 ? null : parts.join('\n');
+}
+
 
 function formatErrorDetail(detail: unknown, fallback: string): string {
   if (typeof detail === 'string') return detail;
@@ -256,6 +275,83 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify(data),
     });
+  }
+
+  /**
+   * SSE-driven counterpart to /speak. Opens ``POST /speak/stream`` and
+   * dispatches every parsed frame through ``onEvent`` in arrival order.
+   * Resolves when the terminal ``[DONE]`` sentinel lands (or the fetch
+   * aborts) and rejects on transport or HTTP errors.
+   *
+   * The route emits ``meta`` → ``audio`` (per sentence) → ``complete`` →
+   * ``[DONE]``; error frames arrive in place of ``complete`` when the
+   * server hits a fault mid-stream and are still followed by ``[DONE]``,
+   * so callers only need one terminator handler.
+   */
+  async streamSpeak(
+    data: StreamingSpeakRequest,
+    onEvent: (event: SpeakStreamEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const response = await fetch(`${this.getBaseUrl()}/speak/stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      body: JSON.stringify(data),
+      signal,
+    });
+
+    if (!response.ok) {
+      // Try to surface the JSON detail for parity with request().
+      let detail = `${response.status} ${response.statusText}`;
+      try {
+        const body = await response.json();
+        detail = formatErrorDetail(body?.detail, detail);
+      } catch {
+        // ignore — non-JSON error body
+      }
+      throw new Error(detail);
+    }
+    if (!response.body) {
+      throw new Error('Streaming speak response has no body');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE spec: frames are separated by a blank line. The server
+        // always yields ``data: ...\n\n``, so splitting on ``\n\n`` gives
+        // one full message per element; the last element is either an
+        // incomplete tail we hold onto for the next chunk or an empty
+        // string when the stream boundary aligns cleanly.
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          const trimmed = part.trim();
+          if (!trimmed) continue;
+          const payload = _extractSseData(trimmed);
+          if (payload === null) continue;
+          if (payload === '[DONE]') return;
+          try {
+            const event = JSON.parse(payload) as SpeakStreamEvent;
+            onEvent(event);
+          } catch {
+            // Malformed frame — skip rather than tearing down the stream.
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
   }
 
   async retryGeneration(generationId: string): Promise<GenerationResponse> {

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -242,6 +242,58 @@ export type CaptureSettingsUpdate = Partial<
   custom_llm_api_key?: string | null;
 };
 
+// --- POST /speak/stream ---------------------------------------------------
+//
+// Request body for the SSE streaming variant of /speak. Shape mirrors the
+// backend Pydantic ``SpeakStreamRequest`` — same profile / engine /
+// personality resolution as /speak plus a chunk sizer.
+export interface StreamingSpeakRequest {
+  text: string;
+  profile?: string;
+  engine?: string;
+  personality?: boolean;
+  language?: string;
+  max_chunk_chars?: number;
+}
+
+// SSE frame shapes. The ``type`` discriminator lets the client route a
+// parsed frame to the correct handler without a schema lookup.
+export interface SpeakStreamMeta {
+  type: 'meta';
+  generation_id: string;
+  sample_rate: number;
+  channels: number;
+  streaming_llm: boolean;
+}
+
+export interface SpeakStreamAudio {
+  type: 'audio';
+  sentence_index: number;
+  /** Base64-encoded raw PCM float32 samples, little-endian, single channel. */
+  pcm_base64: string;
+  text: string;
+}
+
+export interface SpeakStreamComplete {
+  type: 'complete';
+  generation_id: string;
+  duration: number;
+  audio_path?: string | null;
+}
+
+export interface SpeakStreamError {
+  type: 'error';
+  generation_id?: string | null;
+  message: string;
+}
+
+/** Discriminated union of every frame the ``/speak/stream`` route emits. */
+export type SpeakStreamEvent =
+  | SpeakStreamMeta
+  | SpeakStreamAudio
+  | SpeakStreamComplete
+  | SpeakStreamError;
+
 /**
  * One row in the dictation readiness checklist. ``model_name`` is the
  * canonical id understood by ``POST /models/download`` so the UI can wire a

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -217,6 +217,15 @@ export interface CaptureSettings {
   chord_push_to_talk_keys: string[];
   /** keytap key names. Toggle adds Space to the platform-specific PTT chord. */
   chord_toggle_to_talk_keys: string[];
+  /**
+   * Optional OpenAI-compatible endpoint that overrides the built-in Qwen3
+   * LLM for refinement / personality rewriting. When set, backend calls hit
+   * `POST {custom_llm_endpoint}/chat/completions` with the model named by
+   * ``custom_llm_model``; leaving it null keeps the on-device Qwen path.
+   */
+  custom_llm_endpoint: string | null;
+  custom_llm_model: string | null;
+  custom_llm_api_key: string | null;
 }
 
 export type CaptureSettingsUpdate = Partial<CaptureSettings>;

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -225,10 +225,22 @@ export interface CaptureSettings {
    */
   custom_llm_endpoint: string | null;
   custom_llm_model: string | null;
-  custom_llm_api_key: string | null;
+  /**
+   * Whether a custom LLM API key is currently stored on the server. The raw
+   * key value never rides the response — this flag replaces it — so the
+   * settings UI can show a "Configured" indicator without letting the
+   * frontend rehydrate the secret into state or leak it to a browser cache.
+   * Writes still go through ``CaptureSettingsUpdate.custom_llm_api_key``.
+   */
+  custom_llm_api_key_configured: boolean;
 }
 
-export type CaptureSettingsUpdate = Partial<CaptureSettings>;
+export type CaptureSettingsUpdate = Partial<
+  Omit<CaptureSettings, 'custom_llm_api_key_configured'>
+> & {
+  /** Write-only: setting this to a non-empty string stores it, ``null`` clears it. */
+  custom_llm_api_key?: string | null;
+};
 
 /**
  * One row in the dictation readiness checklist. ``model_name`` is the

--- a/app/src/lib/hooks/useStreamingSpeak.ts
+++ b/app/src/lib/hooks/useStreamingSpeak.ts
@@ -1,0 +1,290 @@
+/**
+ * React hook for the progressive-playback path — talks to
+ * ``POST /speak/stream`` and schedules each sentence's audio against a
+ * shared ``AudioContext`` so the browser starts speaking before the LLM
+ * has finished generating.
+ *
+ * The hook owns:
+ *   - state machine (idle → connecting → streaming → complete | error)
+ *   - single ``AudioContext`` created lazily on first ``speak()``
+ *   - a ``nextStartTime`` cursor that keeps sentence-N+1 abutting
+ *     sentence-N so there's no gap between chunks even when audio
+ *     arrives faster than real time
+ *   - the ``AbortController`` for the fetch, wired to a ``.abort()``
+ *     method so the UI can cancel a runaway generation
+ *   - a subtitle log accumulated from the ``text`` field on each audio
+ *     frame, ready for a captions overlay
+ *
+ * The audio payload is base64 PCM float32 mono, decoded with
+ * ``atob`` → ``Uint8Array`` → ``Float32Array`` → ``AudioBuffer``. No
+ * dependency on external decoders.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+import type {
+  SpeakStreamEvent,
+  StreamingSpeakRequest,
+} from '@/lib/api/types';
+
+export type StreamingSpeakStatus =
+  | 'idle'
+  | 'connecting'
+  | 'streaming'
+  | 'complete'
+  | 'error'
+  | 'aborted';
+
+export interface StreamingSpeakSentence {
+  index: number;
+  text: string;
+  /** Wall-clock ``AudioContext.currentTime`` value the chunk is scheduled to start at. */
+  scheduledAt: number;
+  /** Duration in seconds of this chunk's audio. */
+  duration: number;
+}
+
+export interface StreamingSpeakState {
+  status: StreamingSpeakStatus;
+  generationId: string | null;
+  streamingLlm: boolean;
+  sentences: StreamingSpeakSentence[];
+  sampleRate: number | null;
+  duration: number | null;
+  audioPath: string | null;
+  error: string | null;
+  /** Best-effort estimate of which sentence is currently playing, or -1 before playback starts. */
+  playingIndex: number;
+}
+
+const INITIAL_STATE: StreamingSpeakState = {
+  status: 'idle',
+  generationId: null,
+  streamingLlm: false,
+  sentences: [],
+  sampleRate: null,
+  duration: null,
+  audioPath: null,
+  error: null,
+  playingIndex: -1,
+};
+
+export function useStreamingSpeak() {
+  const [state, setState] = useState<StreamingSpeakState>(INITIAL_STATE);
+
+  // Refs so the async fetch loop reads the latest handles without going
+  // through React state updates (which would trigger re-renders per
+  // audio chunk).
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const nextStartTimeRef = useRef<number>(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const activeSourcesRef = useRef<AudioBufferSourceNode[]>([]);
+  const playingIndexRef = useRef<number>(-1);
+
+  const _teardown = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    for (const src of activeSourcesRef.current) {
+      try {
+        src.stop();
+      } catch {
+        // already ended
+      }
+      src.disconnect();
+    }
+    activeSourcesRef.current = [];
+    if (audioCtxRef.current) {
+      // ``AudioContext.close`` is async but we don't await it — the ref
+      // is nulled synchronously so the next speak() opens a fresh one.
+      audioCtxRef.current.close().catch(() => {
+        /* ignore — already closed */
+      });
+      audioCtxRef.current = null;
+    }
+    nextStartTimeRef.current = 0;
+    playingIndexRef.current = -1;
+  }, []);
+
+  // Clean up on unmount so a mid-stream navigation doesn't leave an
+  // orphan AudioContext playing.
+  useEffect(() => {
+    return () => {
+      _teardown();
+    };
+  }, [_teardown]);
+
+  const abort = useCallback(() => {
+    _teardown();
+    setState((prev) =>
+      prev.status === 'idle' || prev.status === 'complete' || prev.status === 'error'
+        ? prev
+        : { ...prev, status: 'aborted' },
+    );
+  }, [_teardown]);
+
+  const speak = useCallback(
+    async (params: StreamingSpeakRequest) => {
+      // Any in-flight stream gets cleaned up before we start the next one
+      // — the hook is single-track by design.
+      _teardown();
+      setState({ ...INITIAL_STATE, status: 'connecting' });
+
+      // AudioContext must be created inside a user gesture to satisfy
+      // Chrome's autoplay policy — callers wire speak() to a click.
+      // Some browsers still start suspended; resume() ensures playback.
+      const ctx = new AudioContext();
+      audioCtxRef.current = ctx;
+      try {
+        await ctx.resume();
+      } catch {
+        // resume rejects on already-running contexts on some engines
+      }
+      nextStartTimeRef.current = ctx.currentTime;
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const handleEvent = (event: SpeakStreamEvent) => {
+        if (event.type === 'meta') {
+          setState((prev) => ({
+            ...prev,
+            status: 'streaming',
+            generationId: event.generation_id,
+            streamingLlm: event.streaming_llm,
+            sampleRate: event.sample_rate,
+          }));
+          return;
+        }
+        if (event.type === 'audio') {
+          const audioCtx = audioCtxRef.current;
+          if (!audioCtx) return;
+
+          const pcm = _base64ToFloat32(event.pcm_base64);
+          if (pcm.length === 0) return;
+
+          // ``sample_rate`` was pinned on the meta frame; fall back to
+          // the AudioContext's rate if a client somehow skipped meta.
+          const sampleRate =
+            audioCtx.sampleRate === 0 ? 24000 : audioCtx.sampleRate;
+          const buffer = audioCtx.createBuffer(1, pcm.length, sampleRateOrDefault(audioCtx, 24000));
+          buffer.copyToChannel(pcm, 0);
+
+          const source = audioCtx.createBufferSource();
+          source.buffer = buffer;
+          source.connect(audioCtx.destination);
+
+          const startAt = Math.max(audioCtx.currentTime, nextStartTimeRef.current);
+          const chunkDuration = pcm.length / (buffer.sampleRate || sampleRate);
+
+          const scheduledIndex = event.sentence_index;
+          source.onended = () => {
+            source.disconnect();
+            activeSourcesRef.current = activeSourcesRef.current.filter(
+              (s) => s !== source,
+            );
+            // The current-playing index only moves forward — a chunk that
+            // finished after a later one already started shouldn't drag
+            // the UI back.
+            if (scheduledIndex >= playingIndexRef.current) {
+              playingIndexRef.current = scheduledIndex + 1;
+              setState((prev) =>
+                prev.playingIndex >= scheduledIndex + 1
+                  ? prev
+                  : { ...prev, playingIndex: scheduledIndex + 1 },
+              );
+            }
+          };
+          source.start(startAt);
+          activeSourcesRef.current.push(source);
+
+          const sentence: StreamingSpeakSentence = {
+            index: event.sentence_index,
+            text: event.text,
+            scheduledAt: startAt,
+            duration: chunkDuration,
+          };
+
+          nextStartTimeRef.current = startAt + chunkDuration;
+
+          setState((prev) => ({
+            ...prev,
+            sentences: [...prev.sentences, sentence],
+            playingIndex:
+              prev.playingIndex === -1 ? event.sentence_index : prev.playingIndex,
+          }));
+          if (playingIndexRef.current === -1) {
+            playingIndexRef.current = event.sentence_index;
+          }
+          return;
+        }
+        if (event.type === 'complete') {
+          setState((prev) => ({
+            ...prev,
+            status: 'complete',
+            generationId: event.generation_id,
+            duration: event.duration,
+            audioPath: event.audio_path ?? null,
+          }));
+          return;
+        }
+        if (event.type === 'error') {
+          setState((prev) => ({
+            ...prev,
+            status: 'error',
+            generationId: event.generation_id ?? prev.generationId,
+            error: event.message,
+          }));
+          return;
+        }
+      };
+
+      try {
+        await apiClient.streamSpeak(params, handleEvent, controller.signal);
+        // ``streamSpeak`` returns on ``[DONE]``. If the server never
+        // sent ``complete`` before ``[DONE]`` (e.g. empty output), leave
+        // the state where the last event handler put it — either
+        // ``error`` or ``streaming``.
+        setState((prev) =>
+          prev.status === 'streaming' ? { ...prev, status: 'complete' } : prev,
+        );
+      } catch (err) {
+        // Abort races are expected — surface them as ``aborted`` not
+        // ``error`` so the UI can distinguish a user cancellation from a
+        // real fault.
+        if ((err as Error)?.name === 'AbortError') {
+          setState((prev) => ({ ...prev, status: 'aborted' }));
+          return;
+        }
+        setState((prev) => ({
+          ...prev,
+          status: 'error',
+          error: (err as Error)?.message ?? 'Streaming speak failed',
+        }));
+      } finally {
+        abortRef.current = null;
+      }
+    },
+    [_teardown],
+  );
+
+  return { state, speak, abort };
+}
+
+function _base64ToFloat32(b64: string): Float32Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  // The backend serialises native-endian float32 with ``ndarray.tobytes()``.
+  // Every platform we ship on (macOS Apple Silicon / x86_64 / Linux x86_64)
+  // is little-endian, which matches Web Audio's Float32Array. If we ever
+  // support big-endian servers this needs an explicit DataView pass.
+  return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+}
+
+function sampleRateOrDefault(ctx: AudioContext, fallback: number): number {
+  return ctx.sampleRate > 0 ? ctx.sampleRate : fallback;
+}

--- a/app/src/lib/hooks/useStreamingSpeak.ts
+++ b/app/src/lib/hooks/useStreamingSpeak.ts
@@ -80,6 +80,11 @@ export function useStreamingSpeak() {
   const abortRef = useRef<AbortController | null>(null);
   const activeSourcesRef = useRef<AudioBufferSourceNode[]>([]);
   const playingIndexRef = useRef<number>(-1);
+  // Server PCM sample rate from the meta frame — the AudioBuffer's third
+  // argument must describe the data's rate (e.g. 24000 Hz TTS output), not
+  // the AudioContext's device rate (44.1/48 kHz on most hardware). Getting
+  // this wrong makes the audio play at ~2× speed with the wrong pitch.
+  const serverSampleRateRef = useRef<number | null>(null);
 
   const _teardown = useCallback(() => {
     if (abortRef.current) {
@@ -105,6 +110,7 @@ export function useStreamingSpeak() {
     }
     nextStartTimeRef.current = 0;
     playingIndexRef.current = -1;
+    serverSampleRateRef.current = null;
   }, []);
 
   // Clean up on unmount so a mid-stream navigation doesn't leave an
@@ -148,6 +154,7 @@ export function useStreamingSpeak() {
 
       const handleEvent = (event: SpeakStreamEvent) => {
         if (event.type === 'meta') {
+          serverSampleRateRef.current = event.sample_rate;
           setState((prev) => ({
             ...prev,
             status: 'streaming',
@@ -164,11 +171,12 @@ export function useStreamingSpeak() {
           const pcm = _base64ToFloat32(event.pcm_base64);
           if (pcm.length === 0) return;
 
-          // ``sample_rate`` was pinned on the meta frame; fall back to
-          // the AudioContext's rate if a client somehow skipped meta.
-          const sampleRate =
-            audioCtx.sampleRate === 0 ? 24000 : audioCtx.sampleRate;
-          const buffer = audioCtx.createBuffer(1, pcm.length, sampleRateOrDefault(audioCtx, 24000));
+          // The AudioBuffer's third argument must describe the *data's*
+          // rate; Web Audio resamples on playback to the device rate.
+          // Prefer the meta frame's sample_rate; fall back to a sensible
+          // default only if a caller ever produces audio before meta.
+          const bufferSampleRate = serverSampleRateRef.current ?? 24000;
+          const buffer = audioCtx.createBuffer(1, pcm.length, bufferSampleRate);
           buffer.copyToChannel(pcm, 0);
 
           const source = audioCtx.createBufferSource();
@@ -176,7 +184,9 @@ export function useStreamingSpeak() {
           source.connect(audioCtx.destination);
 
           const startAt = Math.max(audioCtx.currentTime, nextStartTimeRef.current);
-          const chunkDuration = pcm.length / (buffer.sampleRate || sampleRate);
+          // Duration must use the same rate the buffer was created with,
+          // otherwise ``nextStartTime`` drifts and the gapless chain breaks.
+          const chunkDuration = pcm.length / bufferSampleRate;
 
           const scheduledIndex = event.sentence_index;
           source.onended = () => {
@@ -285,6 +295,3 @@ function _base64ToFloat32(b64: string): Float32Array {
   return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
 }
 
-function sampleRateOrDefault(ctx: AudioContext, fallback: number): number {
-  return ctx.sampleRate > 0 ? ctx.sampleRate : fallback;
-}

--- a/backend/app.py
+++ b/backend/app.py
@@ -322,6 +322,20 @@ async def _run_startup(application: FastAPI) -> None:
     finally:
         db.close()
 
+    # Seed the LLM backend dispatch from the persisted capture settings so
+    # the very first refinement / personality call after startup honours a
+    # user-configured custom OpenAI-compatible endpoint without needing a
+    # settings-write to flip the module state first.
+    db = next(get_db())
+    try:
+        from .services.settings import bootstrap_llm_backend_config
+
+        bootstrap_llm_backend_config(db)
+    except Exception as e:
+        logger.warning("Could not bootstrap custom LLM config: %s", e)
+    finally:
+        db.close()
+
     backend_type = get_backend_type()
     logger.info("Backend: %s", backend_type.upper())
     logger.info("GPU: %s", _get_gpu_status())

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -213,6 +213,11 @@ _custom_llm_endpoint: Optional[str] = None
 _custom_llm_model: Optional[str] = None
 _custom_llm_api_key: Optional[str] = None
 
+# ``_llm_backends`` key for the singleton OpenAI-compat backend. Extracted
+# so ``set_llm_config`` (cache invalidation) and ``get_llm_backend`` (cache
+# lookup + on-miss install) can't drift on the string literal.
+_OPENAI_COMPAT_CACHE_KEY = "openai_compat"
+
 # Supported TTS engines — keyed by engine name, value is the backend class import path.
 # The factory function uses this for the if/elif chain; the model configs live on the backend classes.
 TTS_ENGINES = {
@@ -779,7 +784,7 @@ def set_llm_config(
         _custom_llm_model = model
         _custom_llm_api_key = api_key
         if changed:
-            _llm_backends.pop("openai_compat", None)
+            _llm_backends.pop(_OPENAI_COMPAT_CACHE_KEY, None)
 
 
 def get_llm_backend() -> LLMBackend:
@@ -802,7 +807,7 @@ def get_llm_backend() -> LLMBackend:
         model = _custom_llm_model
         api_key = _custom_llm_api_key
         if endpoint and model:
-            cached = _llm_backends.get("openai_compat")
+            cached = _llm_backends.get(_OPENAI_COMPAT_CACHE_KEY)
             if cached is not None:
                 return cached
             backend = OpenAICompatLLMBackend(
@@ -810,13 +815,15 @@ def get_llm_backend() -> LLMBackend:
                 model=model,
                 api_key=api_key,
             )
-            _llm_backends["openai_compat"] = backend
+            _llm_backends[_OPENAI_COMPAT_CACHE_KEY] = backend
             return backend
 
-    # No custom config — hand off to the Qwen dispatch, which has its own
-    # lock and can take multiple seconds to load a model. Do that outside
-    # ``_llm_backends_lock`` so a slow model load doesn't block concurrent
-    # ``set_llm_config()`` writes.
+    # No custom config — hand off to the Qwen dispatch. ``get_llm_backend_for_engine``
+    # reuses this exact ``_llm_backends_lock`` (see its body below), and
+    # ``threading.Lock`` is non-reentrant, so this call MUST run after the
+    # ``with`` block above has released the lock — nesting it inside would
+    # self-deadlock the calling thread. Doing it here also means a slow
+    # model load doesn't block concurrent ``set_llm_config()`` writes.
     return get_llm_backend_for_engine("qwen_llm")
 
 

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -752,7 +752,7 @@ def set_llm_config(
     model: Optional[str],
     api_key: Optional[str],
 ) -> None:
-    """Update the runtime custom-LLM endpoint config.
+    """Update the runtime custom-LLM endpoint config atomically.
 
     Called from the settings service whenever the user writes to the
     ``custom_llm_endpoint`` / ``custom_llm_model`` / ``custom_llm_api_key``
@@ -760,23 +760,25 @@ def set_llm_config(
     strings or ``None`` clears the config and reverts subsequent
     ``get_llm_backend()`` calls to the built-in Qwen3 path.
 
-    A change drops any cached OpenAI-compat backend so the next call
-    rebuilds against the new URL / model rather than reusing a stale one.
+    The write, the change detection, and the cache invalidation all run
+    under ``_llm_backends_lock`` so a concurrent ``get_llm_backend()``
+    can't sample the endpoint/model/key mid-update and end up talking
+    to a stale URL with fresh credentials (or vice versa).
     """
     global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
     endpoint = endpoint or None
     model = model or None
     api_key = api_key or None
-    changed = (
-        endpoint != _custom_llm_endpoint
-        or model != _custom_llm_model
-        or api_key != _custom_llm_api_key
-    )
-    _custom_llm_endpoint = endpoint
-    _custom_llm_model = model
-    _custom_llm_api_key = api_key
-    if changed:
-        with _llm_backends_lock:
+    with _llm_backends_lock:
+        changed = (
+            endpoint != _custom_llm_endpoint
+            or model != _custom_llm_model
+            or api_key != _custom_llm_api_key
+        )
+        _custom_llm_endpoint = endpoint
+        _custom_llm_model = model
+        _custom_llm_api_key = api_key
+        if changed:
             _llm_backends.pop("openai_compat", None)
 
 
@@ -787,30 +789,35 @@ def get_llm_backend() -> LLMBackend:
     ``set_llm_config()``, returns an ``OpenAICompatLLMBackend`` targeting
     that endpoint; otherwise falls back to the platform-specific Qwen3
     backend (MLX on Apple Silicon, PyTorch elsewhere).
+
+    The config snapshot, cache lookup, and (if needed) backend
+    construction all happen inside ``_llm_backends_lock`` so a request
+    can't race a ``set_llm_config()`` write and end up talking to a
+    prior endpoint using fresh credentials, or the reverse.
     """
-    if _custom_llm_endpoint and _custom_llm_model:
-        return _get_openai_compat_backend()
-    return get_llm_backend_for_engine("qwen_llm")
+    from .openai_compat_backend import OpenAICompatLLMBackend
 
-
-def _get_openai_compat_backend() -> LLMBackend:
-    """Return the cached OpenAI-compat backend, creating it on first call."""
-    cached = _llm_backends.get("openai_compat")
-    if cached is not None:
-        return cached
     with _llm_backends_lock:
-        cached = _llm_backends.get("openai_compat")
-        if cached is not None:
-            return cached
-        from .openai_compat_backend import OpenAICompatLLMBackend
+        endpoint = _custom_llm_endpoint
+        model = _custom_llm_model
+        api_key = _custom_llm_api_key
+        if endpoint and model:
+            cached = _llm_backends.get("openai_compat")
+            if cached is not None:
+                return cached
+            backend = OpenAICompatLLMBackend(
+                endpoint=endpoint,
+                model=model,
+                api_key=api_key,
+            )
+            _llm_backends["openai_compat"] = backend
+            return backend
 
-        backend = OpenAICompatLLMBackend(
-            endpoint=_custom_llm_endpoint,
-            model=_custom_llm_model,
-            api_key=_custom_llm_api_key,
-        )
-        _llm_backends["openai_compat"] = backend
-        return backend
+    # No custom config — hand off to the Qwen dispatch, which has its own
+    # lock and can take multiple seconds to load a model. Do that outside
+    # ``_llm_backends_lock`` so a slow model load doesn't block concurrent
+    # ``set_llm_config()`` writes.
+    return get_llm_backend_for_engine("qwen_llm")
 
 
 def get_llm_backend_for_engine(engine: str) -> LLMBackend:

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -205,6 +205,14 @@ _stt_backend: Optional[STTBackend] = None
 _llm_backends: dict[str, LLMBackend] = {}
 _llm_backends_lock = threading.Lock()
 
+# Custom OpenAI-compatible LLM endpoint config, seeded from persisted
+# capture settings on startup and refreshed whenever the settings service
+# writes an update. Empty strings and None both mean "unset" and fall back
+# to the built-in Qwen3 backend.
+_custom_llm_endpoint: Optional[str] = None
+_custom_llm_model: Optional[str] = None
+_custom_llm_api_key: Optional[str] = None
+
 # Supported TTS engines — keyed by engine name, value is the backend class import path.
 # The factory function uses this for the if/elif chain; the model configs live on the backend classes.
 TTS_ENGINES = {
@@ -739,9 +747,70 @@ def get_stt_backend() -> STTBackend:
     return _stt_backend
 
 
+def set_llm_config(
+    endpoint: Optional[str],
+    model: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    """Update the runtime custom-LLM endpoint config.
+
+    Called from the settings service whenever the user writes to the
+    ``custom_llm_endpoint`` / ``custom_llm_model`` / ``custom_llm_api_key``
+    fields, and once on startup with the persisted row. Passing empty
+    strings or ``None`` clears the config and reverts subsequent
+    ``get_llm_backend()`` calls to the built-in Qwen3 path.
+
+    A change drops any cached OpenAI-compat backend so the next call
+    rebuilds against the new URL / model rather than reusing a stale one.
+    """
+    global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
+    endpoint = endpoint or None
+    model = model or None
+    api_key = api_key or None
+    changed = (
+        endpoint != _custom_llm_endpoint
+        or model != _custom_llm_model
+        or api_key != _custom_llm_api_key
+    )
+    _custom_llm_endpoint = endpoint
+    _custom_llm_model = model
+    _custom_llm_api_key = api_key
+    if changed:
+        with _llm_backends_lock:
+            _llm_backends.pop("openai_compat", None)
+
+
 def get_llm_backend() -> LLMBackend:
-    """Get or create the default Qwen3 LLM backend based on platform."""
+    """Get or create the active LLM backend.
+
+    When a custom OpenAI-compatible endpoint has been configured via
+    ``set_llm_config()``, returns an ``OpenAICompatLLMBackend`` targeting
+    that endpoint; otherwise falls back to the platform-specific Qwen3
+    backend (MLX on Apple Silicon, PyTorch elsewhere).
+    """
+    if _custom_llm_endpoint and _custom_llm_model:
+        return _get_openai_compat_backend()
     return get_llm_backend_for_engine("qwen_llm")
+
+
+def _get_openai_compat_backend() -> LLMBackend:
+    """Return the cached OpenAI-compat backend, creating it on first call."""
+    cached = _llm_backends.get("openai_compat")
+    if cached is not None:
+        return cached
+    with _llm_backends_lock:
+        cached = _llm_backends.get("openai_compat")
+        if cached is not None:
+            return cached
+        from .openai_compat_backend import OpenAICompatLLMBackend
+
+        backend = OpenAICompatLLMBackend(
+            endpoint=_custom_llm_endpoint,
+            model=_custom_llm_model,
+            api_key=_custom_llm_api_key,
+        )
+        _llm_backends["openai_compat"] = backend
+        return backend
 
 
 def get_llm_backend_for_engine(engine: str) -> LLMBackend:
@@ -775,7 +844,11 @@ def get_llm_backend_for_engine(engine: str) -> LLMBackend:
 def reset_backends():
     """Reset backend instances (useful for testing)."""
     global _tts_backend, _tts_backends, _stt_backend, _llm_backends
+    global _custom_llm_endpoint, _custom_llm_model, _custom_llm_api_key
     _tts_backend = None
     _tts_backends.clear()
     _stt_backend = None
     _llm_backends.clear()
+    _custom_llm_endpoint = None
+    _custom_llm_model = None
+    _custom_llm_api_key = None

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -14,7 +14,7 @@ from ..utils import hf_offline_patch  # noqa: F401
 
 import threading
 from dataclasses import dataclass, field
-from typing import Protocol, Optional, Tuple, List
+from typing import AsyncIterator, Protocol, Optional, Tuple, List
 from typing_extensions import runtime_checkable
 import numpy as np
 
@@ -187,6 +187,35 @@ class LLMBackend(Protocol):
         pattern-match on inline system-prompt examples (echoing them
         verbatim for unrelated inputs), but treat structured turns as
         data and generalize instead. Used by the refinement service.
+        """
+        ...
+
+    def generate_stream(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> AsyncIterator[str]:
+        """Stream the assistant reply as text deltas.
+
+        For OpenAI-compatible remote endpoints this yields per-token
+        deltas as they arrive. Backends without a true streaming path
+        (the built-in Qwen3 loaders) fall back to a single yield of the
+        full generate() result — consumers get the same content and can
+        treat the iterator uniformly, they just won't see any overlap
+        benefit until the underlying backend gains real streaming.
+        """
+        ...
+
+    def supports_streaming(self) -> bool:
+        """Whether the backend produces incremental deltas from generate_stream.
+
+        Callers use this to decide whether spinning up a per-sentence TTS
+        pipeline is worth the coordination overhead vs. running the
+        existing sequential generate → chunked TTS path.
         """
         ...
 

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -185,4 +185,13 @@ def _extract_content(data: dict, url: str) -> str:
         content = first.get("text")
     if content is None:
         raise ValueError(f"No content in response from {url}: {data!r}")
+    if not isinstance(content, str):
+        # Vision-capable and tool-use servers sometimes return the content as
+        # an array of typed parts instead of a bare string. Refinement /
+        # personality are text-only paths, so surface a clear error instead
+        # of tripping ``AttributeError`` on ``.strip()`` and burying the
+        # shape mismatch.
+        raise ValueError(
+            f"Unexpected content type {type(content).__name__} in response from {url}: {data!r}"
+        )
     return content.strip()

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -1,0 +1,141 @@
+"""
+OpenAI-compatible LLM backend.
+
+Delegates chat completion to any HTTP endpoint that speaks the OpenAI
+``/v1/chat/completions`` protocol — llama.cpp server, vLLM, LocalAI,
+LM Studio, Ollama's OpenAI-compat shim, or the OpenAI API itself.
+Skips the on-device download / model-load path because the remote
+server is expected to serve the model.
+
+The user configures ``custom_llm_endpoint`` / ``custom_llm_model`` /
+``custom_llm_api_key`` in capture settings; when the endpoint is set,
+``get_llm_backend()`` returns an instance of this class instead of the
+built-in Qwen3 backend.
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from . import DEFAULT_LLM_MAX_TOKENS, DEFAULT_LLM_TEMPERATURE
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 120.0
+
+
+class OpenAICompatLLMBackend:
+    """LLM backend that delegates to an OpenAI-compatible chat endpoint."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        model: str,
+        api_key: Optional[str] = None,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ):
+        # Strip a trailing slash so callers can pass either
+        # ``http://host:port/v1`` or ``http://host:port/v1/``.
+        self.endpoint = endpoint.rstrip("/")
+        self.model = model
+        # Empty string means "no auth" — the app UI stores an empty field
+        # the same way an unset field looks in the DB.
+        self.api_key = api_key or None
+        self.timeout = timeout
+        # ``model_size`` / ``_current_model_size`` are read by the shared
+        # download-progress / unload plumbing on other backends. Report the
+        # remote model name so the routes layer can echo it back to clients.
+        self.model_size = model
+        self._current_model_size = model
+
+    def is_loaded(self) -> bool:
+        # A remote endpoint is always "loaded" from this process's point of
+        # view — no local weights to page in.
+        return True
+
+    async def load_model(self, model_size: Optional[str] = None) -> None:  # noqa: ARG002
+        """No-op — remote endpoint holds the model."""
+        return
+
+    def unload_model(self) -> None:
+        """No-op — nothing to unload locally."""
+        return
+
+    async def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,  # noqa: ARG002 — kept for protocol parity
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> str:
+        messages = _build_messages(prompt, system, examples)
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        url = f"{self.endpoint}/chat/completions"
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Truncate the body — some servers echo the whole prompt in
+                # error responses, and log files fill up fast otherwise.
+                body_preview = exc.response.text[:500]
+                logger.error(
+                    "OpenAI-compat endpoint %s returned %d: %s",
+                    url,
+                    exc.response.status_code,
+                    body_preview,
+                )
+                raise
+            except httpx.RequestError as exc:
+                logger.error("OpenAI-compat endpoint %s request failed: %s", url, exc)
+                raise
+
+            data = response.json()
+
+        return _extract_content(data, url)
+
+
+def _build_messages(
+    prompt: str,
+    system: Optional[str],
+    examples: Optional[list[tuple[str, str]]],
+) -> list[dict]:
+    messages: list[dict] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    if examples:
+        for user_text, assistant_text in examples:
+            messages.append({"role": "user", "content": user_text})
+            messages.append({"role": "assistant", "content": assistant_text})
+    messages.append({"role": "user", "content": prompt})
+    return messages
+
+
+def _extract_content(data: dict, url: str) -> str:
+    choices = data.get("choices") or []
+    if not choices:
+        raise ValueError(f"No choices in response from {url}: {data!r}")
+
+    first = choices[0]
+    message = first.get("message") or {}
+    content = message.get("content")
+    if content is None:
+        # Fallback: some servers still return the legacy text-completion
+        # shape (``choices[0].text``) even from the chat endpoint.
+        content = first.get("text")
+    if content is None:
+        raise ValueError(f"No content in response from {url}: {data!r}")
+    return content.strip()

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -35,6 +35,18 @@ class OpenAICompatLLMBackend:
         api_key: Optional[str] = None,
         timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     ):
+        """Configure the backend for a specific remote endpoint.
+
+        Args:
+            endpoint: Full base URL up to and including the ``/v1``
+                segment (trailing slash tolerated).
+            model: Model name to send in every request's ``model`` field.
+            api_key: Optional bearer token; empty string treated the same
+                as ``None`` so a blank UI field disables auth.
+            timeout: Per-request timeout in seconds. Defaults to two
+                minutes so slow remote hosts don't cut off long
+                generations.
+        """
         # Strip a trailing slash so callers can pass either
         # ``http://host:port/v1`` or ``http://host:port/v1/``.
         self.endpoint = endpoint.rstrip("/")
@@ -50,8 +62,13 @@ class OpenAICompatLLMBackend:
         self._current_model_size = model
 
     def is_loaded(self) -> bool:
-        # A remote endpoint is always "loaded" from this process's point of
-        # view — no local weights to page in.
+        """Return ``True`` unconditionally — the remote server owns model state.
+
+        Voicebox's shared plumbing polls ``is_loaded`` to decide whether
+        to show a "downloading model…" progress bar; since a remote
+        endpoint has nothing to page in from this process's point of
+        view, the answer is always yes.
+        """
         return True
 
     async def load_model(self, model_size: Optional[str] = None) -> None:  # noqa: ARG002
@@ -71,6 +88,20 @@ class OpenAICompatLLMBackend:
         model_size: Optional[str] = None,  # noqa: ARG002 — kept for protocol parity
         examples: Optional[list[tuple[str, str]]] = None,
     ) -> str:
+        """Post one non-streaming chat completion and return the assistant text.
+
+        Mirrors ``LLMBackend.generate`` — the same call signature the
+        built-in Qwen backends use — so refinement and personality
+        services can swap between local and remote transparently.
+        ``model_size`` is accepted for protocol parity but ignored:
+        remote model selection is pinned at construction time.
+
+        Raises:
+            httpx.HTTPStatusError: The remote returned a non-2xx status.
+            httpx.RequestError: Transport failure (timeout, DNS, TLS).
+            ValueError: The response was well-formed HTTP but carried no
+                content in either the chat or legacy completion shapes.
+        """
         messages = _build_messages(prompt, system, examples)
         payload = {
             "model": self.model,
@@ -113,6 +144,14 @@ def _build_messages(
     system: Optional[str],
     examples: Optional[list[tuple[str, str]]],
 ) -> list[dict]:
+    """Assemble the ``messages`` array for a chat completion request.
+
+    Optional system prompt and few-shot ``(user, assistant)`` pairs are
+    laid out in the order the OpenAI protocol expects: system first,
+    then example turns, then the fresh user prompt. Small models pattern-
+    match on inline examples in the system prompt but generalise from
+    structured turns, so refinement passes examples through this path.
+    """
     messages: list[dict] = []
     if system:
         messages.append({"role": "system", "content": system})
@@ -125,6 +164,14 @@ def _build_messages(
 
 
 def _extract_content(data: dict, url: str) -> str:
+    """Pull the assistant text out of a parsed chat-completion response.
+
+    Prefers the modern ``choices[0].message.content`` field but falls
+    back to the legacy ``choices[0].text`` layout for servers that still
+    return the text-completion shape from the chat endpoint. Raises
+    ``ValueError`` when neither field is present so the failure surfaces
+    with the offending URL and payload for debugging.
+    """
     choices = data.get("choices") or []
     if not choices:
         raise ValueError(f"No choices in response from {url}: {data!r}")

--- a/backend/backends/openai_compat_backend.py
+++ b/backend/backends/openai_compat_backend.py
@@ -13,8 +13,9 @@ The user configures ``custom_llm_endpoint`` / ``custom_llm_model`` /
 built-in Qwen3 backend.
 """
 
+import json
 import logging
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 import httpx
 
@@ -137,6 +138,108 @@ class OpenAICompatLLMBackend:
             data = response.json()
 
         return _extract_content(data, url)
+
+    async def generate_stream(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,  # noqa: ARG002 — kept for protocol parity
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> AsyncIterator[str]:
+        """Stream the assistant reply as text deltas via OpenAI SSE.
+
+        Each yielded string is the ``delta.content`` field of one chunk.
+        Consumers accumulate these to reconstruct the full reply; the
+        streaming TTS pipeline in ``chunked_tts`` uses the accumulator
+        to fire per-sentence TTS as soon as a sentence boundary lands.
+        """
+        messages = _build_messages(prompt, system, examples)
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": True,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        url = f"{self.endpoint}/chat/completions"
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                async with client.stream("POST", url, headers=headers, json=payload) as response:
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        delta = _parse_sse_delta(line)
+                        if delta is _SSE_DONE:
+                            break
+                        if delta:
+                            yield delta
+            except httpx.HTTPStatusError as exc:
+                body_preview = ""
+                try:
+                    body_preview = (await exc.response.aread()).decode("utf-8", "replace")[:500]
+                except Exception:
+                    pass
+                logger.error(
+                    "OpenAI-compat streaming endpoint %s returned %d: %s",
+                    url,
+                    exc.response.status_code,
+                    body_preview,
+                )
+                raise
+            except httpx.RequestError as exc:
+                logger.error("OpenAI-compat streaming endpoint %s request failed: %s", url, exc)
+                raise
+
+    def supports_streaming(self) -> bool:
+        return True
+
+
+# Sentinel returned by ``_parse_sse_delta`` when the terminal ``[DONE]``
+# marker arrives — an in-band value distinct from "no content to yield".
+_SSE_DONE = object()
+
+
+def _parse_sse_delta(line: str) -> object:
+    """Extract ``delta.content`` from a single SSE line.
+
+    Returns:
+      - ``_SSE_DONE`` when the terminal ``data: [DONE]`` marker arrives.
+      - An empty string on lines with no useful payload (comments,
+        keep-alives, role-only deltas, blank frames) — callers should skip.
+      - The delta content string otherwise.
+    """
+    if not line or not line.startswith("data:"):
+        # Comments start with ``:`` (keep-alive heartbeats) or the line
+        # is a blank separator between events; nothing to yield.
+        return ""
+
+    payload = line[5:].strip()
+    if payload == "[DONE]":
+        return _SSE_DONE
+    if not payload:
+        return ""
+
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.debug("Ignoring malformed SSE frame: %s", payload[:120])
+        return ""
+
+    choices = chunk.get("choices") or []
+    if not choices:
+        return ""
+
+    delta = choices[0].get("delta") or {}
+    content = delta.get("content")
+    return content if isinstance(content, str) else ""
 
 
 def _build_messages(

--- a/backend/backends/qwen_llm_backend.py
+++ b/backend/backends/qwen_llm_backend.py
@@ -9,7 +9,7 @@ and STT engines.
 
 import asyncio
 import logging
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 from . import LLMBackend, DEFAULT_LLM_MAX_TOKENS, DEFAULT_LLM_TEMPERATURE
 from .base import (
@@ -145,6 +145,35 @@ class PyTorchQwenLLMBackend:
             self._generate_sync, prompt, system, max_tokens, temperature, examples
         )
 
+    async def generate_stream(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> AsyncIterator[str]:
+        """Fallback that yields the full generate() result as a single chunk.
+
+        Adding a real token-by-token stream to transformers.generate would
+        require a TextIteratorStreamer + threading dance; leaving that to
+        a follow-up keeps the fallback surface small while consumers still
+        get the same content, just without overlap benefit.
+        """
+        text = await self.generate(
+            prompt,
+            system=system,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            model_size=model_size,
+            examples=examples,
+        )
+        yield text
+
+    def supports_streaming(self) -> bool:
+        return False
+
     def _generate_sync(
         self,
         prompt: str,
@@ -261,6 +290,35 @@ class MLXQwenLLMBackend:
         return await asyncio.to_thread(
             self._generate_sync, prompt, system, max_tokens, temperature, examples
         )
+
+    async def generate_stream(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = DEFAULT_LLM_MAX_TOKENS,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
+        model_size: Optional[str] = None,
+        examples: Optional[list[tuple[str, str]]] = None,
+    ) -> AsyncIterator[str]:
+        """Fallback yielding the full generate() result as a single chunk.
+
+        mlx_lm has a token-by-token generator API but hooking it up would
+        require re-implementing the ``mlx_generate`` convenience wrapper.
+        Left to a follow-up; the single-chunk fallback keeps the
+        surface uniform for now.
+        """
+        text = await self.generate(
+            prompt,
+            system=system,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            model_size=model_size,
+            examples=examples,
+        )
+        yield text
+
+    def supports_streaming(self) -> bool:
+        return False
 
     def _generate_sync(
         self,

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -243,6 +243,27 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "hotkey_enabled BOOLEAN NOT NULL DEFAULT 0",
             "hotkey_enabled",
         )
+    if "custom_llm_endpoint" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_endpoint VARCHAR",
+            "custom_llm_endpoint",
+        )
+    if "custom_llm_model" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_model VARCHAR",
+            "custom_llm_model",
+        )
+    if "custom_llm_api_key" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "custom_llm_api_key VARCHAR",
+            "custom_llm_api_key",
+        )
 
 
 def _migrate_mcp_bindings(engine, inspector, tables: set[str]) -> None:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -218,6 +218,14 @@ class CaptureSettings(Base):
     chord_toggle_to_talk_keys = Column(
         JSON, nullable=False, default=default_toggle_to_talk_chord
     )
+    # Optional OpenAI-compatible endpoint that overrides the built-in Qwen3
+    # LLM for refinement / personality rewriting. When ``custom_llm_endpoint``
+    # is set, the backend layer delegates every LLM call to this URL instead
+    # of running Qwen locally; leaving it null keeps the on-device path and
+    # the ``llm_model`` size selector above.
+    custom_llm_endpoint = Column(String, nullable=True)
+    custom_llm_model = Column(String, nullable=True)
+    custom_llm_api_key = Column(String, nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,7 @@ Pydantic models for request/response validation.
 """
 
 from pydantic import BaseModel, Field, model_validator
-from typing import Any, Optional, List
+from typing import Any, Literal, Optional, List
 from datetime import datetime
 
 from .utils.capture_chords import (
@@ -400,6 +400,82 @@ class SpeakRequest(BaseModel):
         None,
         pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
     )
+
+
+class SpeakStreamRequest(BaseModel):
+    """Body for POST /speak/stream — like SpeakRequest, plus a chunk sizer.
+
+    Kept separate from ``SpeakRequest`` so the streaming route can grow
+    stream-only knobs without polluting the fire-and-forget /speak
+    contract. Everything else mirrors the plain /speak body.
+    """
+
+    text: str = Field(..., min_length=1, max_length=10000)
+    profile: Optional[str] = Field(None)
+    engine: Optional[str] = Field(
+        None,
+        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+    )
+    personality: Optional[bool] = Field(None)
+    language: Optional[str] = Field(
+        None,
+        pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
+    )
+    max_chunk_chars: int = Field(default=800, ge=100, le=5000)
+
+
+# --- SSE event shapes ------------------------------------------------------
+#
+# These live server-side only — each is JSON-serialised into the ``data:``
+# field of an SSE frame. The ``type`` discriminator lets the client route
+# frames to the right handler (audio decoder, completion callback, error
+# toast) without a schema-per-frame lookup.
+
+
+class SpeakStreamMeta(BaseModel):
+    """First event sent — metadata the client needs before any audio."""
+
+    type: Literal["meta"] = "meta"
+    generation_id: str
+    sample_rate: int
+    channels: int = 1
+    # Which of the two backend paths produced the stream. Useful for the
+    # client to display an "LLM streaming enabled" hint and for
+    # observability — the sequential path emits the same event shape but
+    # ships a single audio chunk at the end.
+    streaming_llm: bool
+
+
+class SpeakStreamAudioChunk(BaseModel):
+    """One sentence's worth of audio, base64-encoded PCM float32."""
+
+    type: Literal["audio"] = "audio"
+    sentence_index: int
+    # Base64-encoded raw float32 PCM samples, little-endian, single channel.
+    # The client decodes with ``atob`` → ``Uint8Array`` → ``Float32Array`` →
+    # ``AudioBuffer`` and schedules against ``audioCtx.currentTime`` so
+    # sentence boundaries land gap-lessly.
+    pcm_base64: str
+    # Sentence text this audio was rendered from, echoed back so the client
+    # can subtitle progressively without re-running the LLM.
+    text: str
+
+
+class SpeakStreamComplete(BaseModel):
+    """Terminal event before ``[DONE]`` — final generation record + duration."""
+
+    type: Literal["complete"] = "complete"
+    generation_id: str
+    duration: float
+    audio_path: Optional[str] = None
+
+
+class SpeakStreamError(BaseModel):
+    """Streamed error — sent instead of ``complete`` when generation fails."""
+
+    type: Literal["error"] = "error"
+    generation_id: Optional[str] = None
+    message: str
 
 
 class LLMGenerateRequest(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,8 +2,8 @@
 Pydantic models for request/response validation.
 """
 
-from pydantic import BaseModel, Field
-from typing import Optional, List
+from pydantic import BaseModel, Field, model_validator
+from typing import Any, Optional, List
 from datetime import datetime
 
 from .utils.capture_chords import (
@@ -266,7 +266,36 @@ class CaptureSettingsResponse(BaseModel):
     )
     custom_llm_endpoint: Optional[str] = None
     custom_llm_model: Optional[str] = None
-    custom_llm_api_key: Optional[str] = None
+    # Provider credential — write-only. The response reports whether one is
+    # configured but never echoes the value, so the settings API can't be
+    # used to exfiltrate stored keys and the frontend can't rehydrate them
+    # into React state where a browser cache could pick them up.
+    custom_llm_api_key_configured: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _mask_custom_llm_api_key(cls, data: Any) -> Any:
+        """Replace the raw ``custom_llm_api_key`` with a boolean ``_configured`` flag.
+
+        Runs before field validation so the stored credential is never
+        materialised on a Response instance, even in memory. Accepts both
+        SQLAlchemy ORM rows (``from_attributes=True`` path) and plain dicts
+        so tests that construct the model directly get the same treatment.
+        """
+        if isinstance(data, dict):
+            raw_key = data.pop("custom_llm_api_key", None)
+            data.setdefault("custom_llm_api_key_configured", bool(raw_key))
+            return data
+        # ORM row — build a snapshot dict, drop the secret, and hand the
+        # rest to Pydantic. ``from_attributes`` won't reach the raw
+        # attribute anymore because the returned dict wins.
+        columns = getattr(getattr(data, "__table__", None), "columns", None)
+        if columns is None:
+            return data
+        snapshot = {c.name: getattr(data, c.name, None) for c in columns}
+        raw_key = snapshot.pop("custom_llm_api_key", None)
+        snapshot["custom_llm_api_key_configured"] = bool(raw_key)
+        return snapshot
 
     class Config:
         from_attributes = True

--- a/backend/models.py
+++ b/backend/models.py
@@ -264,6 +264,9 @@ class CaptureSettingsResponse(BaseModel):
     chord_toggle_to_talk_keys: List[str] = Field(
         default_factory=default_toggle_to_talk_chord
     )
+    custom_llm_endpoint: Optional[str] = None
+    custom_llm_model: Optional[str] = None
+    custom_llm_api_key: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -284,6 +287,9 @@ class CaptureSettingsUpdate(BaseModel):
     hotkey_enabled: Optional[bool] = None
     chord_push_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
     chord_toggle_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
+    custom_llm_endpoint: Optional[str] = None
+    custom_llm_model: Optional[str] = None
+    custom_llm_api_key: Optional[str] = None
 
 
 class GenerationSettingsResponse(BaseModel):

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -78,15 +78,29 @@ async def generate_speech(
 
     text = data.text
     source = "manual"
+    personality_prompt: str | None = None
     if data.personality and getattr(profile, "personality", None):
-        try:
-            llm_result = await personality.rewrite_as_profile(profile.personality, data.text)
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
-        text = llm_result.text.strip()
-        if not text:
-            raise HTTPException(status_code=500, detail="LLM produced empty output; nothing to speak.")
-        source = "personality_speak"
+        # When the active LLM backend can stream, defer the rewrite into
+        # the background task so it can overlap with per-sentence TTS.
+        # Otherwise materialise the full rewrite up-front (existing path)
+        # so the DB row records the actual spoken text before enqueueing.
+        from ..backends import get_llm_backend
+
+        llm_backend = get_llm_backend()
+        if getattr(llm_backend, "supports_streaming", lambda: False)():
+            personality_prompt = profile.personality
+            source = "personality_speak"
+        else:
+            try:
+                llm_result = await personality.rewrite_as_profile(profile.personality, data.text)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            text = llm_result.text.strip()
+            if not text:
+                raise HTTPException(
+                    status_code=500, detail="LLM produced empty output; nothing to speak."
+                )
+            source = "personality_speak"
 
     generation = await history.create_generation(
         profile_id=data.profile_id,
@@ -139,6 +153,7 @@ async def generate_speech(
             mode="generate",
             max_chunk_chars=data.max_chunk_chars,
             crossfade_ms=data.crossfade_ms,
+            personality_prompt=personality_prompt,
         )
     )
 

--- a/backend/routes/llm.py
+++ b/backend/routes/llm.py
@@ -18,40 +18,54 @@ router = APIRouter()
 
 @router.post("/llm/generate", response_model=models.LLMGenerateResponse)
 async def llm_generate(request: models.LLMGenerateRequest):
-    """Run a single-turn Qwen3 completion."""
+    """Run a single-turn chat completion via the active LLM backend.
+
+    Routes to the built-in Qwen3 backend by default. If the user has
+    configured a custom OpenAI-compatible endpoint under capture settings,
+    ``get_llm_model()`` returns that backend and the Qwen-specific size
+    validation / download-progress plumbing below is skipped.
+    """
+    from ..backends.openai_compat_backend import OpenAICompatLLMBackend
+
     backend = llm.get_llm_model()
-    model_size = request.model_size or backend.model_size
 
-    valid_sizes = {cfg.model_size for cfg in get_llm_model_configs()}
-    if model_size not in valid_sizes:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid LLM size '{model_size}'. Must be one of: {sorted(valid_sizes)}",
-        )
+    if isinstance(backend, OpenAICompatLLMBackend):
+        # Custom endpoint owns model selection. The remote server validates
+        # its own model name and there's nothing to download locally.
+        model_size = backend.model_size
+    else:
+        model_size = request.model_size or backend.model_size
 
-    already_loaded = backend.is_loaded() and backend.model_size == model_size
-    if not already_loaded and not backend._is_model_cached(model_size):
-        progress_model_name = f"qwen3-{model_size.lower()}"
-        task_manager = get_task_manager()
+        valid_sizes = {cfg.model_size for cfg in get_llm_model_configs()}
+        if model_size not in valid_sizes:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid LLM size '{model_size}'. Must be one of: {sorted(valid_sizes)}",
+            )
 
-        async def download_llm_background():
-            try:
-                await backend.load_model(model_size)
-                task_manager.complete_download(progress_model_name)
-            except Exception as e:
-                task_manager.error_download(progress_model_name, str(e))
+        already_loaded = backend.is_loaded() and backend.model_size == model_size
+        if not already_loaded and not backend._is_model_cached(model_size):
+            progress_model_name = f"qwen3-{model_size.lower()}"
+            task_manager = get_task_manager()
 
-        task_manager.start_download(progress_model_name)
-        create_background_task(download_llm_background())
+            async def download_llm_background():
+                try:
+                    await backend.load_model(model_size)
+                    task_manager.complete_download(progress_model_name)
+                except Exception as e:
+                    task_manager.error_download(progress_model_name, str(e))
 
-        return JSONResponse(
-            status_code=202,
-            content={
-                "message": f"Qwen3 {model_size} is being downloaded. Please wait and try again.",
-                "model_name": progress_model_name,
-                "downloading": True,
-            },
-        )
+            task_manager.start_download(progress_model_name)
+            create_background_task(download_llm_background())
+
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "message": f"Qwen3 {model_size} is being downloaded. Please wait and try again.",
+                    "model_name": progress_model_name,
+                    "downloading": True,
+                },
+            )
 
     examples: list[tuple[str, str]] | None = None
     if request.examples:

--- a/backend/routes/speak.py
+++ b/backend/routes/speak.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import models
@@ -92,3 +93,88 @@ async def speak(
         },
     )
     return generation
+
+
+@router.post("/speak/stream")
+async def speak_stream(
+    data: models.SpeakStreamRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> StreamingResponse:
+    """SSE variant of ``POST /speak`` that streams audio as it renders.
+
+    Same profile / engine / personality resolution as ``/speak``, but
+    the response body is a ``text/event-stream`` sequence of frames:
+
+    - ``meta``   — one, up front, carrying sample rate + channels.
+    - ``audio``  — one per sentence, base64-encoded PCM float32.
+    - ``complete`` — one, right before the terminal sentinel.
+    - ``[DONE]`` — OpenAI-style terminator.
+    """
+    client_id = request.headers.get("X-Voicebox-Client-Id")
+    profile = resolve_profile(data.profile, client_id, db)
+    if profile is None:
+        if data.profile:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Voice profile '{data.profile}' not found.",
+            )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No voice profile resolved. Pass `profile` (name or id), "
+                "or configure a default in Voicebox → Settings → MCP."
+            ),
+        )
+
+    binding = None
+    if client_id:
+        binding = (
+            db.query(MCPClientBinding)
+            .filter(MCPClientBinding.client_id == client_id)
+            .first()
+        )
+
+    personality_flag = data.personality
+    if personality_flag is None and binding is not None:
+        personality_flag = bool(binding.default_personality)
+
+    engine = data.engine
+    if engine is None and binding is not None:
+        engine = binding.default_engine
+    if engine is None:
+        engine = "qwen"
+
+    # Late import to keep top-of-file cheap for the fire-and-forget path.
+    from ..services.stream_speak import stream_speak_events
+
+    generator = stream_speak_events(
+        profile_id=profile.id,
+        text=data.text,
+        engine=engine,
+        language=data.language or "en",
+        personality=bool(personality_flag),
+        profile_personality=getattr(profile, "personality", None),
+        max_chunk_chars=data.max_chunk_chars,
+    )
+
+    mcp_events.publish(
+        "speak-start",
+        {
+            "profile_name": profile.name,
+            "source": "rest_stream",
+            "client_id": client_id,
+        },
+    )
+
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            # Disable nginx-style response buffering so each frame lands
+            # on the wire the instant we yield it.
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -42,13 +42,25 @@ async def run_generation(
     max_chunk_chars: Optional[int] = None,
     crossfade_ms: Optional[int] = None,
     version_id: Optional[str] = None,
+    personality_prompt: Optional[str] = None,
 ) -> None:
     """Execute TTS inference and persist the result.
 
     This is the single entry point for all background generation work.
     It is designed to be enqueued via ``services.task_queue.enqueue_generation``.
+
+    When ``personality_prompt`` is set and the active LLM backend supports
+    streaming, ``text`` is treated as the user's input and the LLM is
+    streamed into per-sentence TTS jobs — first-audio-latency drops from
+    (LLM_time + TTS_time) to roughly max(LLM_time, TTS_time). Backends
+    without a real stream fall back to the sequential path.
     """
-    from ..backends import load_engine_model, get_tts_backend_for_engine, engine_needs_trim
+    from ..backends import (
+        get_llm_backend,
+        get_tts_backend_for_engine,
+        load_engine_model,
+        engine_needs_trim,
+    )
     from ..utils.chunked_tts import generate_chunked
     from ..utils.audio import normalize_audio, save_audio, trim_tts_output
 
@@ -84,7 +96,26 @@ async def run_generation(
         if crossfade_ms is not None:
             gen_kwargs["crossfade_ms"] = crossfade_ms
 
-        audio, sample_rate = await generate_chunked(tts_model, text, voice_prompt, **gen_kwargs)
+        llm_backend = get_llm_backend()
+        streaming_available = bool(
+            personality_prompt
+            and getattr(llm_backend, "supports_streaming", lambda: False)()
+        )
+        if streaming_available:
+            audio, sample_rate = await _run_streaming_personality_generation(
+                llm_backend=llm_backend,
+                tts_backend=tts_model,
+                personality_prompt=personality_prompt,
+                user_text=text,
+                voice_prompt=voice_prompt,
+                gen_kwargs=gen_kwargs,
+                max_chunk_chars=max_chunk_chars,
+                crossfade_ms=crossfade_ms,
+            )
+        else:
+            audio, sample_rate = await generate_chunked(
+                tts_model, text, voice_prompt, **gen_kwargs
+            )
 
         # --- Normalize (generate and regenerate always; retry skips) -----
         if normalize or mode == "regenerate":
@@ -149,6 +180,60 @@ async def run_generation(
     finally:
         task_manager.complete_generation(generation_id)
         bg_db.close()
+
+
+async def _run_streaming_personality_generation(
+    *,
+    llm_backend,
+    tts_backend,
+    personality_prompt: str,
+    user_text: str,
+    voice_prompt: dict,
+    gen_kwargs: dict,
+    max_chunk_chars: Optional[int],
+    crossfade_ms: Optional[int],
+) -> tuple:
+    """Drive the LLM stream → per-sentence TTS pipeline for the personality path.
+
+    Kept out of :func:`run_generation` so the sequential-path body stays
+    readable — this is the concurrent branch, and it needs a handful of
+    imports the sequential path doesn't touch.
+    """
+    from .personality import rewrite_as_profile_stream
+    from ..utils.chunked_tts import (
+        DEFAULT_MAX_CHUNK_CHARS,
+        concatenate_audio_chunks,
+        generate_streaming_from_sentences,
+        stream_sentences,
+    )
+    import numpy as np
+
+    resolved_max_chunk = max_chunk_chars if max_chunk_chars is not None else DEFAULT_MAX_CHUNK_CHARS
+    resolved_crossfade = crossfade_ms if crossfade_ms is not None else 50
+
+    llm_stream = rewrite_as_profile_stream(personality_prompt, user_text)
+    sentence_stream = stream_sentences(llm_stream, max_chunk_chars=resolved_max_chunk)
+
+    audio_chunks = []
+    sample_rate: Optional[int] = None
+    async for audio, sr in generate_streaming_from_sentences(
+        tts_backend,
+        sentence_stream,
+        voice_prompt,
+        language=gen_kwargs.get("language", "en"),
+        seed=gen_kwargs.get("seed"),
+        instruct=gen_kwargs.get("instruct"),
+        trim_fn=gen_kwargs.get("trim_fn"),
+    ):
+        audio_chunks.append(audio)
+        if sample_rate is None:
+            sample_rate = sr
+
+    if sample_rate is None:
+        raise ValueError("Streaming LLM produced no output; nothing to speak.")
+
+    audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=resolved_crossfade)
+    return audio, sample_rate
 
 
 def _notify_speak_end(generation_id: str, *, status: str) -> None:

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -216,7 +216,7 @@ async def _run_streaming_personality_generation(
 
     audio_chunks = []
     sample_rate: Optional[int] = None
-    async for audio, sr in generate_streaming_from_sentences(
+    async for audio, sr, _sentence in generate_streaming_from_sentences(
         tts_backend,
         sentence_stream,
         voice_prompt,

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -102,7 +102,7 @@ async def run_generation(
             and getattr(llm_backend, "supports_streaming", lambda: False)()
         )
         if streaming_available:
-            audio, sample_rate = await _run_streaming_personality_generation(
+            audio, sample_rate, spoken_text = await _run_streaming_personality_generation(
                 llm_backend=llm_backend,
                 tts_backend=tts_model,
                 personality_prompt=personality_prompt,
@@ -112,6 +112,12 @@ async def run_generation(
                 max_chunk_chars=max_chunk_chars,
                 crossfade_ms=crossfade_ms,
             )
+            # The generations row was created with ``data.text`` (the raw
+            # user input) because the personality rewrite happens inside
+            # the streaming pipeline — patch the row with what was
+            # actually spoken so History matches the audio.
+            if spoken_text:
+                await _update_generation_text(generation_id, spoken_text, bg_db)
         else:
             audio, sample_rate = await generate_chunked(
                 tts_model, text, voice_prompt, **gen_kwargs
@@ -215,8 +221,9 @@ async def _run_streaming_personality_generation(
     sentence_stream = stream_sentences(llm_stream, max_chunk_chars=resolved_max_chunk)
 
     audio_chunks = []
+    sentence_texts: list[str] = []
     sample_rate: Optional[int] = None
-    async for audio, sr, _sentence in generate_streaming_from_sentences(
+    async for audio, sr, sentence in generate_streaming_from_sentences(
         tts_backend,
         sentence_stream,
         voice_prompt,
@@ -226,6 +233,7 @@ async def _run_streaming_personality_generation(
         trim_fn=gen_kwargs.get("trim_fn"),
     ):
         audio_chunks.append(audio)
+        sentence_texts.append(sentence)
         if sample_rate is None:
             sample_rate = sr
 
@@ -233,7 +241,30 @@ async def _run_streaming_personality_generation(
         raise ValueError("Streaming LLM produced no output; nothing to speak.")
 
     audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=resolved_crossfade)
-    return audio, sample_rate
+    # Return the rewritten text alongside audio so the caller can persist
+    # what was actually spoken — otherwise History would keep the raw
+    # user input, which disagrees with the audio on personality paths.
+    spoken_text = " ".join(s for s in sentence_texts if s).strip()
+    return audio, sample_rate, spoken_text
+
+
+async def _update_generation_text(generation_id: str, text: str, db) -> None:
+    """Patch the persisted ``generations.text`` after a streaming personality run.
+
+    ``history.update_generation_status`` only writes status / error / audio_path
+    / duration, so we go direct on the row rather than growing that signature
+    for a personality-path corner case.
+    """
+    from ..database import Generation as DBGeneration
+
+    def _sync() -> None:
+        row = db.query(DBGeneration).filter_by(id=generation_id).first()
+        if row is None:
+            return
+        row.text = text
+        db.commit()
+
+    await asyncio.to_thread(_sync)
 
 
 def _notify_speak_end(generation_id: str, *, status: str) -> None:

--- a/backend/services/personality.py
+++ b/backend/services/personality.py
@@ -20,6 +20,7 @@ ideas.
 """
 
 from dataclasses import dataclass
+from typing import AsyncIterator
 
 from . import llm as llm_service
 from .refinement import collapse_repetitive_artifacts
@@ -118,3 +119,40 @@ async def rewrite_as_profile(
         model_size=resolved_size,
     )
     return PersonalityResult(text=output.strip(), model_size=resolved_size)
+
+
+async def rewrite_as_profile_stream(
+    personality: str | None,
+    user_text: str,
+    model_size: str | None = None,
+) -> AsyncIterator[str]:
+    """Streaming counterpart of :func:`rewrite_as_profile`.
+
+    Yields the same content as ``rewrite_as_profile().text`` but as
+    per-token deltas when the active LLM backend supports it — the
+    streaming TTS pipeline turns those into per-sentence audio jobs so
+    the caller starts hearing the character before the model has
+    finished restating the whole message.
+
+    Backends without a true streaming path fall back to a single yield
+    of the full response, so the caller can treat every backend
+    uniformly.
+    """
+    character = _require_personality(personality)
+    cleaned = collapse_repetitive_artifacts(user_text)
+    if not cleaned.strip():
+        raise ValueError("Rewrite needs non-empty text to restate.")
+
+    backend = llm_service.get_llm_model()
+    resolved_size = model_size or backend.model_size
+    system_prompt = _build_system_prompt(character, _REWRITE_TASK)
+
+    async for delta in backend.generate_stream(
+        prompt=cleaned,
+        system=system_prompt,
+        max_tokens=1024,
+        temperature=0.3,
+        model_size=resolved_size,
+    ):
+        if delta:
+            yield delta

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -74,7 +74,34 @@ def update_capture_settings(db: Session, patch: dict[str, Any]) -> DBCaptureSett
     _apply_patch(row, patch)
     db.commit()
     db.refresh(row)
+    _sync_llm_backend_config(row)
     return row
+
+
+def _sync_llm_backend_config(row: DBCaptureSettings) -> None:
+    """Push the persisted custom-LLM endpoint into the backend module state.
+
+    Called after every capture-settings write and once on startup from
+    ``bootstrap_llm_backend_config``. Keeps the runtime dispatch in
+    ``backends.get_llm_backend()`` in sync with what the DB row holds so
+    the user's next refinement / personality call routes to the new URL
+    without a restart.
+    """
+    # Imported inline to avoid a circular import at module load — the
+    # backends package pulls in HF patches that in turn import services.
+    from .. import backends
+
+    backends.set_llm_config(
+        endpoint=row.custom_llm_endpoint,
+        model=row.custom_llm_model,
+        api_key=row.custom_llm_api_key,
+    )
+
+
+def bootstrap_llm_backend_config(db: Session) -> None:
+    """Seed the backend LLM config from the persisted row on server startup."""
+    row = _get_or_create_capture_row(db)
+    _sync_llm_backend_config(row)
 
 
 def get_generation_settings(db: Session) -> DBGenerationSettings:

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -23,6 +23,12 @@ SINGLETON_ID = 1
 
 
 def _get_or_create_capture_row(db: Session) -> DBCaptureSettings:
+    """Fetch the singleton capture-settings row, lazily creating it on first read.
+
+    Every setter path is a partial update against this row, so callers
+    can assume the returned object exists and holds the schema defaults
+    for any field the user hasn't customised yet.
+    """
     row = db.query(DBCaptureSettings).filter(DBCaptureSettings.id == SINGLETON_ID).first()
     if row is None:
         row = DBCaptureSettings(
@@ -37,6 +43,11 @@ def _get_or_create_capture_row(db: Session) -> DBCaptureSettings:
 
 
 def _get_or_create_generation_row(db: Session) -> DBGenerationSettings:
+    """Fetch the singleton generation-settings row, lazily creating it on first read.
+
+    Symmetric counterpart to :func:`_get_or_create_capture_row` for the
+    long-form generation defaults (chunk sizer, crossfade, normalize).
+    """
     row = db.query(DBGenerationSettings).filter(DBGenerationSettings.id == SINGLETON_ID).first()
     if row is None:
         row = DBGenerationSettings(id=SINGLETON_ID)
@@ -70,6 +81,13 @@ def get_capture_settings(db: Session) -> DBCaptureSettings:
 
 
 def update_capture_settings(db: Session, patch: dict[str, Any]) -> DBCaptureSettings:
+    """Apply a partial update to the capture-settings singleton and persist it.
+
+    After the commit, propagates the (possibly changed) custom-LLM
+    endpoint into the backend module state via
+    :func:`_sync_llm_backend_config` so subsequent refinement /
+    personality calls route to the new URL without needing a restart.
+    """
     row = _get_or_create_capture_row(db)
     _apply_patch(row, patch)
     db.commit()
@@ -110,6 +128,13 @@ def get_generation_settings(db: Session) -> DBGenerationSettings:
 
 
 def update_generation_settings(db: Session, patch: dict[str, Any]) -> DBGenerationSettings:
+    """Apply a partial update to the generation-settings singleton and persist it.
+
+    Unlike :func:`update_capture_settings`, no runtime state depends on
+    these values — the fields flow directly into the next
+    ``run_generation`` invocation via ``GenerationSettings`` — so the
+    commit is enough.
+    """
     row = _get_or_create_generation_row(db)
     _apply_patch(row, patch)
     db.commit()

--- a/backend/services/stream_speak.py
+++ b/backend/services/stream_speak.py
@@ -97,23 +97,39 @@ async def stream_speak_events(
         )
         streaming_llm = can_stream_llm
 
+        # Materialise the text that TTS will actually render, so the
+        # generations row stored below matches the audio on disk. On the
+        # personality paths that means the rewritten reply; on the plain
+        # path it's the caller's own text unchanged.
         if can_stream_llm:
             llm_stream = rewrite_as_profile_stream(profile_personality, text)
+            # Every branch runs through ``stream_sentences`` so long
+            # inputs stay chunked to ``max_chunk_chars`` instead of
+            # falling into a single oversized ``backend.generate`` call
+            # on the fallback paths.
             sentence_stream = stream_sentences(llm_stream, max_chunk_chars=max_chunk_chars)
         elif personality and profile_personality:
-            # Personality requested but the LLM can't stream — fall back to
-            # the non-streaming rewrite, then treat the whole reply as a
-            # single sentence stream so the SSE contract stays uniform.
+            # Personality requested but the LLM can't stream — fall back
+            # to the non-streaming rewrite, then pipe the whole reply
+            # through the same sentence splitter so TTS still runs one
+            # sentence at a time.
             from .personality import rewrite_as_profile
 
             rewritten = await rewrite_as_profile(profile_personality, text)
-            sentence_stream = _single_sentence_stream(rewritten.text.strip())
+            sentence_stream = stream_sentences(
+                _as_single_chunk(rewritten.text.strip()),
+                max_chunk_chars=max_chunk_chars,
+            )
         else:
-            sentence_stream = _single_sentence_stream(text)
+            sentence_stream = stream_sentences(
+                _as_single_chunk(text),
+                max_chunk_chars=max_chunk_chars,
+            )
 
         trim_fn = trim_tts_output if engine_needs_trim(engine) else None
 
         audio_chunks: list[np.ndarray] = []
+        sentence_texts: list[str] = []
         sample_rate: Optional[int] = None
         sentence_index = 0
 
@@ -136,6 +152,7 @@ async def stream_speak_events(
                 )
 
             audio_chunks.append(audio)
+            sentence_texts.append(sentence)
             pcm_b64 = base64.b64encode(np.asarray(audio, dtype=np.float32).tobytes()).decode("ascii")
             yield _sse_data(
                 models.SpeakStreamAudioChunk(
@@ -160,6 +177,12 @@ async def stream_speak_events(
         final_path = config.get_generations_dir() / f"{generation_id}.wav"
         save_audio(final_audio, str(final_path), sample_rate)
 
+        # The persisted ``text`` has to match what was actually spoken —
+        # ``data.text`` is the raw user input, so on the personality path
+        # it would disagree with the audio otherwise. Join what the
+        # streaming pipeline handed to TTS.
+        spoken_text = " ".join(s for s in sentence_texts if s).strip() or text
+
         # Persist a generations row so History reflects streamed speech
         # the same way fire-and-forget /speak does. Failing to persist
         # is non-fatal — the audio is already on disk and the client has
@@ -169,7 +192,7 @@ async def stream_speak_events(
             try:
                 await history.create_generation(
                     profile_id=profile_id,
-                    text=text,
+                    text=spoken_text,
                     language=language,
                     audio_path=config.to_storage_path(final_path),
                     duration=len(final_audio) / sample_rate,
@@ -205,11 +228,12 @@ async def stream_speak_events(
         yield _sse_done()
 
 
-async def _single_sentence_stream(text: str) -> AsyncIterator[str]:
-    """Wrap a fully-materialised string as a one-element async sentence iterator.
+async def _as_single_chunk(text: str) -> AsyncIterator[str]:
+    """Adapt a materialised string into a one-element async iterator.
 
-    Lets the non-streaming personality path and the plain no-personality
-    path share the SSE emitter loop without duplicating branch logic.
+    Feeds the plain and non-streaming-personality paths into
+    ``stream_sentences`` so long inputs still get sentence-level chunking
+    instead of collapsing into one oversized TTS call.
     """
     cleaned = text.strip()
     if cleaned:

--- a/backend/services/stream_speak.py
+++ b/backend/services/stream_speak.py
@@ -212,7 +212,13 @@ async def stream_speak_events(
             models.SpeakStreamComplete(
                 generation_id=generation_id,
                 duration=len(final_audio) / sample_rate,
-                audio_path=str(final_path),
+                # Match the ``audio_path`` shape the generations row was
+                # persisted with (storage-relative, via
+                # ``config.to_storage_path``) so a client looking the row
+                # up by ``generation_id`` finds the same path in both
+                # places rather than an absolute filesystem path here and
+                # a storage-relative one in History.
+                audio_path=config.to_storage_path(final_path),
             ).model_dump()
         )
         yield _sse_done()

--- a/backend/services/stream_speak.py
+++ b/backend/services/stream_speak.py
@@ -1,0 +1,226 @@
+"""
+Server-side driver for ``POST /speak/stream``.
+
+Wraps the streaming LLM+TTS pipeline in an SSE-friendly async generator
+so the client hears each sentence as soon as it lands instead of waiting
+for the full audio file to be concatenated and saved. The event shape
+mirrors OpenAI's streaming style (a ``data: {...}`` frame per event, a
+final ``data: [DONE]`` sentinel) so the browser side needs no server-
+specific framing code.
+
+The generator yields SSE-formatted ``str`` values, one per frame,
+ready to be fed straight into a ``StreamingResponse``. Callers should
+not JSON-encode or wrap the output — that's already done here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import traceback
+import uuid
+from typing import AsyncIterator, Optional
+
+import numpy as np
+
+from .. import config, models
+from ..database import get_db
+from ..utils.audio import save_audio
+
+logger = logging.getLogger(__name__)
+
+
+async def stream_speak_events(
+    *,
+    profile_id: str,
+    text: str,
+    engine: str,
+    language: str,
+    personality: bool,
+    profile_personality: Optional[str],
+    max_chunk_chars: int,
+) -> AsyncIterator[str]:
+    """Drive one /speak/stream request and yield SSE frames.
+
+    Frames (in order):
+      1. ``meta`` — sample_rate + channels + generation_id.
+      2. ``audio`` — one per sentence, base64-encoded PCM float32.
+      3. ``complete`` — total duration + final audio_path.
+      4. ``[DONE]`` sentinel.
+
+    On failure at any step the generator yields an ``error`` frame and
+    the terminal sentinel; it never leaves the SSE connection open on a
+    partial state.
+    """
+    from ..backends import (
+        engine_needs_trim,
+        get_llm_backend,
+        get_tts_backend_for_engine,
+        load_engine_model,
+    )
+    from ..utils.chunked_tts import (
+        concatenate_audio_chunks,
+        generate_streaming_from_sentences,
+        stream_sentences,
+    )
+    from ..utils.audio import trim_tts_output
+    from . import history, profiles
+    from .personality import rewrite_as_profile_stream
+
+    generation_id = str(uuid.uuid4())
+
+    try:
+        tts_backend = get_tts_backend_for_engine(engine)
+        await load_engine_model(engine)
+
+        bg_db = next(get_db())
+        try:
+            voice_prompt = await profiles.create_voice_prompt_for_profile(
+                profile_id,
+                bg_db,
+                use_cache=True,
+                engine=engine,
+            )
+        finally:
+            bg_db.close()
+
+        # Build the sentence stream — either from the streaming LLM path
+        # (when the active backend can produce deltas AND personality is on)
+        # or from a single-sentence generator wrapping the raw user text.
+        llm_backend = get_llm_backend()
+        can_stream_llm = bool(
+            personality
+            and profile_personality
+            and getattr(llm_backend, "supports_streaming", lambda: False)()
+        )
+        streaming_llm = can_stream_llm
+
+        if can_stream_llm:
+            llm_stream = rewrite_as_profile_stream(profile_personality, text)
+            sentence_stream = stream_sentences(llm_stream, max_chunk_chars=max_chunk_chars)
+        elif personality and profile_personality:
+            # Personality requested but the LLM can't stream — fall back to
+            # the non-streaming rewrite, then treat the whole reply as a
+            # single sentence stream so the SSE contract stays uniform.
+            from .personality import rewrite_as_profile
+
+            rewritten = await rewrite_as_profile(profile_personality, text)
+            sentence_stream = _single_sentence_stream(rewritten.text.strip())
+        else:
+            sentence_stream = _single_sentence_stream(text)
+
+        trim_fn = trim_tts_output if engine_needs_trim(engine) else None
+
+        audio_chunks: list[np.ndarray] = []
+        sample_rate: Optional[int] = None
+        sentence_index = 0
+
+        async for audio, sr, sentence in generate_streaming_from_sentences(
+            tts_backend,
+            sentence_stream,
+            voice_prompt,
+            language=language,
+            trim_fn=trim_fn,
+        ):
+            if sample_rate is None:
+                sample_rate = sr
+                yield _sse_data(
+                    models.SpeakStreamMeta(
+                        generation_id=generation_id,
+                        sample_rate=sr,
+                        channels=1,
+                        streaming_llm=streaming_llm,
+                    ).model_dump()
+                )
+
+            audio_chunks.append(audio)
+            pcm_b64 = base64.b64encode(np.asarray(audio, dtype=np.float32).tobytes()).decode("ascii")
+            yield _sse_data(
+                models.SpeakStreamAudioChunk(
+                    sentence_index=sentence_index,
+                    pcm_base64=pcm_b64,
+                    text=sentence,
+                ).model_dump()
+            )
+            sentence_index += 1
+
+        if sample_rate is None:
+            yield _sse_data(
+                models.SpeakStreamError(
+                    generation_id=generation_id,
+                    message="Pipeline produced no audio.",
+                ).model_dump()
+            )
+            yield _sse_done()
+            return
+
+        final_audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=50)
+        final_path = config.get_generations_dir() / f"{generation_id}.wav"
+        save_audio(final_audio, str(final_path), sample_rate)
+
+        # Persist a generations row so History reflects streamed speech
+        # the same way fire-and-forget /speak does. Failing to persist
+        # is non-fatal — the audio is already on disk and the client has
+        # the whole thing in memory.
+        try:
+            bg_db = next(get_db())
+            try:
+                await history.create_generation(
+                    profile_id=profile_id,
+                    text=text,
+                    language=language,
+                    audio_path=config.to_storage_path(final_path),
+                    duration=len(final_audio) / sample_rate,
+                    seed=None,
+                    db=bg_db,
+                    generation_id=generation_id,
+                    status="completed",
+                    engine=engine,
+                    source="stream_speak",
+                )
+            finally:
+                bg_db.close()
+        except Exception:
+            logger.warning("History row for streamed speak failed", exc_info=True)
+
+        yield _sse_data(
+            models.SpeakStreamComplete(
+                generation_id=generation_id,
+                duration=len(final_audio) / sample_rate,
+                audio_path=str(final_path),
+            ).model_dump()
+        )
+        yield _sse_done()
+
+    except Exception as exc:
+        traceback.print_exc()
+        yield _sse_data(
+            models.SpeakStreamError(
+                generation_id=generation_id,
+                message=str(exc),
+            ).model_dump()
+        )
+        yield _sse_done()
+
+
+async def _single_sentence_stream(text: str) -> AsyncIterator[str]:
+    """Wrap a fully-materialised string as a one-element async sentence iterator.
+
+    Lets the non-streaming personality path and the plain no-personality
+    path share the SSE emitter loop without duplicating branch logic.
+    """
+    cleaned = text.strip()
+    if cleaned:
+        yield cleaned
+
+
+def _sse_data(payload: dict) -> str:
+    """Format a dict as one SSE ``data:`` frame."""
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _sse_done() -> str:
+    """Terminal OpenAI-style sentinel."""
+    return "data: [DONE]\n\n"

--- a/backend/tests/test_openai_compat_integration.py
+++ b/backend/tests/test_openai_compat_integration.py
@@ -110,26 +110,40 @@ async def test_backend_generates_non_empty_response():
 
 
 async def test_backend_respects_examples_history():
-    """Few-shot examples reach the endpoint as proper user/assistant turns."""
+    """Few-shot examples reach the endpoint as proper user/assistant turns.
+
+    Uses an arbitrary mapping (``ping → PONG``, ``foo → BAR``) so a passing
+    assertion actually proves the examples were serialised into the
+    request. A non-empty translation would still pass if ``examples``
+    were silently dropped; the model has to have seen the pattern to
+    return the mapped token on a novel input.
+    """
     backend = OpenAICompatLLMBackend(
         endpoint=_endpoint(),
         model=_model(),
         api_key=_api_key(),
     )
     reply = await backend.generate(
-        prompt="hola",
+        prompt="baz",
         system=(
-            "You are a translation bot. Reply with the single-word English "
-            "translation of the user's message and nothing else."
+            "You are a lookup function. Respond with exactly one uppercase word "
+            "matching the mapping shown in the examples and nothing else."
         ),
-        max_tokens=16,
+        max_tokens=8,
         temperature=0.0,
         examples=[
-            ("bonjour", "hello"),
-            ("guten tag", "hello"),
+            ("ping", "PONG"),
+            ("foo", "BAR"),
         ],
     )
-    assert reply.strip(), "Endpoint returned an empty translation"
+    stripped = reply.strip().upper()
+    # The model may add punctuation; check that the mapped-shape token
+    # ("QUX" is the natural next entry after PONG/BAR) leads the reply.
+    assert stripped, "Endpoint returned an empty response to a few-shot prompt"
+    assert stripped.startswith(("QUX", "BAZ")), (
+        f"Reply {reply!r} doesn't look like it followed the example mapping — "
+        "the ``examples`` field may have been dropped in transit."
+    )
 
 
 async def test_dispatch_returns_openai_compat_when_config_set():

--- a/backend/tests/test_openai_compat_integration.py
+++ b/backend/tests/test_openai_compat_integration.py
@@ -1,0 +1,182 @@
+"""
+Integration tests for the OpenAI-compatible LLM backend.
+
+These tests hit a **real** endpoint — no HTTP mocks — because the whole
+point of the backend is to survive whatever quirks a real server's
+response shape has. They are skipped automatically when no reachable
+endpoint is configured, so ``pytest`` on a fresh clone still returns
+green.
+
+To run them, boot any OpenAI-compatible server (llama.cpp,
+vLLM, LM Studio, LocalAI, ALICE-LLM's ``server`` binary, or the OpenAI
+API itself), then:
+
+    export VOICEBOX_TEST_OPENAI_COMPAT_URL=http://localhost:8090/v1
+    export VOICEBOX_TEST_OPENAI_COMPAT_MODEL=<the model the server serves>
+    # optional if the endpoint requires bearer auth
+    export VOICEBOX_TEST_OPENAI_COMPAT_API_KEY=<token>
+    pytest backend/tests/test_openai_compat_integration.py -v
+"""
+
+import os
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+from backend.backends import (
+    get_llm_backend,
+    reset_backends,
+    set_llm_config,
+)
+from backend.backends.openai_compat_backend import OpenAICompatLLMBackend
+
+
+ENDPOINT_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_URL"
+MODEL_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_MODEL"
+API_KEY_ENV = "VOICEBOX_TEST_OPENAI_COMPAT_API_KEY"
+
+
+def _endpoint() -> str | None:
+    return os.environ.get(ENDPOINT_ENV) or None
+
+
+def _model() -> str | None:
+    return os.environ.get(MODEL_ENV) or None
+
+
+def _api_key() -> str | None:
+    return os.environ.get(API_KEY_ENV) or None
+
+
+def _endpoint_reachable(url: str) -> bool:
+    """Cheap TCP probe so we skip cleanly when nothing is listening.
+
+    A full HTTP GET would work too, but that couples the skip to whichever
+    path (``/v1``, ``/health``, ``/models``…) the local server happens to
+    expose. TCP handshake to the ``host:port`` from the URL is enough to
+    tell us "run the test" vs "user hasn't started their server".
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except OSError:
+        return False
+
+
+def _endpoint_ready() -> bool:
+    url = _endpoint()
+    model = _model()
+    if not url or not model:
+        return False
+    return _endpoint_reachable(url)
+
+
+pytestmark = pytest.mark.skipif(
+    not _endpoint_ready(),
+    reason=(
+        f"OpenAI-compatible endpoint not configured or unreachable. Set "
+        f"{ENDPOINT_ENV} and {MODEL_ENV} and start the server to run "
+        "these integration tests."
+    ),
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_backends_between_tests():
+    reset_backends()
+    yield
+    reset_backends()
+
+
+async def test_backend_generates_non_empty_response():
+    """One real round trip against the configured endpoint."""
+    backend = OpenAICompatLLMBackend(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    reply = await backend.generate(
+        prompt="Reply with exactly the word: pong",
+        system="You are a terse test harness. Follow the instruction literally.",
+        max_tokens=16,
+        temperature=0.0,
+    )
+    assert isinstance(reply, str)
+    assert reply.strip(), "Endpoint returned an empty string"
+
+
+async def test_backend_respects_examples_history():
+    """Few-shot examples reach the endpoint as proper user/assistant turns."""
+    backend = OpenAICompatLLMBackend(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    reply = await backend.generate(
+        prompt="hola",
+        system=(
+            "You are a translation bot. Reply with the single-word English "
+            "translation of the user's message and nothing else."
+        ),
+        max_tokens=16,
+        temperature=0.0,
+        examples=[
+            ("bonjour", "hello"),
+            ("guten tag", "hello"),
+        ],
+    )
+    assert reply.strip(), "Endpoint returned an empty translation"
+
+
+async def test_dispatch_returns_openai_compat_when_config_set():
+    """``get_llm_backend()`` routes to the custom backend once config is on."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    backend = get_llm_backend()
+    assert isinstance(backend, OpenAICompatLLMBackend)
+    assert backend.endpoint == _endpoint().rstrip("/")
+    assert backend.model == _model()
+
+
+async def test_dispatch_reverts_when_config_cleared():
+    """Clearing the endpoint falls back to the on-device Qwen path."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    assert isinstance(get_llm_backend(), OpenAICompatLLMBackend)
+
+    set_llm_config(endpoint=None, model=None, api_key=None)
+    fallback = get_llm_backend()
+    assert not isinstance(fallback, OpenAICompatLLMBackend)
+
+
+async def test_dispatch_rebuilds_when_endpoint_changes():
+    """A URL swap drops the cached backend so the next call rebuilds."""
+    set_llm_config(
+        endpoint=_endpoint(),
+        model=_model(),
+        api_key=_api_key(),
+    )
+    first = get_llm_backend()
+
+    # Point at a syntactically different URL. We're testing the cache
+    # invalidation path — the second URL doesn't need to be reachable.
+    set_llm_config(
+        endpoint=_endpoint() + "/alt",
+        model=_model(),
+        api_key=_api_key(),
+    )
+    second = get_llm_backend()
+
+    assert first is not second
+    assert isinstance(second, OpenAICompatLLMBackend)
+    assert second.endpoint.endswith("/alt")

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -384,6 +384,18 @@ async def stream_sentences(
         yield tail
 
 
+STREAMING_TTS_CONCURRENCY = 2
+"""Cap for per-sentence TTS tasks running against one backend.
+
+Backends only guard model loading, not concurrent inference; without a
+cap a long LLM run can queue dozens of ``backend.generate`` coroutines
+against the same GPU/CPU worker and starve the process. Two in flight
+keeps sentence N+1 warm while the caller consumes sentence N without
+letting a burst pile up. Tunable by callers via the ``concurrency``
+parameter below.
+"""
+
+
 async def generate_streaming_from_sentences(
     backend,
     sentence_stream: AsyncIterator[str],
@@ -392,20 +404,30 @@ async def generate_streaming_from_sentences(
     seed: int | None = None,
     instruct: str | None = None,
     trim_fn=None,
+    concurrency: int = STREAMING_TTS_CONCURRENCY,
 ) -> AsyncIterator[Tuple[np.ndarray, int, str]]:
     """Fire per-sentence TTS as sentences arrive; yield ordered ``(audio, sr, sentence)``.
 
-    Each sentence is dispatched to ``backend.generate`` as an
-    ``asyncio.create_task`` the moment it lands, so sentence *N+1*'s TTS
-    starts running while sentence *N*'s audio is still being awaited by
-    the caller. The tasks are awaited in submission order, so the
-    yielded tuples arrive in the same order the sentences were produced
-    — the caller doesn't have to reorder anything.
+    Sentence *N+1*'s TTS starts while sentence *N*'s audio is still being
+    awaited by the caller, but the semaphore keeps at most ``concurrency``
+    tasks in flight so a burst of sentences from a fast LLM doesn't fan
+    out into dozens of parallel ``backend.generate`` calls. Tasks are
+    still awaited in submission order, so the yielded tuples arrive in
+    the same order the sentences were produced — callers don't have to
+    reorder anything.
 
-    The sentence text is echoed back alongside its audio so downstream
-    consumers (SSE-to-client streaming, progressive subtitles) don't
-    have to duplicate the buffer logic to keep them in sync.
+    On generator close / cancellation the ``finally`` block cancels every
+    outstanding task and waits for them so we never leak orphan work into
+    the event loop.
     """
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _run_tts(sentence: str, chunk_seed: int | None):
+        async with semaphore:
+            return await backend.generate(
+                sentence, voice_prompt, language, chunk_seed, instruct
+            )
+
     pending: List[Tuple[str, asyncio.Task]] = []
     index = 0
 
@@ -417,28 +439,35 @@ async def generate_streaming_from_sentences(
                 audio = trim_fn(audio, sr)
             yield np.asarray(audio, dtype=np.float32), sr, sent
 
-    async for sentence in sentence_stream:
-        # Vary the seed per sentence to avoid correlated RNG artefacts but
-        # keep it deterministic for a given (seed, sentence-index).
-        chunk_seed = (seed + index) if seed is not None else None
-        pending.append(
-            (
-                sentence,
-                asyncio.create_task(
-                    backend.generate(sentence, voice_prompt, language, chunk_seed, instruct)
-                ),
+    try:
+        async for sentence in sentence_stream:
+            # Vary the seed per sentence to avoid correlated RNG artefacts
+            # but keep it deterministic for a given (seed, sentence-index).
+            chunk_seed = (seed + index) if seed is not None else None
+            pending.append((sentence, asyncio.create_task(_run_tts(sentence, chunk_seed))))
+            index += 1
+
+            async for out in _drain_ready():
+                yield out
+
+        for sent, task in pending:
+            audio, sr = await task
+            if trim_fn is not None:
+                audio = trim_fn(audio, sr)
+            yield np.asarray(audio, dtype=np.float32), sr, sent
+        pending.clear()
+    finally:
+        # Consumer stopped early / cancellation raised — kill outstanding
+        # TTS work rather than orphaning it, then drain the coroutines so
+        # ``CancelledError`` propagates cleanly.
+        if pending:
+            for _, task in pending:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                *(task for _, task in pending), return_exceptions=True
             )
-        )
-        index += 1
-
-        async for out in _drain_ready():
-            yield out
-
-    for sent, task in pending:
-        audio, sr = await task
-        if trim_fn is not None:
-            audio = trim_fn(audio, sr)
-        yield np.asarray(audio, dtype=np.float32), sr, sent
+            pending.clear()
 
 
 async def generate_streaming_chunked(

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -392,34 +392,41 @@ async def generate_streaming_from_sentences(
     seed: int | None = None,
     instruct: str | None = None,
     trim_fn=None,
-) -> AsyncIterator[Tuple[np.ndarray, int]]:
-    """Fire per-sentence TTS as sentences arrive; yield ordered audio chunks.
+) -> AsyncIterator[Tuple[np.ndarray, int, str]]:
+    """Fire per-sentence TTS as sentences arrive; yield ordered ``(audio, sr, sentence)``.
 
     Each sentence is dispatched to ``backend.generate`` as an
     ``asyncio.create_task`` the moment it lands, so sentence *N+1*'s TTS
-    starts running while sentence *N*'s audio is still being awaited by the
-    caller. The tasks are awaited in submission order, so the yielded
-    ``(audio, sample_rate)`` tuples arrive in the same order the sentences
-    were produced — the caller doesn't have to reorder anything.
+    starts running while sentence *N*'s audio is still being awaited by
+    the caller. The tasks are awaited in submission order, so the
+    yielded tuples arrive in the same order the sentences were produced
+    — the caller doesn't have to reorder anything.
+
+    The sentence text is echoed back alongside its audio so downstream
+    consumers (SSE-to-client streaming, progressive subtitles) don't
+    have to duplicate the buffer logic to keep them in sync.
     """
-    pending: List[asyncio.Task] = []
+    pending: List[Tuple[str, asyncio.Task]] = []
     index = 0
 
-    async def _drain_ready() -> AsyncIterator[Tuple[np.ndarray, int]]:
-        while pending and pending[0].done():
-            task = pending.pop(0)
+    async def _drain_ready() -> AsyncIterator[Tuple[np.ndarray, int, str]]:
+        while pending and pending[0][1].done():
+            sent, task = pending.pop(0)
             audio, sr = task.result()
             if trim_fn is not None:
                 audio = trim_fn(audio, sr)
-            yield np.asarray(audio, dtype=np.float32), sr
+            yield np.asarray(audio, dtype=np.float32), sr, sent
 
     async for sentence in sentence_stream:
         # Vary the seed per sentence to avoid correlated RNG artefacts but
         # keep it deterministic for a given (seed, sentence-index).
         chunk_seed = (seed + index) if seed is not None else None
         pending.append(
-            asyncio.create_task(
-                backend.generate(sentence, voice_prompt, language, chunk_seed, instruct)
+            (
+                sentence,
+                asyncio.create_task(
+                    backend.generate(sentence, voice_prompt, language, chunk_seed, instruct)
+                ),
             )
         )
         index += 1
@@ -427,11 +434,11 @@ async def generate_streaming_from_sentences(
         async for out in _drain_ready():
             yield out
 
-    for task in pending:
+    for sent, task in pending:
         audio, sr = await task
         if trim_fn is not None:
             audio = trim_fn(audio, sr)
-        yield np.asarray(audio, dtype=np.float32), sr
+        yield np.asarray(audio, dtype=np.float32), sr, sent
 
 
 async def generate_streaming_chunked(
@@ -473,7 +480,7 @@ async def generate_streaming_chunked(
 
     audio_chunks: List[np.ndarray] = []
     sample_rate: int | None = None
-    async for audio, sr in generate_streaming_from_sentences(
+    async for audio, sr, _sentence in generate_streaming_from_sentences(
         tts_backend,
         sentence_stream,
         voice_prompt,

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -9,9 +9,10 @@ Short text (≤ max_chunk_chars) uses the single-shot fast path with zero
 overhead.
 """
 
+import asyncio
 import logging
 import re
-from typing import List, Tuple
+from typing import AsyncIterator, List, Tuple
 
 import numpy as np
 
@@ -102,6 +103,37 @@ def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) 
         remaining = remaining[split_pos + 1 :]
 
     return chunks
+
+
+def _find_first_sentence_end(text: str) -> int:
+    """Return the index of the *first* sentence-ending punctuation in ``text``.
+
+    Mirror of :func:`_find_last_sentence_end` but scans forward instead of
+    backward — used by the streaming pipeline, which needs to flush the
+    earliest complete sentence as soon as it lands so the TTS backend can
+    start on it while the LLM keeps generating.
+    """
+    ascii_positions: List[int] = []
+    for m in re.finditer(r"[.!?](?:\s|$)", text):
+        pos = m.start()
+        char = text[pos]
+        if char == ".":
+            word_start = pos - 1
+            while word_start >= 0 and text[word_start].isalpha():
+                word_start -= 1
+            word = text[word_start + 1 : pos].lower()
+            if word in _ABBREVIATIONS:
+                continue
+            if word_start >= 0 and text[word_start].isdigit():
+                continue
+        if _inside_bracket_tag(text, pos):
+            continue
+        ascii_positions.append(pos)
+
+    cjk_positions = [m.start() for m in re.finditer(r"[。！？]", text)]
+
+    all_positions = ascii_positions + cjk_positions
+    return min(all_positions) if all_positions else -1
 
 
 def _find_last_sentence_end(text: str) -> int:
@@ -294,6 +326,172 @@ async def generate_chunked(
         audio_chunks.append(np.asarray(chunk_audio, dtype=np.float32))
         if sample_rate is None:
             sample_rate = chunk_sr
+
+    audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=crossfade_ms)
+    return audio, sample_rate
+
+
+async def stream_sentences(
+    llm_stream: AsyncIterator[str],
+    max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+) -> AsyncIterator[str]:
+    """Buffer an LLM text stream and emit one complete sentence at a time.
+
+    Consumes ``llm_stream`` (typically ``LLMBackend.generate_stream``), keeps
+    a rolling text buffer, and yields as soon as a sentence-ending
+    punctuation lands inside it. If the buffer ever exceeds
+    ``max_chunk_chars`` without a sentence end, it flushes at a clause
+    boundary or whitespace so a runaway generation can't stall the TTS
+    pipeline forever. Trailing text (no punctuation on the last chunk)
+    is flushed at end-of-stream.
+    """
+    buffer = ""
+    async for delta in llm_stream:
+        if not delta:
+            continue
+        buffer += delta
+
+        while True:
+            # Preferred: a real sentence boundary.
+            end = _find_first_sentence_end(buffer)
+            if end != -1:
+                sentence = buffer[: end + 1].strip()
+                buffer = buffer[end + 1 :]
+                if sentence:
+                    yield sentence
+                continue
+
+            # Fallback: buffer got too long without punctuation. Cut at
+            # a clause boundary (or whitespace) so the TTS backend keeps
+            # moving even when the LLM produces one long run-on line.
+            if len(buffer) < max_chunk_chars:
+                break
+
+            segment = buffer[:max_chunk_chars]
+            cut = _find_last_clause_boundary(segment)
+            if cut == -1:
+                cut = segment.rfind(" ")
+            if cut == -1:
+                cut = _safe_hard_cut(segment, max_chunk_chars)
+
+            sentence = buffer[: cut + 1].strip()
+            buffer = buffer[cut + 1 :]
+            if sentence:
+                yield sentence
+
+    tail = buffer.strip()
+    if tail:
+        yield tail
+
+
+async def generate_streaming_from_sentences(
+    backend,
+    sentence_stream: AsyncIterator[str],
+    voice_prompt: dict,
+    language: str = "en",
+    seed: int | None = None,
+    instruct: str | None = None,
+    trim_fn=None,
+) -> AsyncIterator[Tuple[np.ndarray, int]]:
+    """Fire per-sentence TTS as sentences arrive; yield ordered audio chunks.
+
+    Each sentence is dispatched to ``backend.generate`` as an
+    ``asyncio.create_task`` the moment it lands, so sentence *N+1*'s TTS
+    starts running while sentence *N*'s audio is still being awaited by the
+    caller. The tasks are awaited in submission order, so the yielded
+    ``(audio, sample_rate)`` tuples arrive in the same order the sentences
+    were produced — the caller doesn't have to reorder anything.
+    """
+    pending: List[asyncio.Task] = []
+    index = 0
+
+    async def _drain_ready() -> AsyncIterator[Tuple[np.ndarray, int]]:
+        while pending and pending[0].done():
+            task = pending.pop(0)
+            audio, sr = task.result()
+            if trim_fn is not None:
+                audio = trim_fn(audio, sr)
+            yield np.asarray(audio, dtype=np.float32), sr
+
+    async for sentence in sentence_stream:
+        # Vary the seed per sentence to avoid correlated RNG artefacts but
+        # keep it deterministic for a given (seed, sentence-index).
+        chunk_seed = (seed + index) if seed is not None else None
+        pending.append(
+            asyncio.create_task(
+                backend.generate(sentence, voice_prompt, language, chunk_seed, instruct)
+            )
+        )
+        index += 1
+
+        async for out in _drain_ready():
+            yield out
+
+    for task in pending:
+        audio, sr = await task
+        if trim_fn is not None:
+            audio = trim_fn(audio, sr)
+        yield np.asarray(audio, dtype=np.float32), sr
+
+
+async def generate_streaming_chunked(
+    llm_backend,
+    tts_backend,
+    prompt: str,
+    voice_prompt: dict,
+    *,
+    system: str | None = None,
+    llm_max_tokens: int = 512,
+    llm_temperature: float = 0.7,
+    llm_model_size: str | None = None,
+    llm_examples: list[tuple[str, str]] | None = None,
+    language: str = "en",
+    seed: int | None = None,
+    instruct: str | None = None,
+    max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    crossfade_ms: int = 50,
+    trim_fn=None,
+) -> Tuple[np.ndarray, int]:
+    """End-to-end LLM stream → per-sentence TTS → concatenated audio.
+
+    Pulls text from ``llm_backend.generate_stream``, batches into sentences,
+    dispatches each sentence to ``tts_backend.generate`` as an asyncio task,
+    then concatenates the ordered audio chunks with a crossfade to remove
+    boundary clicks. First-audio-latency drops to roughly the LLM's
+    time-to-first-sentence plus one TTS chunk instead of the sum of the
+    two, which is the whole point of the streaming path.
+    """
+    llm_stream = llm_backend.generate_stream(
+        prompt,
+        system=system,
+        max_tokens=llm_max_tokens,
+        temperature=llm_temperature,
+        model_size=llm_model_size,
+        examples=llm_examples,
+    )
+    sentence_stream = stream_sentences(llm_stream, max_chunk_chars=max_chunk_chars)
+
+    audio_chunks: List[np.ndarray] = []
+    sample_rate: int | None = None
+    async for audio, sr in generate_streaming_from_sentences(
+        tts_backend,
+        sentence_stream,
+        voice_prompt,
+        language=language,
+        seed=seed,
+        instruct=instruct,
+        trim_fn=trim_fn,
+    ):
+        audio_chunks.append(audio)
+        if sample_rate is None:
+            sample_rate = sr
+
+    if sample_rate is None:
+        # Streaming produced no audio (empty LLM output). Callers that
+        # already validate against empty LLM output will have caught this
+        # upstream; returning an empty array keeps the type honest for
+        # anyone who didn't.
+        return np.array([], dtype=np.float32), 0
 
     audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=crossfade_ms)
     return audio, sample_rate


### PR DESCRIPTION
Depends on #947 (custom OpenAI-compat endpoint). This PR stacks on top of it — every commit from #947 is included, with the streaming work in the last eight.

Layers a streaming path onto the endpoint infrastructure from #947 so users pointed at an SSE-capable OpenAI-compat endpoint (llama.cpp server, vLLM, LM Studio, LocalAI, OpenAI, or a self-hosted engine like [ALICE-LLM](https://github.com/ext-sakamoro/ALICE-LLM)) hear the first sentence before the LLM has finished generating.

## Design

### Backend

- `LLMBackend.generate_stream()` + `supports_streaming()` added to the protocol. `OpenAICompatLLMBackend` implements a real SSE consumer via `httpx.AsyncClient.stream()` — yields `delta.content` strings as they arrive, honours the `[DONE]` sentinel. The built-in Qwen3 backends declare no streaming and fall back to a single-yield wrap of `generate()`.
- `chunked_tts` gains three async helpers: `stream_sentences` (LLM chunk iter → sentence iter), `generate_streaming_from_sentences` (fires per-sentence TTS as `asyncio.create_task`, yields ordered `(audio, sr, sentence)` 3-tuples), and `generate_streaming_chunked` end-to-end.
- `services.personality.rewrite_as_profile_stream` mirrors `rewrite_as_profile` but yields per-token deltas so the streaming TTS pipeline can start work before the LLM has finished restating the message.
- `services.generation.run_generation` grows a `personality_prompt` parameter. When set alongside a streaming-capable LLM backend, the background task runs the streaming pipeline instead of the sequential text → chunked TTS path. Backends without streaming ignore the parameter and take the existing route.
- **New \`POST /speak/stream\` route** returns \`text/event-stream\` — same profile / engine / personality resolution as \`/speak\`, but the response body is a sequence of SSE frames (\`meta\` → \`audio\` per sentence → \`complete\` → \`[DONE]\`). Audio is base64-encoded PCM float32 in a JSON payload; final concatenated audio still lands on disk and gets a generations-table row so History keeps working.

### Frontend

- \`apiClient.streamSpeak(params, onEvent, signal)\` opens the SSE stream with \`fetch\` + \`ReadableStream\`, parses SSE \`\\n\\n\` frame boundaries + repeated \`data:\` lines, dispatches events to a callback, and rejects with \`AbortError\` on user cancellation.
- \`useStreamingSpeak\` hook — state machine (idle → connecting → streaming → complete | error | aborted), single \`AudioContext\` opened lazily inside a user gesture, gap-less \`nextStartTime\` cursor so consecutive sentences abut with zero gap, \`playingIndex\` that only moves forward, unmount cleanup, \`AbortController\` cancellation.
- \`FloatingGenerateBox\` renders a secondary **Speak with streaming (β)** button whenever the user has both wired a custom endpoint AND selected a profile with a personality prompt set — the two conditions where the LLM+TTS overlap actually buys any latency. Otherwise the button stays hidden and the box looks exactly like it did before. Icon flips from \`AudioLines\` to \`Square\` while streaming; click aborts.

## Measured latency

Against a real streaming source (an OpenAI-compat SSE endpoint) with a mock TTS backend rendering each sentence in 500 ms, a two-sentence weather-forecast prompt reached first audio ~7 s earlier than the sequential LLM→TTS path (29 s vs 36 s wall clock). Real TTS engines (Kokoro, Chatterbox, Qwen CustomVoice) will amplify the total-time win too because their per-sentence latency is closer to the LLM's than the mock is.

## Testing

- **Backend**: module-layer end-to-end drives \`stream_speak_events\` against a real SSE endpoint + MockTTS and verifies the frame sequence (\`meta\` → \`audio × N\` → \`complete\` → \`[DONE]\`), base64 PCM round-trip, error-frame fallback, and generations-row persistence.
- SSE protocol verified via \`curl -N\` — per-token \`delta.content\` chunks arrive incrementally, terminal \`finish_reason\` chunk lands, and the non-streaming path (\`stream=false\`) preserves the existing \`ChatCompletionResponse\` shape.

**Not yet verified in-browser.** The UI parts (Web Audio scheduling, autoplay policy handling, subtitle rendering) follow the standard patterns for progressive audio playback but I don't have a Tauri dev environment set up here to click through the actual button. The (β) suffix on the label reflects that. Happy to iterate on visual issues once someone with the setup can play with it.

## Breaking changes / migration

None. \`POST /speak/stream\` is additive alongside \`POST /speak\`. The streaming path in \`run_generation\` only fires when the LLM backend reports \`supports_streaming=True\` AND \`personality=true\`; the existing sequential path is preserved otherwise, and the streaming button UI only appears when the two settings that make it useful are both on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming “Speak” with start/stop controls and progressive, sentence-by-sentence playback.
  * Added advanced custom LLM (OpenAI-compatible) settings for refinement/personality rewriting, including remote-vs-built-in status and API key replace/clear.
* **Bug Fixes**
  * Improved streaming reliability with proper cancellation/abort behavior and clearer mid-stream error feedback; results are persisted on successful completion.
* **Documentation**
  * Updated English and Japanese UI text for streaming controls and remote refinement descriptions.
* **Tests**
  * Added real OpenAI-compatible backend integration tests that automatically skip when not configured or unreachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->