### PR TITLE
fix(macos): set Command flag on Cmd-down event so Electron apps paste

### DIFF
--- a/tauri/src-tauri/src/synthetic_keys.rs
+++ b/tauri/src-tauri/src/synthetic_keys.rs
@@ -4,10 +4,14 @@
 //! pipeline so the focused app performs its native paste action against
 //! whatever the clipboard module has just staged.
 //!
-//! - **macOS** — Cmd down, V down with Cmd flag, V up with Cmd flag, Cmd
-//!   up via `CGEventPost` at `kCGHIDEventTap`. Accessibility permission is
-//!   load-bearing: without it the system swallows the events silently, so
-//!   callers must gate on [`crate::accessibility::is_trusted`].
+//! - **macOS** — Cmd down with Cmd flag, V down with Cmd flag, V up with
+//!   Cmd flag, Cmd up via `CGEventPost` at `kCGHIDEventTap`. The Cmd-down
+//!   event carries the Command flag so its `flagsChanged` representation
+//!   matches hardware — Electron/Chromium tracks modifier state from that
+//!   flag and drops the paste otherwise (see the note on the event table).
+//!   Accessibility permission is load-bearing: without it the system
+//!   swallows the events silently, so callers must gate on
+//!   [`crate::accessibility::is_trusted`].
 //! - **Windows** — Ctrl down, V down, V up, Ctrl up via `SendInput`. No
 //!   permission gate, but UAC/UIPI blocks delivery into elevated target
 //!   windows when we run non-elevated — nothing we can do short of also
@@ -101,7 +105,18 @@ pub fn send_paste() -> Result<(), String> {
         let _source_guard = scopeguard::guard(source, |s| CFRelease(s as *const c_void));
 
         let events = [
-            (KEYCODE_LEFT_CMD, true, 0),
+            // The Cmd-down event must carry the Command flag itself. On real
+            // hardware the Cmd keyDown is a flagsChanged event whose flags
+            // already include Command; Chromium/Electron builds its tracked
+            // modifier state from that flag. Posting Cmd-down with flags = 0
+            // leaves that tracker showing "Command up", so the following V —
+            // even though its own flags carry Command — matches neither the
+            // Cmd+V accelerator (tracker says no modifier) nor plain-text
+            // insertion (event flags say Command), and Electron drops it
+            // silently. AppKit reads the V event's own flags and pastes
+            // regardless, which is why native apps worked but Electron
+            // targets (Slack, VS Code) silently no-op'd.
+            (KEYCODE_LEFT_CMD, true, K_CG_EVENT_FLAG_MASK_COMMAND),
             (v_keycode, true, K_CG_EVENT_FLAG_MASK_COMMAND),
             (v_keycode, false, K_CG_EVENT_FLAG_MASK_COMMAND),
             (KEYCODE_LEFT_CMD, false, 0),


### PR DESCRIPTION
## Summary

macOS auto-paste silently fails in Electron/Chromium apps (Slack, VS Code, VS Code Insiders) while working fine in native apps (Notes, TextEdit, Warp). One-line root cause in the synthetic-key sequence.

## Repro

- macOS 27.0, VoiceBox 0.5.0, auto-paste enabled, Accessibility + Input Monitoring granted (verified; `tccutil reset` + re-grant made no difference).
- Dictate → transcript is correct → auto-paste **lands in native apps** (Notes, TextEdit, Warp) but is **silently dropped in Electron apps** (Slack, VS Code / VS Code Insiders — both the editor and the integrated terminal).
- Manual ⌘V into those same Electron apps pastes correctly, so the clipboard is being staged fine — only the synthetic keystroke is lost.
- Secure Event Input ruled out: `ioreg -l -w 0 | grep -i SecureInput` returns nothing.
- Notably: **no stray `v` is typed** either — nothing happens at all.

## Root cause

In `tauri/src-tauri/src/synthetic_keys.rs`, the macOS `send_paste` sequence posted the **Cmd-down** event with `flags = 0`, setting `kCGEventFlagMaskCommand` only on the V events:

```rust
let events = [
    (KEYCODE_LEFT_CMD, true, 0),                       // Cmd down — flags = 0
    (v_keycode, true,  K_CG_EVENT_FLAG_MASK_COMMAND),
    (v_keycode, false, K_CG_EVENT_FLAG_MASK_COMMAND),
    (KEYCODE_LEFT_CMD, false, 0),
];
```

On real hardware the Cmd keyDown is a `flagsChanged` event whose flags already include Command, and Chromium/Electron builds its **tracked modifier state** from that flag. With `flags = 0` the tracker stays at "Command up," so the following V:

- **does not match the Cmd+V accelerator** — Chromium dispatches shortcuts from its tracked modifier state, which says no modifier is held; and
- **is not inserted as text** either — the V event's own flags *do* carry Command, so Chromium suppresses character insertion.

It falls in the gap and is dropped silently — which is exactly why there's no paste **and** no stray `v`. AppKit, by contrast, pastes off the V keyDown's own `modifierFlags`, so native apps were unaffected. This cleanly explains the native-works / Electron-fails split.

## Fix

Set `kCGEventFlagMaskCommand` on the Cmd-down event so its `flagsChanged` representation matches hardware. Chromium then registers Command=down and Cmd+V matches.

```rust
(KEYCODE_LEFT_CMD, true, K_CG_EVENT_FLAG_MASK_COMMAND),  // was: flags = 0
```

Likely also fixes #762 and #643.

## Testing notes

I was not able to build the Tauri/Rust app in my environment, so this change is **not yet runtime-verified** — it's a targeted, self-contained fix backed by the CGEvent/Chromium modifier-tracking analysis above. Appreciate a maintainer confirming a paste into Slack + VS Code on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste reliability on macOS in Chromium- and Electron-based apps.
  * Corrected Command-key state tracking during synthetic paste actions to prevent paste operations from being dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->