### PR TITLE
fix(key_codes): add Function key arm so macOS fn can be bound to a chord

### DIFF
--- a/tauri/src-tauri/src/key_codes.rs
+++ b/tauri/src-tauri/src/key_codes.rs
@@ -30,6 +30,7 @@ pub fn key_from_str(name: &str) -> Option<Key> {
         "ShiftLeft" => Key::ShiftLeft,
         "ShiftRight" => Key::ShiftRight,
         "CapsLock" => Key::CapsLock,
+        "Function" => Key::Function,
 
         // Whitespace / navigation
         "Space" => Key::Space,


### PR DESCRIPTION
Fixes #941.

## Problem

`key_from_str()` in `tauri/src-tauri/src/key_codes.rs` had no arm for `"Function"`, so it fell through to `None`. `build_chord` propagates that `None` as a hard `Err` via `?`, so any chord containing `fn` made `build_chord_bindings` fail entirely — `HotkeyMonitor` was never spawned, silently disabling **both** push-to-talk and toggle-to-talk until the chord was changed back to a mapped key. No error is logged either, since the failure happens before the "ChordMatcher build failed" log line would run.

Every other layer already supports it:
- `keytap::Key::Function` exists (confirmed in `jamiepine/keytap`'s `src/key.rs`)
- keytap's macOS key tap already observes it (`kVK_Function` → `Key::Function`)
- the frontend's `canonicalKeyFromEvent`/`displayLabelForKey` already allowlist/label `'Function'` → `'fn'`

Only this string→`Key` bridge was missing the arm.

## Fix

One arm, exactly as suggested in the issue:

```rust
"Function" => Key::Function,
```

## Testing

There's no existing test suite for `key_codes.rs` (no `#[test]` module in the file), so I didn't add test scaffolding beyond the scope of this one-line fix. I don't have a Mac to verify the chord end-to-end, but the fix is a direct, mechanical addition matching the pattern of every other key arm in the same match block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling by recognizing the canonical “Function” key name when restoring saved key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->