### PR TITLE
fix(backend): guard avatar upload against a missing filename

### DIFF
--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -232,7 +232,7 @@ async def upload_profile_avatar(
     db: Session = Depends(get_db),
 ):
     """Upload or update avatar image for a profile."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=Path(file.filename).suffix) as tmp:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=Path(file.filename or "").suffix) as tmp:
         content = await file.read()
         tmp.write(content)
         tmp_path = tmp.name


### PR DESCRIPTION
## Problem

`POST /profiles/{profile_id}/avatar` builds the temp-file suffix from `Path(file.filename).suffix`:

```python
with tempfile.NamedTemporaryFile(delete=False, suffix=Path(file.filename).suffix) as tmp:
```

`UploadFile.filename` can be `None` (a multipart part without a `filename`), and `Path(None)` raises `TypeError`. This line runs **before** the `try`/`except`, so the error isn't converted to a clean 4xx — the request fails with an unhandled **500**.

Every other upload handler in the codebase already guards this exact case with `file.filename or ""`:

- `add_profile_sample` — `routes/profiles.py:162`
- `transcribe` — `routes/transcription.py:30`
- audio import — `routes/generations.py:415`

The avatar endpoint is the lone inconsistency.

## Fix

One line — apply the same guard:

```python
suffix=Path(file.filename or "").suffix
```

A filename-less upload now yields an empty suffix (handled downstream by `upload_avatar`, which validates the image) instead of crashing with a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar uploads when no filename is provided.
  * Prevented upload failures caused by missing file extension information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->