### PR TITLE
chore: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *$py.class
 *.so
 .Python
+.venv/
 venv/
 env/
 ENV/


### PR DESCRIPTION
Add `.venv/` to `.gitignore` alongside the existing `venv/` entry. The backend setup uses `python -m venv backend/.venv` (the modern convention) but that path was not covered, causing it to appear as an untracked file. Single-line change, no functional impact.