### PR TITLE
fix(ui): parse naive-UTC timestamps consistently in formatAbsoluteDate

### DIFF
--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -25,27 +25,30 @@ function getDateLocale() {
   }
 }
 
-export function formatDate(date: string | Date): string {
-  let dateObj: Date;
-  if (typeof date === 'string') {
-    const dateStr = date.trim();
-    if (!dateStr.includes('Z') && !dateStr.match(/[+-]\d{2}:\d{2}$/)) {
-      dateObj = new Date(`${dateStr}Z`);
-    } else {
-      dateObj = new Date(dateStr);
-    }
-  } else {
-    dateObj = date;
+// Backend timestamps are naive UTC (Python `datetime.utcnow()`), serialized
+// without a timezone suffix. Per the ES spec such date-only/date-time strings
+// are parsed as *local* time, so we append `Z` to force UTC when no timezone
+// is present. Used by every server-timestamp formatter for consistency.
+function parseServerDate(date: string | Date): Date {
+  if (typeof date !== 'string') {
+    return date;
   }
+  const dateStr = date.trim();
+  if (!dateStr.includes('Z') && !dateStr.match(/[+-]\d{2}:\d{2}$/)) {
+    return new Date(`${dateStr}Z`);
+  }
+  return new Date(dateStr);
+}
 
-  return formatDistance(dateObj, new Date(), {
+export function formatDate(date: string | Date): string {
+  return formatDistance(parseServerDate(date), new Date(), {
     addSuffix: true,
     locale: getDateLocale(),
   }).replace(/^about /i, '');
 }
 
 export function formatAbsoluteDate(date: string | Date): string {
-  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  const dateObj = parseServerDate(date);
   return dateObj.toLocaleString(i18n.language, {
     month: 'short',
     day: 'numeric',

--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -25,12 +25,8 @@ function getDateLocale() {
   }
 }
 
-// Backend timestamps are naive UTC (Python `datetime.utcnow()`), serialized
-// as a timezone-less date-time string (e.g. "2026-07-23T10:00:00"). Per the
-// ES spec such date-time strings are parsed as *local* time (unlike date-only
-// strings such as "2026-07-23", which are parsed as UTC), so we append `Z` to
-// force UTC when no timezone is present. Used by every server-timestamp
-// formatter for consistency.
+// Backend timestamps are naive UTC — append `Z` so JS doesn't parse a
+// timezone-less date-time string as local time.
 function parseServerDate(date: string | Date): Date {
   if (typeof date !== 'string') {
     return date;

--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -26,9 +26,11 @@ function getDateLocale() {
 }
 
 // Backend timestamps are naive UTC (Python `datetime.utcnow()`), serialized
-// without a timezone suffix. Per the ES spec such date-only/date-time strings
-// are parsed as *local* time, so we append `Z` to force UTC when no timezone
-// is present. Used by every server-timestamp formatter for consistency.
+// as a timezone-less date-time string (e.g. "2026-07-23T10:00:00"). Per the
+// ES spec such date-time strings are parsed as *local* time (unlike date-only
+// strings such as "2026-07-23", which are parsed as UTC), so we append `Z` to
+// force UTC when no timezone is present. Used by every server-timestamp
+// formatter for consistency.
 function parseServerDate(date: string | Date): Date {
   if (typeof date !== 'string') {
     return date;


### PR DESCRIPTION
## Problem

`formatAbsoluteDate` and `formatDate` (in `app/src/lib/utils/format.ts`) interpret timezone-less timestamp strings differently.

Backend timestamps are naive UTC — stored via Python `datetime.utcnow()` (`backend/database/models.py`) and serialized without a timezone suffix (e.g. `"2026-07-23T10:00:00"`). Per the [ES spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#date_time_string_format), such date-time strings are parsed as **local time**.

- `formatDate` handles this: it appends `Z` when no timezone is present, so the value is parsed as UTC. ✅
- `formatAbsoluteDate` called `new Date(date)` directly, so the same value was parsed as local time — showing the wrong absolute time, off by the viewer's UTC offset (e.g. **+9h in JST**). ❌

Because both formatters are used on the **same** `capture.created_at` in the Captures tab — `formatDate` in the list and `formatAbsoluteDate` in the detail panel (`CapturesTab.tsx`) — the relative and absolute times disagree for one recording.

This looks like an oversight from commit `47e4da7`, which added the UTC normalization to `formatDate` but not to `formatAbsoluteDate`.

## Fix

Extract the normalization into a shared `parseServerDate` helper and use it in both formatters. `formatDate`'s behavior is unchanged; `formatAbsoluteDate` now interprets naive-UTC timestamps correctly.

## Testing

- `biome check app/src/lib/utils/format.ts` passes.
- `formatDate` logic is preserved verbatim (just extracted); only `formatAbsoluteDate` changes behavior, now matching `formatDate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date/time rendering for timestamps returned by the server.
  * Timestamps that don’t include timezone information are now interpreted consistently as UTC.
  * Relative (“about …”) and absolute date/time formatting remain consistent, with improved normalization to ensure accuracy across formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->