### PR TITLE
fix(docs): update quick start guide to reflect current terminology for voice profiles

### DIFF
--- a/docs/content/docs/overview/quick-start.mdx
+++ b/docs/content/docs/overview/quick-start.mdx
@@ -14,12 +14,12 @@ Make sure you have [installed Voicebox](/overview/installation) and launched the
 Voice profiles are the foundation of Voicebox. Each profile contains voice samples that the AI uses to clone the voice.
 
 <Steps>
-  <Step title="Navigate to Profiles">
-    Click the **Profiles** tab in the sidebar
+  <Step title="Navigate to Voices">
+    Click the **Voices** tab in the sidebar
   </Step>
 
-  <Step title="Create New Profile">
-    Click the **+ New Profile** button
+  <Step title="Create New Voice">
+    Click the **+ New Voice** button
 
     Fill in the details:
     - **Name:** A descriptive name (e.g., "John Smith")


### PR DESCRIPTION
Updating the quick start guide terminology to reflect the current UI labels where `Profiles` was changed to `Voices`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start guide with the current navigation path and button labels for creating a voice profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->