### PR TITLE
fix(cache): don't treat orphaned .incomplete blobs as an in-progress download

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -47,11 +47,18 @@ def is_model_cached(
         if not repo_cache.exists():
             return False
 
-        # Incomplete blobs mean a download is still in progress
+        # An .incomplete blob means a download is still in progress -- unless
+        # a completed blob with the same hash already sits next to it, which
+        # happens when a retried/concurrent download leaves a stale .incomplete
+        # behind after the real transfer already finished. Only orphaned
+        # .incomplete files (no matching completed blob) count as "in progress".
         blobs_dir = repo_cache / "blobs"
-        if blobs_dir.exists() and any(blobs_dir.glob("*.incomplete")):
-            logger.debug(f"Found .incomplete files for {hf_repo}")
-            return False
+        if blobs_dir.exists():
+            for incomplete in blobs_dir.glob("*.incomplete"):
+                completed = incomplete.with_name(incomplete.name.removesuffix(".incomplete"))
+                if not completed.exists():
+                    logger.debug(f"Found in-progress .incomplete file for {hf_repo}")
+                    return False
 
         snapshots_dir = repo_cache / "snapshots"
         if not snapshots_dir.exists():

--- a/backend/tests/test_is_model_cached.py
+++ b/backend/tests/test_is_model_cached.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for ``is_model_cached``'s handling of stale ``.incomplete`` blobs.
+
+A retried or concurrent download can leave an orphaned ``.incomplete`` file
+next to its now-completed counterpart (same blob hash, no suffix). Only a
+genuinely in-progress download -- an ``.incomplete`` with no completed blob
+alongside it -- should mark the model as not cached.
+
+``is_model_cached`` is extracted and exec'd standalone (instead of importing
+``backend.backends.base``) so this test doesn't pull in the module's sibling
+imports (audio/progress/hf_progress/tasks), which in turn require the full
+ML stack (torch/transformers/librosa/fastapi/...) this pure filesystem check
+never touches.
+"""
+
+import ast
+import logging
+from pathlib import Path
+from typing import Optional
+
+_SOURCE = (Path(__file__).parent.parent / "backends" / "base.py").read_text()
+_MODULE = ast.parse(_SOURCE)
+_FUNC_SRC = next(
+    ast.get_source_segment(_SOURCE, node)
+    for node in _MODULE.body
+    if isinstance(node, ast.FunctionDef) and node.name == "is_model_cached"
+)
+
+_namespace = {
+    "Path": Path,
+    "Optional": Optional,
+    "logger": logging.getLogger("test_is_model_cached"),
+}
+exec(_FUNC_SRC, _namespace)  # noqa: S102
+is_model_cached = _namespace["is_model_cached"]
+
+
+def _make_repo_cache(tmp_path, repo="org/model"):
+    repo_dir = tmp_path / ("models--" + repo.replace("/", "--"))
+    blobs_dir = repo_dir / "blobs"
+    snapshots_dir = repo_dir / "snapshots" / "abc123"
+    blobs_dir.mkdir(parents=True)
+    snapshots_dir.mkdir(parents=True)
+    return repo_dir, blobs_dir, snapshots_dir
+
+
+def test_orphaned_incomplete_blob_does_not_block_cache_hit(tmp_path, monkeypatch):
+    import huggingface_hub.constants as hf_constants
+
+    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(tmp_path))
+
+    repo = "org/model"
+    _, blobs_dir, snapshots_dir = _make_repo_cache(tmp_path, repo)
+
+    completed_blob = blobs_dir / "deadbeef"
+    completed_blob.write_bytes(b"weights")
+    (blobs_dir / "deadbeef.incomplete").write_bytes(b"stale partial")
+    (snapshots_dir / "model.safetensors").symlink_to(completed_blob)
+
+    assert is_model_cached(repo) is True
+
+
+def test_genuinely_in_progress_download_is_not_cached(tmp_path, monkeypatch):
+    import huggingface_hub.constants as hf_constants
+
+    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(tmp_path))
+
+    repo = "org/model"
+    _, blobs_dir, snapshots_dir = _make_repo_cache(tmp_path, repo)
+
+    (blobs_dir / "feedface.incomplete").write_bytes(b"partial")
+    (snapshots_dir / "config.json").write_text("{}")
+
+    assert is_model_cached(repo) is False


### PR DESCRIPTION
## Summary

`is_model_cached()` marks a model as not-cached whenever *any* `.incomplete` blob exists in its HF cache dir, even when a completed blob with the same hash already sits right next to it. A retried or concurrent download (e.g. the model gets loaded from the app while a separate `hf download`/backend process is also touching the same cache) can leave this kind of orphaned `.incomplete` file behind after the real transfer already finished.

Once that happens, the model looks perpetually "downloading" and the backend re-triggers a full re-download on every load — even though the weights are already on disk and valid. I hit this locally with Whisper Turbo after the model had already loaded successfully once.

## Fix

Only `.incomplete` files with no matching completed blob (same hash, no suffix) now count as a genuinely in-progress download. If the completed blob is already there, the orphan is ignored for cache-detection purposes (it's not deleted — just no longer treated as blocking).

## Verification

- Added `backend/tests/test_is_model_cached.py`:
  - `test_orphaned_incomplete_blob_does_not_block_cache_hit` — completed blob + stale `.incomplete` sibling → still detected as cached
  - `test_genuinely_in_progress_download_is_not_cached` → still correctly detected as not-cached
- `pytest backend/tests/test_is_model_cached.py -v` — 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model cache detection to ignore stale download artifacts when a complete model is already available.
  - Models with genuinely unfinished downloads are still correctly reported as incomplete.
  - Prevented unnecessary model downloads when a valid cached copy exists.

- **Tests**
  - Added coverage for completed models with leftover download files.
  - Added coverage confirming active, incomplete downloads are not treated as cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->