### PR TITLE
fix(transcription): transcode uploads to WAV before STT (fixes WebM dictation)

### DIFF
--- a/backend/routes/transcription.py
+++ b/backend/routes/transcription.py
@@ -35,12 +35,24 @@ async def transcribe_audio(
             tmp.write(chunk)
         tmp_path = tmp.name
 
+    stt_path = tmp_path
     try:
-        from ..utils.audio import load_audio
+        from ..utils.audio import load_audio, save_audio
         from ..backends import WHISPER_HF_REPOS
 
         audio, sr = await asyncio.to_thread(load_audio, tmp_path)
         duration = len(audio) / sr
+
+        # The STT backend (mlx_audio.stt -> miniaudio) only decodes
+        # WAV/FLAC/MP3/Vorbis, so browser recordings uploaded as WebM/Opus
+        # fail with "unsupported file format" (issue: web-mode dictation).
+        # librosa already decoded the file above (it falls back to
+        # audioread/ffmpeg for exotic containers), so re-encode that PCM to a
+        # temp WAV and hand *that* to Whisper. WAV inputs pass through
+        # unchanged.
+        if file_suffix != ".wav":
+            stt_path = f"{tmp_path}.stt.wav"
+            await asyncio.to_thread(save_audio, audio, stt_path, sr)
 
         whisper_model = transcribe.get_whisper_model()
         model_size = model if model else whisper_model.model_size
@@ -76,7 +88,7 @@ async def transcribe_audio(
                 },
             )
 
-        text = await whisper_model.transcribe(tmp_path, language, model_size)
+        text = await whisper_model.transcribe(stt_path, language, model_size)
 
         return models.TranscriptionResponse(
             text=text,
@@ -89,3 +101,5 @@ async def transcribe_audio(
         raise HTTPException(status_code=500, detail=str(e))
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+        if stt_path != tmp_path:
+            Path(stt_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

`POST /transcribe` fails with **500 `unsupported file format`** for WebM/Opus uploads — which is exactly what Chrome and Firefox `MediaRecorder` produce. In web mode (`just dev-web`), in-app dictation and the "record reference" flow are therefore broken.

Root cause: the route decodes the upload with librosa **only to compute the duration**, then hands the *original, undecoded* file to `whisper_model.transcribe(tmp_path, …)`. The STT backend (`mlx_audio.stt` → **miniaudio**) only decodes WAV/FLAC/MP3/Vorbis, so WebM blows up. The Tauri desktop app was unaffected because WebKit's `MediaRecorder` emits MP4, not WebM.

### Reproduction (before)

Same 6.95 s audio in three containers, against a running backend:

| Upload | Result |
| --- | --- |
| `.webm` | ❌ `{"detail":"unsupported file format"}` |
| `.m4a` | ✅ transcribed |
| `.wav` | ✅ transcribed |

## Fix

librosa already fully decodes the upload for the duration calculation (it falls back to audioread/ffmpeg for exotic containers). Re-encode that in-memory PCM to a temp WAV and pass **that** to Whisper. WAV inputs pass through unchanged; the temp WAV is removed in the `finally` block. No new dependencies — it reuses the decode that already happens.

### After

| Upload | Result |
| --- | --- |
| `.webm` | ✅ transcribed (identical text to `.m4a`/`.wav`) |
| `.m4a` | ✅ |
| `.wav` | ✅ |

## Testing

- Verified all three formats return identical transcripts against a running backend (MLX/Apple Silicon).
- Confirmed no `*.stt.wav` temp files are leaked after requests.
- `ruff check` introduces no new warnings (the two pre-existing ones on this file are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded audio transcription support to accept additional upload formats by automatically converting them to WAV when needed.

- **Bug Fixes**
  - Improved transcription reliability for non-WAV audio files.
  - Added cleanup handling for temporary converted audio files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->