### PR TITLE
fix(export): disambiguate export filenames with generation id

### DIFF
--- a/app/src/lib/hooks/useHistory.ts
+++ b/app/src/lib/hooks/useHistory.ts
@@ -47,12 +47,14 @@ export function useExportGeneration() {
     mutationFn: async ({ generationId, text }: { generationId: string; text: string }) => {
       const blob = await apiClient.exportGeneration(generationId);
 
-      // Create safe filename from text
+      // Create safe filename from text. Append a short id so exports of
+      // similarly-worded generations don't collide on the same filename
+      // (the first 30 chars are frequently identical).
       const safeText = text
         .substring(0, 30)
         .replace(/[^a-z0-9]/gi, '-')
         .toLowerCase();
-      const filename = `generation-${safeText}.voicebox.zip`;
+      const filename = `generation-${safeText}-${generationId.substring(0, 8)}.voicebox.zip`;
 
       await platform.filesystem.saveFile(filename, blob, [
         {
@@ -73,12 +75,14 @@ export function useExportGenerationAudio() {
     mutationFn: async ({ generationId, text }: { generationId: string; text: string }) => {
       const blob = await apiClient.exportGenerationAudio(generationId);
 
-      // Create safe filename from text
+      // Create safe filename from text. Append a short id so exports of
+      // similarly-worded generations don't collide on the same filename
+      // (the first 30 chars are frequently identical).
       const safeText = text
         .substring(0, 30)
         .replace(/[^a-z0-9]/gi, '-')
         .toLowerCase();
-      const filename = `${safeText}.wav`;
+      const filename = `${safeText}-${generationId.substring(0, 8)}.wav`;
 
       await platform.filesystem.saveFile(filename, blob, [
         {

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -151,7 +151,9 @@ async def export_generation(
     safe_text = "".join(c for c in generation.text[:30] if c.isalnum() or c in (" ", "-", "_")).strip()
     if not safe_text:
         safe_text = "generation"
-    filename = f"generation-{safe_text}.voicebox.zip"
+    # Append a short id so exports of similarly-worded generations don't collide
+    # on the same filename (the first 30 chars are frequently identical).
+    filename = f"generation-{safe_text}-{generation_id[:8]}.voicebox.zip"
 
     return StreamingResponse(
         io.BytesIO(zip_bytes),
@@ -180,7 +182,9 @@ async def export_generation_audio(
     safe_text = "".join(c for c in generation.text[:30] if c.isalnum() or c in (" ", "-", "_")).strip()
     if not safe_text:
         safe_text = "generation"
-    filename = f"{safe_text}.wav"
+    # Append a short id so exports of similarly-worded generations don't collide
+    # on the same filename (the first 30 chars are frequently identical).
+    filename = f"{safe_text}-{generation_id[:8]}.wav"
 
     return FileResponse(
         audio_path,


### PR DESCRIPTION
## Problem

Export filenames are derived from only the first 30 characters of the generation text:

- `backend/routes/history.py` — `Content-Disposition` for `/history/{id}/export-audio` (`{text}.wav`) and `/history/{id}/export` (`generation-{text}.voicebox.zip`)
- `app/src/lib/hooks/useHistory.ts` — the filename passed to `platform.filesystem.saveFile` in both export hooks

When iterating on the same line — a very common workflow — generations share the same 30-char prefix and therefore get **identical filenames**. Exporting several of them collides on disk: the browser appends ` (1)`/` (2)`, and users end up opening audio that doesn't match the filename, which looks like the app exported the wrong audio.

### Reproduction

Two distinct generations whose text both starts with *"Martina se fai la brava stasera puoi rientrare domani…"*:

| Generation | Size | md5 | Filename (before) |
| --- | --- | --- | --- |
| `95ac48a0…` | 311 KB | `63967a68…` | `Martina se fai la brava staser.wav` |
| `4ed9b3cc…` | 200 KB | `0c404d44…` | `Martina se fai la brava staser.wav` |

Different audio, identical filename.

## Fix

Append the first 8 characters of the generation id to the `.wav` and `.voicebox.zip` export filenames, in both the backend `Content-Disposition` headers and the frontend save-file hooks.

After the fix:

```
95ac48a0 -> Martina se fai la brava staser-95ac48a0.wav
4ed9b3cc -> Martina se fai la brava staser-4ed9b3cc.wav
```

## Testing

- Verified both `/export-audio` and `/export` now return unique `Content-Disposition` filenames for the colliding pair above, against a running backend.
- `tsc -p app/tsconfig.json --noEmit` — passes.
- `biome lint` on the changed file — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported Voicebox ZIP and WAV files now include a unique identifier in their filenames.
  * Prevented files from being unintentionally overwritten when exports have similar text or names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->