### PR TITLE
fix(linux-audio): select monitor device by name instead of setting PULSE_SOURCE

### DIFF
--- a/tauri/src-tauri/src/audio_capture/linux.rs
+++ b/tauri/src-tauri/src/audio_capture/linux.rs
@@ -66,13 +66,46 @@ fn find_monitor_source_via_pactl() -> Option<String> {
     None
 }
 
+/// Select the capture device: prefer an exact match against the monitor
+/// source name reported by `pactl`, then fall back to any device whose name
+/// contains "monitor", then the host's default input device.
+fn select_capture_device(host: &cpal::Host, monitor_source: Option<&str>) -> Option<cpal::Device> {
+    let devices: Vec<cpal::Device> = host.input_devices().ok()?.collect();
+
+    if let Some(target) = monitor_source {
+        if let Some(pos) = devices
+            .iter()
+            .position(|d| d.name().map(|n| n == target).unwrap_or(false))
+        {
+            eprintln!(
+                "Linux audio capture: Using pactl monitor device: {}",
+                target
+            );
+            return devices.into_iter().nth(pos);
+        }
+    }
+
+    if let Some(pos) = devices.iter().position(|d| {
+        d.name()
+            .map(|n| n.to_lowercase().contains("monitor"))
+            .unwrap_or(false)
+    }) {
+        let name = devices[pos].name().unwrap_or_default();
+        eprintln!("Linux audio capture: Found monitor device by name: {}", name);
+        return devices.into_iter().nth(pos);
+    }
+
+    eprintln!("Linux audio capture: No monitor device found, falling back to default input");
+    host.default_input_device()
+}
+
 /// Start capturing system audio on Linux using PulseAudio monitor sources.
 ///
 /// On modern Linux with PulseAudio or PipeWire, we first try to detect the
-/// monitor source via `pactl` and set the `PULSE_SOURCE` environment variable.
-/// This tells PulseAudio's ALSA plugin to use the monitor as the default input
-/// source for this process. If `pactl` is unavailable, we fall back to searching
-/// cpal device names for "monitor".
+/// monitor source via `pactl`, then select the matching cpal input device by
+/// name. This avoids mutating the process environment (`PULSE_SOURCE`), which
+/// is not thread-safe and would affect every thread in the process. If `pactl`
+/// is unavailable, we fall back to searching cpal device names for "monitor".
 pub async fn start_capture(
     state: &AudioCaptureState,
     max_duration_secs: u32,
@@ -101,73 +134,16 @@ pub async fn start_capture(
 
     // Spawn capture on a dedicated thread
     thread::spawn(move || {
-        // Try to set PULSE_SOURCE to a monitor before initializing cpal.
-        // This tells PulseAudio/PipeWire's ALSA plugin to use the monitor
-        // as the default input source for this process.
-        let monitor_source = find_monitor_source_via_pactl();
-        if let Some(ref source_name) = monitor_source {
-            eprintln!(
-                "Linux audio capture: Setting PULSE_SOURCE={}",
-                source_name
-            );
-            std::env::set_var("PULSE_SOURCE", source_name);
-        }
-
         let host = cpal::default_host();
+        let monitor_source = find_monitor_source_via_pactl();
 
-        // Select the capture device.
-        // If PULSE_SOURCE was set, the default input device IS the monitor.
-        // Otherwise, fall back to searching device names for "monitor".
-        let device = if monitor_source.is_some() {
-            // PULSE_SOURCE was set — default input IS the monitor now
-            match host.default_input_device() {
-                Some(d) => {
-                    let name = d.name().unwrap_or_default();
-                    eprintln!(
-                        "Linux audio capture: Using PULSE_SOURCE monitor device: {}",
-                        name
-                    );
-                    d
-                }
-                None => {
-                    let error_msg = "No audio input device available".to_string();
-                    eprintln!("{}", error_msg);
-                    *error_arc.lock().unwrap() = Some(error_msg);
-                    return;
-                }
-            }
-        } else {
-            // pactl not available — try to find monitor by name (original approach)
-            let mut monitor_device = None;
-            if let Ok(devices) = host.input_devices() {
-                for d in devices {
-                    if let Ok(name) = d.name() {
-                        let name_lower = name.to_lowercase();
-                        if name_lower.contains("monitor") {
-                            eprintln!(
-                                "Linux audio capture: Found monitor device by name: {}",
-                                name
-                            );
-                            monitor_device = Some(d);
-                            break;
-                        }
-                    }
-                }
-            }
-            match monitor_device {
-                Some(d) => d,
-                None => {
-                    eprintln!("Linux audio capture: No monitor device found, falling back to default input");
-                    match host.default_input_device() {
-                        Some(d) => d,
-                        None => {
-                            let error_msg = "No audio input device available".to_string();
-                            eprintln!("{}", error_msg);
-                            *error_arc.lock().unwrap() = Some(error_msg);
-                            return;
-                        }
-                    }
-                }
+        let device = match select_capture_device(&host, monitor_source.as_deref()) {
+            Some(d) => d,
+            None => {
+                let error_msg = "No audio input device available".to_string();
+                eprintln!("{}", error_msg);
+                *error_arc.lock().unwrap() = Some(error_msg);
+                return;
             }
         };
 


### PR DESCRIPTION
## Problem

Fixes #471.

The Linux audio capture path called `std::env::set_var("PULSE_SOURCE", ...)` from inside a spawned capture thread to steer PulseAudio's ALSA plugin toward the monitor source. Two issues, both called out in #471:

- `std::env::set_var` is not thread-safe on Unix — the underlying `setenv`/`environ` aren't safe to call while other threads (tokio runtime, webview, Tauri plugins) may read the environment. Rust 2024 edition marks it `unsafe fn` for this reason.
- The var was never unset, so it could leak into any later cpal/ALSA init in the same process.

## Fix

Removed the env-var mutation entirely. When `pactl` reports a monitor source name, `select_capture_device` now searches cpal's own `input_devices()` enumeration for a device whose name matches exactly. This is the "pass the source name directly to cpal" option suggested in the issue — it turns out cpal already lists monitor sources as regular input devices by name (the existing pactl-unavailable fallback path already relied on this via a substring search), so no PulseAudio-side indirection is needed at all.

Fallback order is unchanged in spirit:
1. Exact match against the pactl-reported monitor name
2. Any device whose name contains "monitor" (the original fallback)
3. Host default input device

This still re-detects the current default sink's monitor on every `start_capture` call, so switching audio output mid-session is picked up correctly (this behaviour is preserved, not regressed).

## Testing

I don't have a Linux box with PulseAudio/PipeWire handy to exercise this live, so I focused on making the change minimal and mechanically equivalent to the existing (working) fallback path, which already proves cpal enumerates monitor devices by name on this backend. Happy to adjust if you can test against real hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux audio capture device selection for monitor sources.
  * Added fallback handling to use a matching monitor device, the first available monitor, or the default input device.
  * Improved error reporting when no suitable capture device is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->