### PR TITLE
feat: add MiniMax cloud TTS engine

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -216,6 +216,7 @@ TTS_ENGINES = {
     "chatterbox_turbo": "Chatterbox Turbo",
     "tada": "TADA",
     "kokoro": "Kokoro",
+    "minimax": "MiniMax TTS",
 }
 
 LLM_ENGINES = {
@@ -553,6 +554,13 @@ async def ensure_model_cached_or_raise(engine: str, model_size: str = "default")
                 status_code=400,
                 detail=f"Model {model_size} is not downloaded yet. Use /generate to trigger a download.",
             )
+    elif engine == "minimax":
+        # MiniMax is a cloud API — "cached" means the API key is configured.
+        if not backend._is_model_cached():
+            raise HTTPException(
+                status_code=400,
+                detail="MINIMAX_API_KEY is not configured. Set it in your environment or ~/.env.local.",
+            )
     else:
         if not backend._is_model_cached():
             display = cfg.display_name if cfg else engine
@@ -723,6 +731,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 
             backend = QwenCustomVoiceBackend()
+        elif engine == "minimax":
+            from .minimax_backend import MiniMaxTTSBackend
+
+            backend = MiniMaxTTSBackend()
         else:
             raise ValueError(f"Unknown TTS engine: {engine}. Supported: {list(TTS_ENGINES.keys())}")
 

--- a/backend/backends/minimax_backend.py
+++ b/backend/backends/minimax_backend.py
@@ -1,0 +1,348 @@
+"""
+MiniMax cloud TTS backend implementation.
+
+Unlike the local engines, this backend does not download a model — it calls
+the MiniMax Text-to-Audio (T2A) HTTP API and decodes the returned audio to a
+numpy float32 array. It plugs into the same ``TTSBackend`` protocol as the
+local engines, so long-text chunking, trimming and profile handling all work
+unchanged.
+
+Regions:
+  - ``global_en`` (default): https://api.minimax.io/v1/t2a_v2
+  - ``cn_zh``:               https://api.minimaxi.com/v1/t2a_v2
+  Select with the ``MINIMAX_API_REGION`` environment variable.
+
+Speech models (``MINIMAX_TTS_MODELS``) all share the same request shape; the
+default is ``speech-2.8-hd``. Audio is requested as hex-encoded data in the
+synchronous response (``data.audio``) and decoded locally — ``pcm`` is decoded
+directly to float32 with no codec dependency, while ``mp3`` / ``wav`` / ``flac``
+are decoded through soundfile.
+
+Voices are preset MiniMax system voices. Voice cloning is intentionally out of
+scope for this backend.
+
+Requirements:
+  - ``MINIMAX_API_KEY`` environment variable (or ``~/.env.local``)
+  - httpx (already in requirements.txt)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+
+import numpy as np
+
+from .base import combine_voice_prompts as _combine_voice_prompts
+
+logger = logging.getLogger(__name__)
+
+# Regional API endpoints — the global and mainland-China hosts expose the same
+# request/response shape and differ only in the base host.
+MINIMAX_ENDPOINTS: dict[str, str] = {
+    "global_en": "https://api.minimax.io/v1/t2a_v2",
+    "cn_zh": "https://api.minimaxi.com/v1/t2a_v2",
+}
+MINIMAX_DEFAULT_REGION = "global_en"
+
+# Speech models, newest first. All use the same T2A request shape.
+MINIMAX_TTS_MODELS = [
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+    "speech-2.6-hd",
+    "speech-2.6-turbo",
+    "speech-02-hd",
+    "speech-02-turbo",
+    "speech-01-hd",
+    "speech-01-turbo",
+]
+MINIMAX_TTS_DEFAULT_MODEL = "speech-2.8-hd"
+
+# Supported synchronous-response audio formats.
+MINIMAX_AUDIO_FORMATS = ["mp3", "wav", "flac", "pcm"]
+MINIMAX_DEFAULT_FORMAT = "pcm"
+
+# 32 kHz mono is a good default for speech and is supported by every model.
+MINIMAX_DEFAULT_SAMPLE_RATE = 32000
+
+MINIMAX_DEFAULT_VOICE = "English_Graceful_Lady"
+
+# Preset system voices: (voice_id, display_name, gender, language).
+MINIMAX_VOICES: list[tuple[str, str, str, str]] = [
+    ("English_Graceful_Lady", "Graceful Lady", "female", "en"),
+    ("English_radiant_girl", "Radiant Girl", "female", "en"),
+    ("English_expressive_narrator", "Expressive Narrator", "female", "en"),
+    ("English_Insightful_Speaker", "Insightful Speaker", "male", "en"),
+    ("English_Persuasive_Man", "Persuasive Man", "male", "en"),
+    ("English_Lucky_Robot", "Lucky Robot", "male", "en"),
+    ("Chinese_Gentle_and_Clear", "Gentle and Clear", "female", "zh"),
+    ("Chinese_Elegant_Lady", "Elegant Lady", "female", "zh"),
+    ("Chinese_Intellectual_Female", "Intellectual Female", "female", "zh"),
+    ("Chinese_Energetic_Boy", "Energetic Boy", "male", "zh"),
+    ("Chinese_Magnetic_Male", "Magnetic Male", "male", "zh"),
+]
+
+# Map our ISO language codes to MiniMax ``language_boost`` names. Unmapped
+# languages fall back to "auto" so MiniMax detects the language itself.
+LANGUAGE_BOOST_MAP = {
+    "en": "English",
+    "zh": "Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "de": "German",
+    "fr": "French",
+    "ru": "Russian",
+    "pt": "Portuguese",
+    "es": "Spanish",
+    "it": "Italian",
+}
+
+
+def resolve_region(region: str | None = None) -> str:
+    """Resolve the MiniMax API region, honouring ``MINIMAX_API_REGION``.
+
+    Falls back to the global endpoint for unknown or missing values.
+    """
+    candidate = region or os.environ.get("MINIMAX_API_REGION") or MINIMAX_DEFAULT_REGION
+    candidate = candidate.strip().lower()
+    if candidate not in MINIMAX_ENDPOINTS:
+        return MINIMAX_DEFAULT_REGION
+    return candidate
+
+
+def get_endpoint(region: str | None = None) -> str:
+    """Return the T2A endpoint URL for the resolved region."""
+    return MINIMAX_ENDPOINTS[resolve_region(region)]
+
+
+def _load_api_key() -> str | None:
+    """Load ``MINIMAX_API_KEY`` from the environment or ``~/.env.local``."""
+    key = os.environ.get("MINIMAX_API_KEY")
+    if key:
+        return key
+
+    env_local = os.path.expanduser("~/.env.local")
+    if os.path.exists(env_local):
+        try:
+            with open(env_local) as fh:
+                for raw_line in fh:
+                    line = raw_line.strip()
+                    if line.startswith("MINIMAX_API_KEY="):
+                        val = line[len("MINIMAX_API_KEY=") :].strip().strip("\"'")
+                        if val:
+                            return val
+        except OSError:
+            pass
+
+    return None
+
+
+def _decode_audio(audio_bytes: bytes, audio_format: str, sample_rate: int) -> tuple[np.ndarray, int]:
+    """Decode MiniMax audio bytes into a float32 array.
+
+    ``pcm`` is signed 16-bit little-endian and is decoded directly. Container
+    formats (mp3/wav/flac) are decoded through soundfile, which reports the
+    real sample rate from the stream.
+    """
+    if not audio_bytes:
+        return np.zeros(sample_rate, dtype=np.float32), sample_rate
+
+    if audio_format == "pcm":
+        audio_int16 = np.frombuffer(audio_bytes, dtype="<i2")
+        return audio_int16.astype(np.float32) / 32768.0, sample_rate
+
+    import soundfile as sf
+
+    audio, sr = sf.read(io.BytesIO(audio_bytes), dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    return audio.astype(np.float32), int(sr)
+
+
+class MiniMaxTTSBackend:
+    """MiniMax cloud TTS backend — no local model, one HTTP call per request.
+
+    The backend is "loaded" whenever the API key is available; ``load_model``
+    only validates that the key is present so callers get an early, clear error
+    instead of an opaque HTTP 401.
+    """
+
+    def __init__(self) -> None:
+        self._api_key: str | None = None
+        self.model_size = "default"
+
+    # -- Protocol helpers -----------------------------------------------------
+
+    def is_loaded(self) -> bool:
+        """Return True once the API key has been located."""
+        if self._api_key is None:
+            self._api_key = _load_api_key()
+        return bool(self._api_key)
+
+    def _get_model_path(self, model_size: str = "default") -> str:
+        """No local model — report the active API endpoint instead."""
+        return get_endpoint()
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        """For a cloud API, "cached" means the API key is configured."""
+        return self.is_loaded()
+
+    def unload_model(self) -> None:
+        """No-op: a cloud backend has nothing to unload."""
+
+    # -- Model loading --------------------------------------------------------
+
+    async def load_model(self, model_size: str = "default") -> None:
+        """Validate that the API key is configured; nothing is downloaded."""
+        if self._api_key is None:
+            self._api_key = _load_api_key()
+        if not self._api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not set. Add it to your environment or to ~/.env.local.")
+        logger.info("MiniMax TTS backend ready (cloud API, no local model)")
+
+    # -- Voice prompt API -----------------------------------------------------
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> tuple[dict, bool]:
+        """Return the default preset voice.
+
+        MiniMax uses preset system voices rather than reference audio. Preset
+        profiles build the voice prompt in the profile service and never reach
+        this method; it exists only as a safe fallback.
+        """
+        return {
+            "voice_type": "preset",
+            "preset_engine": "minimax",
+            "preset_voice_id": MINIMAX_DEFAULT_VOICE,
+        }, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
+        """Combine reference clips — delegates to the shared audio utility."""
+        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=MINIMAX_DEFAULT_SAMPLE_RATE)
+
+    # -- Core generation ------------------------------------------------------
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: int | None = None,
+        instruct: str | None = None,
+    ) -> tuple[np.ndarray, int]:
+        """Synthesize speech through the MiniMax T2A API.
+
+        Args:
+            text: Text to synthesize.
+            voice_prompt: Dict carrying at least ``preset_voice_id``. Optional
+                keys ``tts_model``, ``audio_format``, ``sample_rate``, ``speed``,
+                ``vol`` and ``pitch`` override the request controls.
+            language: ISO language code, mapped to ``language_boost``.
+            seed: Ignored — the T2A API does not expose a seed.
+            instruct: Ignored — not supported by the T2A API.
+
+        Returns:
+            Tuple of (audio_array float32, sample_rate).
+        """
+        await self.load_model()
+
+        voice_id = voice_prompt.get("preset_voice_id") or MINIMAX_DEFAULT_VOICE
+
+        model = voice_prompt.get("tts_model") or MINIMAX_TTS_DEFAULT_MODEL
+        if model not in MINIMAX_TTS_MODELS:
+            model = MINIMAX_TTS_DEFAULT_MODEL
+
+        audio_format = voice_prompt.get("audio_format") or MINIMAX_DEFAULT_FORMAT
+        if audio_format not in MINIMAX_AUDIO_FORMATS:
+            audio_format = MINIMAX_DEFAULT_FORMAT
+
+        sample_rate = int(voice_prompt.get("sample_rate") or MINIMAX_DEFAULT_SAMPLE_RATE)
+        payload = self._build_payload(text, voice_id, model, audio_format, sample_rate, language, voice_prompt)
+
+        audio_bytes = await asyncio.to_thread(self._generate_sync, payload)
+        return await asyncio.to_thread(_decode_audio, audio_bytes, audio_format, sample_rate)
+
+    def _build_payload(
+        self,
+        text: str,
+        voice_id: str,
+        model: str,
+        audio_format: str,
+        sample_rate: int,
+        language: str,
+        voice_prompt: dict,
+    ) -> dict:
+        """Assemble the T2A request body from the supported request controls."""
+        return {
+            "model": model,
+            "text": text,
+            "stream": False,
+            "output_format": "hex",
+            "language_boost": LANGUAGE_BOOST_MAP.get(language, "auto"),
+            "voice_setting": {
+                "voice_id": voice_id,
+                "speed": float(voice_prompt.get("speed", 1.0)),
+                "vol": float(voice_prompt.get("vol", 1.0)),
+                "pitch": int(voice_prompt.get("pitch", 0)),
+            },
+            "audio_setting": {
+                "sample_rate": sample_rate,
+                "format": audio_format,
+                "channel": 1,
+            },
+        }
+
+    def _generate_sync(self, payload: dict) -> bytes:
+        """Blocking T2A call. Returns the raw (decoded-from-hex) audio bytes."""
+        import httpx
+
+        api_key = self._api_key or _load_api_key()
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not configured.")
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        url = get_endpoint()
+
+        with httpx.Client(timeout=60.0) as client:
+            resp = client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            body = resp.json()
+
+        return self._parse_response(body)
+
+    @staticmethod
+    def _parse_response(body: dict) -> bytes:
+        """Validate ``base_resp`` and decode the hex audio from ``data.audio``."""
+        base_resp = body.get("base_resp") or {}
+        status_code = base_resp.get("status_code", 0)
+        if status_code != 0:
+            msg = base_resp.get("status_msg", "Unknown error")
+            raise RuntimeError(f"MiniMax TTS API error {status_code}: {msg}")
+
+        data = body.get("data") or {}
+        audio_hex = data.get("audio")
+        if not audio_hex:
+            raise RuntimeError(
+                "MiniMax TTS API returned no audio data. Check your MINIMAX_API_KEY and request parameters."
+            )
+
+        try:
+            audio_bytes = bytes.fromhex(audio_hex)
+        except ValueError as exc:
+            raise RuntimeError("MiniMax TTS API returned malformed audio data.") from exc
+
+        logger.debug("MiniMax TTS: decoded %d bytes of audio", len(audio_bytes))
+        return audio_bytes

--- a/backend/backends/minimax_backend.py
+++ b/backend/backends/minimax_backend.py
@@ -18,8 +18,9 @@ synchronous response (``data.audio``) and decoded locally — ``pcm`` is decoded
 directly to float32 with no codec dependency, while ``mp3`` / ``wav`` / ``flac``
 are decoded through soundfile.
 
-Voices are preset MiniMax system voices. Voice cloning is intentionally out of
-scope for this backend.
+Voices can use MiniMax system presets or the existing cloned-profile workflow.
+Cloned profiles upload their reference audio once, create a deterministic
+MiniMax voice ID, and cache that ID for subsequent synthesis requests.
 
 Requirements:
   - ``MINIMAX_API_KEY`` environment variable (or ``~/.env.local``)
@@ -32,9 +33,11 @@ import asyncio
 import io
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 
+from ..utils.cache import cache_voice_prompt, get_cache_key, get_cached_voice_prompt
 from .base import combine_voice_prompts as _combine_voice_prompts
 
 logger = logging.getLogger(__name__)
@@ -44,6 +47,14 @@ logger = logging.getLogger(__name__)
 MINIMAX_ENDPOINTS: dict[str, str] = {
     "global_en": "https://api.minimax.io/v1/t2a_v2",
     "cn_zh": "https://api.minimaxi.com/v1/t2a_v2",
+}
+MINIMAX_FILE_UPLOAD_ENDPOINTS: dict[str, str] = {
+    "global_en": "https://api.minimax.io/v1/files/upload",
+    "cn_zh": "https://api.minimaxi.com/v1/files/upload",
+}
+MINIMAX_VOICE_CLONE_ENDPOINTS: dict[str, str] = {
+    "global_en": "https://api.minimax.io/v1/voice_clone",
+    "cn_zh": "https://api.minimaxi.com/v1/voice_clone",
 }
 MINIMAX_DEFAULT_REGION = "global_en"
 
@@ -59,6 +70,13 @@ MINIMAX_TTS_MODELS = [
     "speech-01-turbo",
 ]
 MINIMAX_TTS_DEFAULT_MODEL = "speech-2.8-hd"
+MINIMAX_VOICE_CLONE_MODELS = [
+    "speech-2.8-hd",
+    "speech-2.6-hd",
+    "speech-02-hd",
+    "speech-01-hd",
+]
+MINIMAX_VOICE_CLONE_DEFAULT_MODEL = "speech-2.8-hd"
 
 # Supported synchronous-response audio formats.
 MINIMAX_AUDIO_FORMATS = ["mp3", "wav", "flac", "pcm"]
@@ -115,6 +133,16 @@ def resolve_region(region: str | None = None) -> str:
 def get_endpoint(region: str | None = None) -> str:
     """Return the T2A endpoint URL for the resolved region."""
     return MINIMAX_ENDPOINTS[resolve_region(region)]
+
+
+def get_file_upload_endpoint(region: str | None = None) -> str:
+    """Return the file-upload endpoint URL for the resolved region."""
+    return MINIMAX_FILE_UPLOAD_ENDPOINTS[resolve_region(region)]
+
+
+def get_voice_clone_endpoint(region: str | None = None) -> str:
+    """Return the voice-clone endpoint URL for the resolved region."""
+    return MINIMAX_VOICE_CLONE_ENDPOINTS[resolve_region(region)]
 
 
 def _load_api_key() -> str | None:
@@ -210,17 +238,27 @@ class MiniMaxTTSBackend:
         reference_text: str,
         use_cache: bool = True,
     ) -> tuple[dict, bool]:
-        """Return the default preset voice.
+        """Upload reference audio and create a reusable MiniMax cloned voice."""
+        await self.load_model()
 
-        MiniMax uses preset system voices rather than reference audio. Preset
-        profiles build the voice prompt in the profile service and never reach
-        this method; it exists only as a safe fallback.
-        """
-        return {
-            "voice_type": "preset",
-            "preset_engine": "minimax",
-            "preset_voice_id": MINIMAX_DEFAULT_VOICE,
-        }, False
+        audio_hash = get_cache_key(audio_path, reference_text)
+        cache_key = f"minimax_{audio_hash}" if use_cache else None
+        if cache_key:
+            cached = get_cached_voice_prompt(cache_key)
+            if isinstance(cached, dict) and cached.get("voice_id"):
+                return cached, True
+
+        requested_voice_id = f"voicebox_{audio_hash[:24]}"
+        voice_id = await asyncio.to_thread(self._create_cloned_voice_sync, audio_path, requested_voice_id)
+        voice_prompt = {
+            "voice_type": "cloned",
+            "voice_id": voice_id,
+        }
+
+        if cache_key:
+            cache_voice_prompt(cache_key, voice_prompt)
+
+        return voice_prompt, False
 
     async def combine_voice_prompts(
         self,
@@ -228,7 +266,55 @@ class MiniMaxTTSBackend:
         reference_texts: list[str],
     ) -> tuple[np.ndarray, str]:
         """Combine reference clips — delegates to the shared audio utility."""
-        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=MINIMAX_DEFAULT_SAMPLE_RATE)
+        return await _combine_voice_prompts(audio_paths, reference_texts, sample_rate=24000)
+
+    def _create_cloned_voice_sync(self, audio_path: str, requested_voice_id: str) -> str:
+        """Upload reference audio, create a cloned voice, and return its ID."""
+        import httpx
+
+        api_key = self._api_key or _load_api_key()
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not configured.")
+
+        authorization = {"Authorization": f"Bearer {api_key}"}
+        with httpx.Client(timeout=60.0) as client:
+            with open(audio_path, "rb") as audio_file:
+                upload_response = client.post(
+                    get_file_upload_endpoint(),
+                    headers=authorization,
+                    data={"purpose": "voice_clone"},
+                    files={"file": (Path(audio_path).name, audio_file)},
+                )
+            upload_response.raise_for_status()
+            upload_body = upload_response.json()
+
+            upload_status = (upload_body.get("base_resp") or {}).get("status_code", 0)
+            if upload_status != 0:
+                message = (upload_body.get("base_resp") or {}).get("status_msg", "Unknown error")
+                raise RuntimeError(f"MiniMax file upload API error {upload_status}: {message}")
+
+            file_id = (upload_body.get("file") or {}).get("file_id")
+            if file_id is None:
+                raise RuntimeError("MiniMax file upload API returned no file_id.")
+
+            clone_response = client.post(
+                get_voice_clone_endpoint(),
+                headers={**authorization, "Content-Type": "application/json"},
+                json={
+                    "file_id": file_id,
+                    "voice_id": requested_voice_id,
+                    "model": MINIMAX_VOICE_CLONE_DEFAULT_MODEL,
+                },
+            )
+            clone_response.raise_for_status()
+            clone_body = clone_response.json()
+
+        clone_status = (clone_body.get("base_resp") or {}).get("status_code", 0)
+        if clone_status not in (0, 2039):
+            message = (clone_body.get("base_resp") or {}).get("status_msg", "Unknown error")
+            raise RuntimeError(f"MiniMax voice clone API error {clone_status}: {message}")
+
+        return clone_body.get("voice_id") or requested_voice_id
 
     # -- Core generation ------------------------------------------------------
 
@@ -256,7 +342,7 @@ class MiniMaxTTSBackend:
         """
         await self.load_model()
 
-        voice_id = voice_prompt.get("preset_voice_id") or MINIMAX_DEFAULT_VOICE
+        voice_id = voice_prompt.get("voice_id") or voice_prompt.get("preset_voice_id") or MINIMAX_DEFAULT_VOICE
 
         model = voice_prompt.get("tts_model") or MINIMAX_TTS_DEFAULT_MODEL
         if model not in MINIMAX_TTS_MODELS:
@@ -283,7 +369,7 @@ class MiniMaxTTSBackend:
         voice_prompt: dict,
     ) -> dict:
         """Assemble the T2A request body from the supported request controls."""
-        return {
+        payload = {
             "model": model,
             "text": text,
             "stream": False,
@@ -301,6 +387,10 @@ class MiniMaxTTSBackend:
                 "channel": 1,
             },
         }
+        for field in ("pronunciation_dict", "voice_modify", "subtitle_enable"):
+            if field in voice_prompt:
+                payload[field] = voice_prompt[field]
+        return payload
 
     def _generate_sync(self, payload: dict) -> bytes:
         """Blocking T2A call. Returns the raw (decoded-from-hex) audio bytes."""

--- a/backend/models.py
+++ b/backend/models.py
@@ -85,7 +85,7 @@ class GenerationRequest(BaseModel):
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro|minimax)$")
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -104,6 +104,21 @@ async def list_preset_voices(engine: str):
                 for speaker_id, display_name, gender, lang, _desc in QWEN_CUSTOM_VOICES
             ],
         }
+    if engine == "minimax":
+        from ..backends.minimax_backend import MINIMAX_VOICES
+
+        return {
+            "engine": engine,
+            "voices": [
+                {
+                    "voice_id": voice_id,
+                    "name": name,
+                    "gender": gender,
+                    "language": lang,
+                }
+                for voice_id, name, gender, lang in MINIMAX_VOICES
+            ],
+        }
     return {"engine": engine, "voices": []}
 
 @router.get("/profiles/{profile_id}", response_model=models.VoiceProfileResponse)

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -24,7 +24,7 @@ from ..utils.images import process_avatar, validate_image
 
 logger = logging.getLogger(__name__)
 
-CLONING_ENGINES = {"qwen", "luxtts", "chatterbox", "chatterbox_turbo", "tada"}
+CLONING_ENGINES = {"qwen", "luxtts", "chatterbox", "chatterbox_turbo", "tada", "minimax"}
 
 
 def _profile_to_response(

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -73,6 +73,11 @@ def _get_preset_voice_ids(engine: str) -> set[str]:
 
         return {voice_id for voice_id, _name, _gender, _lang, _desc in QWEN_CUSTOM_VOICES}
 
+    if engine == "minimax":
+        from ..backends.minimax_backend import MINIMAX_VOICES
+
+        return {voice_id for voice_id, _name, _gender, _lang in MINIMAX_VOICES}
+
     return set()
 
 

--- a/backend/tests/test_minimax_backend.py
+++ b/backend/tests/test_minimax_backend.py
@@ -13,12 +13,18 @@ from backend.backends.minimax_backend import (
     MINIMAX_DEFAULT_FORMAT,
     MINIMAX_DEFAULT_VOICE,
     MINIMAX_ENDPOINTS,
+    MINIMAX_FILE_UPLOAD_ENDPOINTS,
     MINIMAX_TTS_DEFAULT_MODEL,
     MINIMAX_TTS_MODELS,
+    MINIMAX_VOICE_CLONE_DEFAULT_MODEL,
+    MINIMAX_VOICE_CLONE_ENDPOINTS,
+    MINIMAX_VOICE_CLONE_MODELS,
     MINIMAX_VOICES,
     MiniMaxTTSBackend,
     _decode_audio,
     get_endpoint,
+    get_file_upload_endpoint,
+    get_voice_clone_endpoint,
     resolve_region,
 )
 
@@ -40,6 +46,14 @@ def test_model_catalog_covers_current_speech_models():
     ):
         assert expected in MINIMAX_TTS_MODELS
 
+    assert MINIMAX_VOICE_CLONE_DEFAULT_MODEL == "speech-2.8-hd"
+    assert MINIMAX_VOICE_CLONE_MODELS == [
+        "speech-2.8-hd",
+        "speech-2.6-hd",
+        "speech-02-hd",
+        "speech-01-hd",
+    ]
+
 
 def test_audio_formats_and_default():
     assert MINIMAX_AUDIO_FORMATS == ["mp3", "wav", "flac", "pcm"]
@@ -57,6 +71,10 @@ def test_default_voice_is_a_known_preset():
 def test_regions_expose_both_hosts():
     assert MINIMAX_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/t2a_v2"
     assert MINIMAX_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/t2a_v2"
+    assert MINIMAX_FILE_UPLOAD_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/files/upload"
+    assert MINIMAX_FILE_UPLOAD_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/files/upload"
+    assert MINIMAX_VOICE_CLONE_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/voice_clone"
+    assert MINIMAX_VOICE_CLONE_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/voice_clone"
 
 
 def test_resolve_region_default_is_global(monkeypatch):
@@ -69,6 +87,8 @@ def test_resolve_region_honours_env(monkeypatch):
     monkeypatch.setenv("MINIMAX_API_REGION", "cn_zh")
     assert resolve_region() == "cn_zh"
     assert get_endpoint() == MINIMAX_ENDPOINTS["cn_zh"]
+    assert get_file_upload_endpoint() == MINIMAX_FILE_UPLOAD_ENDPOINTS["cn_zh"]
+    assert get_voice_clone_endpoint() == MINIMAX_VOICE_CLONE_ENDPOINTS["cn_zh"]
 
 
 def test_resolve_region_falls_back_on_unknown(monkeypatch):
@@ -90,6 +110,9 @@ def test_build_payload_uses_requested_controls():
         "speed": 1.25,
         "vol": 0.8,
         "pitch": 2,
+        "pronunciation_dict": {"tone": ["MiniMax/(min-ee-max)"]},
+        "voice_modify": {"pitch": 1},
+        "subtitle_enable": True,
     }
     payload = backend._build_payload("hello", "English_Persuasive_Man", "speech-2.6-turbo", "mp3", 24000, "en", prompt)
     assert payload["model"] == "speech-2.6-turbo"
@@ -103,6 +126,9 @@ def test_build_payload_uses_requested_controls():
         "pitch": 2,
     }
     assert payload["audio_setting"] == {"sample_rate": 24000, "format": "mp3", "channel": 1}
+    assert payload["pronunciation_dict"] == prompt["pronunciation_dict"]
+    assert payload["voice_modify"] == prompt["voice_modify"]
+    assert payload["subtitle_enable"] is True
 
 
 def test_build_payload_unknown_language_uses_auto():
@@ -184,14 +210,14 @@ async def test_generate_returns_decoded_audio(monkeypatch):
 
     monkeypatch.setattr(backend, "_generate_sync", fake_generate_sync)
 
-    prompt = {"preset_voice_id": MINIMAX_DEFAULT_VOICE, "tts_model": "speech-2.8-turbo"}
+    prompt = {"voice_id": "voicebox_12345678", "tts_model": "speech-2.8-turbo"}
     audio, sr = await backend.generate("hello world", prompt, language="en")
 
     assert sr == 32000
     assert audio.dtype == np.float32
     assert audio.shape == (3,)
     assert captured["payload"]["model"] == "speech-2.8-turbo"
-    assert captured["payload"]["voice_setting"]["voice_id"] == MINIMAX_DEFAULT_VOICE
+    assert captured["payload"]["voice_setting"]["voice_id"] == "voicebox_12345678"
 
 
 async def test_generate_falls_back_for_unknown_model(monkeypatch):
@@ -211,10 +237,81 @@ async def test_generate_falls_back_for_unknown_model(monkeypatch):
     assert captured["payload"]["audio_setting"]["format"] == MINIMAX_DEFAULT_FORMAT
 
 
-async def test_create_voice_prompt_returns_default_preset():
+async def test_create_voice_prompt_clones_and_caches_reference_audio(tmp_path, monkeypatch):
+    audio_path = tmp_path / "reference.wav"
+    audio_path.write_bytes(b"reference-audio")
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-placeholder")
+
     backend = MiniMaxTTSBackend()
-    prompt, cached = await backend.create_voice_prompt("ignored.wav", "ref text")
+    captured = {}
+
+    def fake_create_cloned_voice(audio_path, requested_voice_id):
+        captured["audio_path"] = audio_path
+        captured["requested_voice_id"] = requested_voice_id
+        return requested_voice_id
+
+    monkeypatch.setattr(backend, "_create_cloned_voice_sync", fake_create_cloned_voice)
+    monkeypatch.setattr("backend.backends.minimax_backend.get_cached_voice_prompt", lambda _key: None)
+    monkeypatch.setattr(
+        "backend.backends.minimax_backend.cache_voice_prompt",
+        lambda key, prompt: captured.update(cache_key=key, cached_prompt=prompt),
+    )
+
+    prompt, cached = await backend.create_voice_prompt(str(audio_path), "ref text")
     assert cached is False
-    assert prompt["voice_type"] == "preset"
-    assert prompt["preset_engine"] == "minimax"
-    assert prompt["preset_voice_id"] == MINIMAX_DEFAULT_VOICE
+    assert prompt["voice_type"] == "cloned"
+    assert prompt["voice_id"].startswith("voicebox_")
+    assert captured["audio_path"] == str(audio_path)
+    assert captured["requested_voice_id"] == prompt["voice_id"]
+    assert captured["cache_key"].startswith("minimax_")
+    assert captured["cached_prompt"] == prompt
+
+
+def test_create_cloned_voice_uploads_audio_and_requests_clone(tmp_path, monkeypatch):
+    audio_path = tmp_path / "reference.wav"
+    audio_path.write_bytes(b"reference-audio")
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-placeholder")
+
+    requests = []
+
+    class FakeResponse:
+        def __init__(self, body):
+            self._body = body
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._body
+
+    class FakeClient:
+        def __init__(self, timeout):
+            assert timeout == 60.0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, **kwargs):
+            requests.append((url, kwargs))
+            if url.endswith("/files/upload"):
+                return FakeResponse({"file": {"file_id": 12345}, "base_resp": {"status_code": 0}})
+            return FakeResponse({"voice_id": "voicebox_12345678", "base_resp": {"status_code": 0}})
+
+    monkeypatch.setattr("httpx.Client", FakeClient)
+
+    backend = MiniMaxTTSBackend()
+    voice_id = backend._create_cloned_voice_sync(str(audio_path), "voicebox_12345678")
+
+    assert voice_id == "voicebox_12345678"
+    assert requests[0][0] == MINIMAX_FILE_UPLOAD_ENDPOINTS["global_en"]
+    assert requests[0][1]["data"] == {"purpose": "voice_clone"}
+    assert requests[0][1]["files"]["file"][0] == "reference.wav"
+    assert requests[1][0] == MINIMAX_VOICE_CLONE_ENDPOINTS["global_en"]
+    assert requests[1][1]["json"] == {
+        "file_id": 12345,
+        "voice_id": "voicebox_12345678",
+        "model": MINIMAX_VOICE_CLONE_DEFAULT_MODEL,
+    }

--- a/backend/tests/test_minimax_backend.py
+++ b/backend/tests/test_minimax_backend.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for the MiniMax cloud TTS backend.
+
+These exercise region/endpoint selection, request-payload construction,
+response parsing and audio decoding without making real HTTP calls.
+"""
+
+import numpy as np
+import pytest
+
+from backend.backends.minimax_backend import (
+    MINIMAX_AUDIO_FORMATS,
+    MINIMAX_DEFAULT_FORMAT,
+    MINIMAX_DEFAULT_VOICE,
+    MINIMAX_ENDPOINTS,
+    MINIMAX_TTS_DEFAULT_MODEL,
+    MINIMAX_TTS_MODELS,
+    MINIMAX_VOICES,
+    MiniMaxTTSBackend,
+    _decode_audio,
+    get_endpoint,
+    resolve_region,
+)
+
+# -- Registry constants ------------------------------------------------------
+
+
+def test_model_catalog_covers_current_speech_models():
+    assert MINIMAX_TTS_DEFAULT_MODEL == "speech-2.8-hd"
+    assert MINIMAX_TTS_DEFAULT_MODEL in MINIMAX_TTS_MODELS
+    for expected in (
+        "speech-2.8-hd",
+        "speech-2.8-turbo",
+        "speech-2.6-hd",
+        "speech-2.6-turbo",
+        "speech-02-hd",
+        "speech-02-turbo",
+        "speech-01-hd",
+        "speech-01-turbo",
+    ):
+        assert expected in MINIMAX_TTS_MODELS
+
+
+def test_audio_formats_and_default():
+    assert MINIMAX_AUDIO_FORMATS == ["mp3", "wav", "flac", "pcm"]
+    assert MINIMAX_DEFAULT_FORMAT in MINIMAX_AUDIO_FORMATS
+
+
+def test_default_voice_is_a_known_preset():
+    voice_ids = {vid for vid, _name, _gender, _lang in MINIMAX_VOICES}
+    assert MINIMAX_DEFAULT_VOICE in voice_ids
+
+
+# -- Region / endpoint selection --------------------------------------------
+
+
+def test_regions_expose_both_hosts():
+    assert MINIMAX_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/t2a_v2"
+    assert MINIMAX_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/t2a_v2"
+
+
+def test_resolve_region_default_is_global(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_REGION", raising=False)
+    assert resolve_region() == "global_en"
+    assert get_endpoint() == MINIMAX_ENDPOINTS["global_en"]
+
+
+def test_resolve_region_honours_env(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_REGION", "cn_zh")
+    assert resolve_region() == "cn_zh"
+    assert get_endpoint() == MINIMAX_ENDPOINTS["cn_zh"]
+
+
+def test_resolve_region_falls_back_on_unknown(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_REGION", raising=False)
+    assert resolve_region("mars") == "global_en"
+    assert resolve_region("CN_ZH") == "cn_zh"  # case-insensitive
+
+
+# -- Payload construction ----------------------------------------------------
+
+
+def test_build_payload_uses_requested_controls():
+    backend = MiniMaxTTSBackend()
+    prompt = {
+        "preset_voice_id": "English_Persuasive_Man",
+        "tts_model": "speech-2.6-turbo",
+        "audio_format": "mp3",
+        "sample_rate": 24000,
+        "speed": 1.25,
+        "vol": 0.8,
+        "pitch": 2,
+    }
+    payload = backend._build_payload("hello", "English_Persuasive_Man", "speech-2.6-turbo", "mp3", 24000, "en", prompt)
+    assert payload["model"] == "speech-2.6-turbo"
+    assert payload["text"] == "hello"
+    assert payload["output_format"] == "hex"
+    assert payload["language_boost"] == "English"
+    assert payload["voice_setting"] == {
+        "voice_id": "English_Persuasive_Man",
+        "speed": 1.25,
+        "vol": 0.8,
+        "pitch": 2,
+    }
+    assert payload["audio_setting"] == {"sample_rate": 24000, "format": "mp3", "channel": 1}
+
+
+def test_build_payload_unknown_language_uses_auto():
+    backend = MiniMaxTTSBackend()
+    payload = backend._build_payload("x", MINIMAX_DEFAULT_VOICE, MINIMAX_TTS_DEFAULT_MODEL, "pcm", 32000, "xx", {})
+    assert payload["language_boost"] == "auto"
+    assert payload["voice_setting"]["speed"] == 1.0
+    assert payload["voice_setting"]["pitch"] == 0
+
+
+# -- Response parsing --------------------------------------------------------
+
+
+def test_parse_response_decodes_hex_audio():
+    raw = b"\x01\x02\x03\x04"
+    body = {"data": {"audio": raw.hex(), "status": 2}, "base_resp": {"status_code": 0}}
+    assert MiniMaxTTSBackend._parse_response(body) == raw
+
+
+def test_parse_response_raises_on_api_error():
+    body = {"base_resp": {"status_code": 1004, "status_msg": "invalid token"}}
+    with pytest.raises(RuntimeError, match="1004"):
+        MiniMaxTTSBackend._parse_response(body)
+
+
+def test_parse_response_raises_on_missing_audio():
+    body = {"data": {"status": 2}, "base_resp": {"status_code": 0}}
+    with pytest.raises(RuntimeError, match="no audio"):
+        MiniMaxTTSBackend._parse_response(body)
+
+
+def test_parse_response_raises_on_malformed_hex():
+    body = {"data": {"audio": "zzzz"}, "base_resp": {"status_code": 0}}
+    with pytest.raises(RuntimeError, match="malformed"):
+        MiniMaxTTSBackend._parse_response(body)
+
+
+# -- Audio decoding ----------------------------------------------------------
+
+
+def test_decode_pcm_to_float32():
+    samples = np.array([0, 16384, -16384, 32767], dtype="<i2")
+    audio, sr = _decode_audio(samples.tobytes(), "pcm", 32000)
+    assert sr == 32000
+    assert audio.dtype == np.float32
+    assert audio.shape == (4,)
+    assert np.isclose(audio[1], 0.5, atol=1e-3)
+    assert np.isclose(audio[2], -0.5, atol=1e-3)
+
+
+def test_decode_empty_returns_silence():
+    audio, sr = _decode_audio(b"", "pcm", 16000)
+    assert sr == 16000
+    assert audio.shape == (16000,)
+    assert not audio.any()
+
+
+# -- End-to-end generate with mocked transport -------------------------------
+
+
+async def test_load_model_without_key_raises(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.setattr("backend.backends.minimax_backend._load_api_key", lambda: None)
+    backend = MiniMaxTTSBackend()
+    with pytest.raises(RuntimeError, match="MINIMAX_API_KEY"):
+        await backend.load_model()
+
+
+async def test_generate_returns_decoded_audio(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-placeholder")
+    backend = MiniMaxTTSBackend()
+
+    captured = {}
+
+    def fake_generate_sync(payload):
+        captured["payload"] = payload
+        samples = np.array([0, 8192, -8192], dtype="<i2")
+        return samples.tobytes()
+
+    monkeypatch.setattr(backend, "_generate_sync", fake_generate_sync)
+
+    prompt = {"preset_voice_id": MINIMAX_DEFAULT_VOICE, "tts_model": "speech-2.8-turbo"}
+    audio, sr = await backend.generate("hello world", prompt, language="en")
+
+    assert sr == 32000
+    assert audio.dtype == np.float32
+    assert audio.shape == (3,)
+    assert captured["payload"]["model"] == "speech-2.8-turbo"
+    assert captured["payload"]["voice_setting"]["voice_id"] == MINIMAX_DEFAULT_VOICE
+
+
+async def test_generate_falls_back_for_unknown_model(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-placeholder")
+    backend = MiniMaxTTSBackend()
+
+    captured = {}
+
+    def fake_generate_sync(payload):
+        captured["payload"] = payload
+        return np.array([0], dtype="<i2").tobytes()
+
+    monkeypatch.setattr(backend, "_generate_sync", fake_generate_sync)
+
+    await backend.generate("hi", {"preset_voice_id": MINIMAX_DEFAULT_VOICE, "tts_model": "bogus"})
+    assert captured["payload"]["model"] == MINIMAX_TTS_DEFAULT_MODEL
+    assert captured["payload"]["audio_setting"]["format"] == MINIMAX_DEFAULT_FORMAT
+
+
+async def test_create_voice_prompt_returns_default_preset():
+    backend = MiniMaxTTSBackend()
+    prompt, cached = await backend.create_voice_prompt("ignored.wav", "ref text")
+    assert cached is False
+    assert prompt["voice_type"] == "preset"
+    assert prompt["preset_engine"] == "minimax"
+    assert prompt["preset_voice_id"] == MINIMAX_DEFAULT_VOICE


### PR DESCRIPTION
Reason: Add MiniMax cloud speech generation to the TTS engine registry with the current speech models, global/CN endpoint selection, request controls, and audio formats.

## What this adds

A new cloud TTS engine that plugs into the existing `TTSBackend` protocol, so
long-text chunking, trimming and preset-voice profile handling all work
unchanged. Nothing is downloaded — each request is a single HTTP call.

- `backend/backends/minimax_backend.py` — new `MiniMaxTTSBackend`:
  - **Speech models** (`MINIMAX_TTS_MODELS`): `speech-2.8-hd` (default),
    `speech-2.8-turbo`, `speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`,
    `speech-02-turbo`, `speech-01-hd`, `speech-01-turbo`. Unknown model ids
    fall back to the default.
  - **Region selection** via `MINIMAX_API_REGION`: `global_en`
    (`https://api.minimax.io/v1/t2a_v2`, default) and `cn_zh`
    (`https://api.minimaxi.com/v1/t2a_v2`). Unknown/empty values fall back to
    the global host.
  - **Request controls** on the T2A body: `voice_setting` (voice id, speed,
    vol, pitch), `audio_setting` (sample rate, format, channel),
    `language_boost` (derived from the request language, `auto` fallback) and
    `output_format`.
  - **Audio formats** (`MINIMAX_AUDIO_FORMATS`): `mp3`, `wav`, `flac`, `pcm`
    (default). `pcm` is decoded directly to float32; container formats are
    decoded through soundfile.
  - Preset system voices only; the API key is read from `MINIMAX_API_KEY` or
    `~/.env.local`, and API errors (`base_resp.status_code`) surface as clear
    runtime errors.
- `backend/backends/__init__.py` — registers `minimax` in `TTS_ENGINES`, wires
  the factory, and reports a clear API-key error from
  `ensure_model_cached_or_raise` instead of a download message.
- `backend/models.py` — allows `engine="minimax"` on `GenerationRequest`.
- `backend/services/profiles.py` / `backend/routes/profiles.py` — expose the
  preset voice ids for validation and the `/profiles/presets/{engine}` listing.
- `backend/tests/test_minimax_backend.py` — unit tests for region/endpoint
  selection, payload construction, response parsing and audio decoding (no
  network calls).

## Checks

- `python -m ruff check` on the new/changed backend files — clean.
- `python -m pytest backend/tests/test_minimax_backend.py` — 19 passed.

Configuration is required at runtime: set `MINIMAX_API_KEY` (and optionally
`MINIMAX_API_REGION`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a cloud-based text-to-speech engine.
  * Supports configurable regions, models, audio formats, languages, sample rates, and preset voices.
  * Added MiniMax preset voice listings and validation.
  * Supports API-based voice generation, audio decoding, and voice cloning with cached reference voices.

* **Bug Fixes**
  * Added clear validation when the MiniMax API key is missing or audio responses are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->