### PR TITLE
fix(docker): normalize CRLF line endings on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+package.json text eol=lf
+scripts/*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ COPY package.json bun.lock CHANGELOG.md ./
 COPY app/ ./app/
 COPY web/ ./web/
 
-# Strip workspaces not needed for web build, and fix trailing comma
-RUN sed -i '/"tauri"/d; /"landing"/d' package.json && \
+# Normalize line endings first (a Windows CRLF checkout would otherwise
+# defeat the `-z 's/,\n  ]/…/'` match below, since it's LF-anchored), then
+# strip workspaces not needed for web build, and fix trailing comma
+RUN sed -i 's/\r$//' package.json && \
+    sed -i '/"tauri"/d; /"landing"/d' package.json && \
     sed -i -z 's/,\n  ]/\n  ]/' package.json
 RUN bun install --no-save
 # Build frontend (skip tsc — upstream has pre-existing type errors)
@@ -100,7 +103,11 @@ EXPOSE 17493
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
     CMD curl -f http://localhost:17493/health || exit 1
 
-# Entrypoint joins GPU groups then drops to the voicebox user
+# Entrypoint joins GPU groups then drops to the voicebox user.
+# Normalize CRLF (a Windows checkout otherwise leaves the shebang as
+# `#!/bin/sh\r`, which Linux can't resolve — reported as a misleading
+# "no such file or directory" even though the file exists).
 COPY --chmod=755 scripts/rocm-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "17493"]


### PR DESCRIPTION
Fixes #915.

## Problem

A Windows Git checkout with checkout-time CRLF conversion enabled produces CRLF working-tree copies of `package.json` and `scripts/rocm-entrypoint.sh`, breaking `docker compose build`/`up` two independent ways:

1. **Frontend build**: the trailing-comma fixup `sed -i -z 's/,\n  ]/\n  ]/'` is LF-anchored and doesn't match `,\r\n  ]`, so the `"web",` entry's trailing comma survives after `"tauri"`/`"landing"` are stripped, producing invalid JSON that fails the Vite build (`JSON does not support trailing commas`).
2. **Runtime entrypoint**: the final stage copies `scripts/rocm-entrypoint.sh` straight from the build context. With a CRLF shebang, the effective interpreter path becomes `/bin/sh\r`, which Linux can't resolve — surfaced as the misleading `exec /usr/local/bin/entrypoint.sh: no such file or directory` even though the file is right there.

## Fix

Two parts, both suggested in the issue:

1. Added `.gitattributes` forcing LF for both files at checkout time going forward:
   ```gitattributes
   package.json text eol=lf
   scripts/*.sh text eol=lf
   ```
2. Added a `sed -i 's/\r$//'` normalization step in each Dockerfile stage (before the trailing-comma fixup, and right after copying the entrypoint script) for resilience with clones that predate the `.gitattributes` rule.

## Testing

I don't have a Windows machine to reproduce the CRLF checkout directly, so I verified the regex behavior conceptually: `sed`'s `-z` mode splits on NUL only, so `\r` before the matched `\n` is preserved as part of the "non-newline" content and defeats the pattern's `,\n` anchor exactly as described. I didn't run the full `docker compose build` end-to-end. Happy to adjust if you can verify against a real CRLF checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform build reliability by normalizing line endings in package configuration and startup scripts.
  * Prevented issues caused by Windows-style CRLF files during container builds and GPU runtime startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->