### PR TITLE
fix(profiles): delete a profile's generations instead of orphaning them

### DIFF
--- a/app/src/lib/hooks/useProfiles.ts
+++ b/app/src/lib/hooks/useProfiles.ts
@@ -51,6 +51,10 @@ export function useDeleteProfile() {
     mutationFn: (profileId: string) => apiClient.deleteProfile(profileId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['profiles'] });
+      // Deleting a profile also deletes its generations, which story items
+      // reference — both caches still hold rows that no longer exist.
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+      queryClient.invalidateQueries({ queryKey: ['stories'] });
     },
   });
 }

--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -11,8 +11,21 @@ from sqlalchemy.orm import Session
 from sqlalchemy import or_
 
 from ..models import GenerationRequest, GenerationResponse, HistoryQuery, HistoryResponse, HistoryListResponse, GenerationVersionResponse, EffectConfig
-from ..database import Generation as DBGeneration, GenerationVersion as DBGenerationVersion, VoiceProfile as DBVoiceProfile
+from ..database import Generation as DBGeneration, GenerationVersion as DBGenerationVersion, StoryItem as DBStoryItem, VoiceProfile as DBVoiceProfile
 from .. import config
+
+
+def _delete_generation_children(generation_id: str, db: Session) -> None:
+    """Remove the rows that reference a generation, plus any version audio files.
+
+    Story items and versions both point at the generation by a non-null FK.
+    The story detail query inner-joins generations, so a leftover story item
+    vanishes from the timeline while staying in the table forever.
+    """
+    from . import versions as versions_mod
+
+    db.query(DBStoryItem).filter_by(generation_id=generation_id).delete()
+    versions_mod.delete_versions_for_generation(generation_id, db)
 
 
 def _get_versions_for_generation(generation_id: str, db: Session) -> tuple:
@@ -254,8 +267,7 @@ async def delete_generation(
         return False
 
     # Delete all version files and records
-    from . import versions as versions_mod
-    versions_mod.delete_versions_for_generation(generation_id, db)
+    _delete_generation_children(generation_id, db)
 
     # Delete main audio file (if not already removed by version cleanup)
     if generation.audio_path:
@@ -281,13 +293,11 @@ async def delete_failed_generations(db: Session) -> int:
     Returns:
         Number of generations deleted.
     """
-    from . import versions as versions_mod
-
     failed = db.query(DBGeneration).filter(DBGeneration.status == "failed").all()
     count = 0
     for generation in failed:
         # Clean up version files/rows first.
-        versions_mod.delete_versions_for_generation(generation.id, db)
+        _delete_generation_children(generation.id, db)
 
         # Remove the main audio file if it somehow made it to disk.
         if generation.audio_path:
@@ -326,14 +336,18 @@ async def delete_generations_by_profile(
     count = 0
     for generation in generations:
         # Delete associated version files and rows first
-        from . import versions as versions_mod
-        versions_mod.delete_versions_for_generation(generation.id, db)
+        _delete_generation_children(generation.id, db)
 
         # Delete audio file
         audio_path = config.resolve_storage_path(generation.audio_path)
         if audio_path is not None and audio_path.exists():
-            audio_path.unlink()
-        
+            try:
+                audio_path.unlink()
+            except OSError:
+                # A file locked by playback shouldn't abort the whole sweep
+                # and leave the profile half-deleted.
+                pass
+
         # Delete from database
         db.delete(generation)
         count += 1

--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -4,6 +4,7 @@ Generation history management module.
 
 from typing import List, Optional, Tuple
 from datetime import datetime
+import logging
 import uuid
 import shutil
 from pathlib import Path
@@ -13,6 +14,8 @@ from sqlalchemy import or_
 from ..models import GenerationRequest, GenerationResponse, HistoryQuery, HistoryResponse, HistoryListResponse, GenerationVersionResponse, EffectConfig
 from ..database import Generation as DBGeneration, GenerationVersion as DBGenerationVersion, StoryItem as DBStoryItem, VoiceProfile as DBVoiceProfile
 from .. import config
+
+logger = logging.getLogger(__name__)
 
 
 def _delete_generation_children(generation_id: str, db: Session) -> None:
@@ -308,7 +311,7 @@ async def delete_failed_generations(db: Session) -> int:
                 except OSError:
                     # Best-effort cleanup — don't abort the whole sweep
                     # if a single file can't be removed.
-                    pass
+                    logger.warning("Could not delete generation audio %s", audio_path)
 
         db.delete(generation)
         count += 1
@@ -346,7 +349,7 @@ async def delete_generations_by_profile(
             except OSError:
                 # A file locked by playback shouldn't abort the whole sweep
                 # and leave the profile half-deleted.
-                pass
+                logger.warning("Could not delete generation audio %s", audio_path)
 
         # Delete from database
         db.delete(generation)

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -11,7 +11,14 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from .. import config
-from ..database import Generation as DBGeneration, ProfileSample as DBProfileSample, VoiceProfile as DBVoiceProfile
+from ..database import (
+    CaptureSettings as DBCaptureSettings,
+    Generation as DBGeneration,
+    MCPClientBinding as DBMCPClientBinding,
+    ProfileChannelMapping as DBProfileChannelMapping,
+    ProfileSample as DBProfileSample,
+    VoiceProfile as DBVoiceProfile,
+)
 from ..models import (
     EffectConfig,
     ProfileSampleResponse,
@@ -21,6 +28,7 @@ from ..models import (
 from ..utils.audio import save_audio, validate_and_load_reference_audio
 from ..utils.cache import _get_cache_dir, clear_profile_cache
 from ..utils.images import process_avatar, validate_image
+from . import history
 
 logger = logging.getLogger(__name__)
 
@@ -429,7 +437,23 @@ async def delete_profile(
     if not profile:
         return False
 
+    # Generations carry a non-null FK to the profile and the history query
+    # inner-joins profiles, so anything left behind here becomes a row the UI
+    # can never show and a .wav in data/generations the user can never reclaim.
+    deleted_generations = await history.delete_generations_by_profile(profile_id, db)
+    if deleted_generations:
+        logger.info("Deleted %d generations belonging to profile %s", deleted_generations, profile_id)
+
     db.query(DBProfileSample).filter_by(profile_id=profile_id).delete()
+    db.query(DBProfileChannelMapping).filter_by(profile_id=profile_id).delete()
+
+    # Nullable pointers at the profile — resolve_profile() already tolerates a
+    # dangling id, but leaving one behind makes the UI show an empty selection
+    # that the user can't clear.
+    db.query(DBMCPClientBinding).filter_by(profile_id=profile_id).update({"profile_id": None})
+    db.query(DBCaptureSettings).filter_by(default_playback_voice_id=profile_id).update(
+        {"default_playback_voice_id": None}
+    )
 
     db.delete(profile)
     db.commit()

--- a/backend/services/versions.py
+++ b/backend/services/versions.py
@@ -8,6 +8,7 @@ version and any number of processed versions with different effects chains.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from pathlib import Path
 from typing import List, Optional
@@ -20,6 +21,8 @@ from ..database import (
 )
 from ..models import GenerationVersionResponse, EffectConfig
 from .. import config
+
+logger = logging.getLogger(__name__)
 
 
 def _version_response(v: DBGenerationVersion) -> GenerationVersionResponse:
@@ -185,7 +188,15 @@ def delete_version(version_id: str, db: Session) -> bool:
 
 
 def delete_versions_for_generation(generation_id: str, db: Session) -> int:
-    """Delete all versions for a generation (used when deleting a generation)."""
+    """Delete all versions for a generation (used when deleting a generation).
+
+    This runs as part of a wider cascade — deleting one generation, sweeping
+    failed ones, or deleting a whole profile. A version file the OS won't let
+    us remove (locked by playback on Windows) must not abort that cascade and
+    strand the caller half-deleted, so the row goes regardless and the leaked
+    file is logged. ``delete_version`` keeps raising, because a single
+    user-initiated delete should fail loudly.
+    """
     versions = (
         db.query(DBGenerationVersion)
         .filter_by(generation_id=generation_id)
@@ -195,7 +206,12 @@ def delete_versions_for_generation(generation_id: str, db: Session) -> int:
     for v in versions:
         audio_path = config.resolve_storage_path(v.audio_path)
         if audio_path is not None and audio_path.exists():
-            audio_path.unlink()
+            try:
+                audio_path.unlink()
+            except OSError:
+                logger.warning(
+                    "Could not delete version audio %s; removing the row anyway", audio_path
+                )
         db.delete(v)
         count += 1
     if count > 0:

--- a/backend/tests/test_profile_delete_cascade.py
+++ b/backend/tests/test_profile_delete_cascade.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for DELETE /profiles/{id} cleaning up everything it owns.
+
+``delete_profile`` used to remove only the profile row, its samples, and the
+profile directory. Generations carry a non-null FK to the profile and
+``list_generations`` inner-joins profiles, so every generation made with a
+deleted profile turned into a row the UI could never show plus a ``.wav`` in
+``data/generations`` the user could never reclaim — unbounded disk growth with
+no way out. Version rows, story items, and channel mappings leaked the same way.
+
+Usage:
+    python -m pytest backend/tests/test_profile_delete_cascade.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Repo root on sys.path so ``backend`` imports as a package (the services use
+# package-relative imports).
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from backend import config
+from backend.database import (
+    Base,
+    CaptureSettings,
+    Generation,
+    GenerationVersion,
+    MCPClientBinding,
+    ProfileChannelMapping,
+    ProfileSample,
+    Story,
+    StoryItem,
+    VoiceProfile,
+)
+from backend.models import HistoryQuery
+from backend.services import history, profiles
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """A session backed by a temp SQLite file, with the data dir redirected."""
+    monkeypatch.setattr(config, "_data_dir", tmp_path)
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+    yield session
+
+    session.close()
+
+
+def _write_wav(name: str) -> tuple[Path, str]:
+    """Create a placeholder audio file and return (abs path, stored path)."""
+    path = config.get_generations_dir() / name
+    path.write_bytes(b"RIFF placeholder")
+    return path, f"generations/{name}"
+
+
+def _make_profile(db, profile_id: str = "profile-1") -> VoiceProfile:
+    profile = VoiceProfile(id=profile_id, name=f"Voice {profile_id}", language="en")
+    db.add(profile)
+    db.commit()
+    return profile
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_removes_generations_and_audio(db):
+    """Generations, versions, and their files go with the profile."""
+    _make_profile(db)
+    gen_file, gen_stored = _write_wav("gen.wav")
+    version_file, version_stored = _write_wav("gen-reverb.wav")
+
+    db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
+    db.add(
+        GenerationVersion(
+            id="version-1",
+            generation_id="gen-1",
+            label="Reverb",
+            audio_path=version_stored,
+        )
+    )
+    db.commit()
+
+    assert await profiles.delete_profile("profile-1", db) is True
+
+    assert db.query(Generation).count() == 0
+    assert db.query(GenerationVersion).count() == 0
+    assert not gen_file.exists()
+    assert not version_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_orphaned_generations_are_invisible_in_history(db):
+    """The history join hides orphans, so leaving them behind strands them."""
+    _make_profile(db)
+    _, gen_stored = _write_wav("gen.wav")
+    db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
+    db.commit()
+
+    assert (await history.list_generations(HistoryQuery(limit=50, offset=0), db)).total == 1
+
+    await profiles.delete_profile("profile-1", db)
+
+    listed = await history.list_generations(HistoryQuery(limit=50, offset=0), db)
+    assert listed.total == 0
+    assert db.query(Generation).count() == 0, "generation is unreachable but still on disk"
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_removes_story_items(db):
+    """Story items reference generations; the story query would hide leftovers."""
+    _make_profile(db)
+    _, gen_stored = _write_wav("gen.wav")
+    db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
+    db.add(Story(id="story-1", name="Chapter one"))
+    db.add(StoryItem(id="item-1", story_id="story-1", generation_id="gen-1"))
+    db.commit()
+
+    await profiles.delete_profile("profile-1", db)
+
+    assert db.query(StoryItem).count() == 0
+    assert db.query(Story).count() == 1, "the story itself must survive"
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_clears_references_to_it(db):
+    """Samples, channel mappings, and default-voice pointers are cleaned up."""
+    _make_profile(db)
+    db.add(ProfileSample(id="sample-1", profile_id="profile-1", audio_path="p.wav", reference_text="hi"))
+    db.add(ProfileChannelMapping(profile_id="profile-1", channel_id="channel-1"))
+    db.add(MCPClientBinding(client_id="claude-code", profile_id="profile-1"))
+    db.add(CaptureSettings(id=1, default_playback_voice_id="profile-1"))
+    db.commit()
+
+    await profiles.delete_profile("profile-1", db)
+
+    assert db.query(ProfileSample).count() == 0
+    assert db.query(ProfileChannelMapping).count() == 0
+    assert db.query(MCPClientBinding).filter_by(client_id="claude-code").one().profile_id is None
+    assert db.query(CaptureSettings).filter_by(id=1).one().default_playback_voice_id is None
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_survives_unremovable_audio(db, monkeypatch):
+    """A file locked by playback must not abort the delete half-way through."""
+    _make_profile(db)
+    gen_file, gen_stored = _write_wav("gen.wav")
+    db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
+    db.commit()
+
+    real_unlink = Path.unlink
+
+    def refuse_locked_file(self, *args, **kwargs):
+        if self == gen_file:
+            raise OSError("file is in use by another process")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse_locked_file)
+
+    assert await profiles.delete_profile("profile-1", db) is True
+    assert db.query(VoiceProfile).count() == 0
+    assert db.query(Generation).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_leaves_other_profiles_alone(db):
+    """Cleanup is scoped to the deleted profile."""
+    _make_profile(db, "profile-1")
+    _make_profile(db, "profile-2")
+    _, keep_stored = _write_wav("keep.wav")
+    _, drop_stored = _write_wav("drop.wav")
+    db.add(Generation(id="gen-keep", profile_id="profile-2", text="keep", audio_path=keep_stored))
+    db.add(Generation(id="gen-drop", profile_id="profile-1", text="drop", audio_path=drop_stored))
+    db.add(ProfileChannelMapping(profile_id="profile-2", channel_id="channel-1"))
+    db.commit()
+
+    await profiles.delete_profile("profile-1", db)
+
+    assert [g.id for g in db.query(Generation).all()] == ["gen-keep"]
+    assert db.query(ProfileChannelMapping).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_profile_returns_false(db):
+    assert await profiles.delete_profile("nope", db) is False

--- a/backend/tests/test_profile_delete_cascade.py
+++ b/backend/tests/test_profile_delete_cascade.py
@@ -145,6 +145,18 @@ async def test_delete_profile_clears_references_to_it(db):
     assert db.query(CaptureSettings).filter_by(id=1).one().default_playback_voice_id is None
 
 
+def _lock(monkeypatch, locked: Path) -> None:
+    """Make ``locked`` refuse deletion, the way Windows does during playback."""
+    real_unlink = Path.unlink
+
+    def refuse_locked_file(self, *args, **kwargs):
+        if self == locked:
+            raise OSError("file is in use by another process")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse_locked_file)
+
+
 @pytest.mark.asyncio
 async def test_delete_profile_survives_unremovable_audio(db, monkeypatch):
     """A file locked by playback must not abort the delete half-way through."""
@@ -153,18 +165,62 @@ async def test_delete_profile_survives_unremovable_audio(db, monkeypatch):
     db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
     db.commit()
 
-    real_unlink = Path.unlink
-
-    def refuse_locked_file(self, *args, **kwargs):
-        if self == gen_file:
-            raise OSError("file is in use by another process")
-        return real_unlink(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "unlink", refuse_locked_file)
+    _lock(monkeypatch, gen_file)
 
     assert await profiles.delete_profile("profile-1", db) is True
     assert db.query(VoiceProfile).count() == 0
     assert db.query(Generation).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_survives_unremovable_version_audio(db, monkeypatch):
+    """Same guarantee for version files, which are unlinked one call deeper."""
+    _make_profile(db)
+    _, gen_stored = _write_wav("gen.wav")
+    version_file, version_stored = _write_wav("gen-reverb.wav")
+    db.add(Generation(id="gen-1", profile_id="profile-1", text="hello", audio_path=gen_stored))
+    db.add(
+        GenerationVersion(
+            id="version-1",
+            generation_id="gen-1",
+            label="Reverb",
+            audio_path=version_stored,
+        )
+    )
+    db.commit()
+
+    _lock(monkeypatch, version_file)
+
+    assert await profiles.delete_profile("profile-1", db) is True
+    assert db.query(VoiceProfile).count() == 0
+    assert db.query(Generation).count() == 0
+    assert db.query(GenerationVersion).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_one_locked_file_does_not_strand_the_rest(db, monkeypatch):
+    """The sweep commits per generation, so aborting mid-loop half-deletes."""
+    _make_profile(db)
+    for i in range(3):
+        _, gen_stored = _write_wav(f"gen{i}.wav")
+        _, version_stored = _write_wav(f"gen{i}-take2.wav")
+        db.add(Generation(id=f"gen-{i}", profile_id="profile-1", text="hi", audio_path=gen_stored))
+        db.add(
+            GenerationVersion(
+                id=f"version-{i}",
+                generation_id=f"gen-{i}",
+                label="take-2",
+                audio_path=version_stored,
+            )
+        )
+    db.commit()
+
+    _lock(monkeypatch, config.get_generations_dir() / "gen1-take2.wav")
+
+    assert await profiles.delete_profile("profile-1", db) is True
+    assert db.query(Generation).count() == 0
+    assert db.query(GenerationVersion).count() == 0
+    assert db.query(VoiceProfile).count() == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

  `delete_profile` removes the profile row, its samples, and the profile
  directory — but not its generations. Since `generations.profile_id` is a
  non-null FK and SQLite FK enforcement is off, the rows survive; and because
  `list_generations` inner-joins `profiles`, they become invisible in the UI.

  The result: every `.wav` ever generated with a deleted profile stays in
  `data/generations/` forever, with no way for the user to see or reclaim it.
  Version rows, story items, and `profile_channel_mappings` leak the same way.

  `history.delete_generations_by_profile()` exists for exactly this and is
  never called. #446 (fixed by #447) was written assuming profile deletion
  routes through it — so #447 hardened a function nothing invokes.

  ## Fix

  - `delete_profile` cascades through `delete_generations_by_profile`, clears
    `profile_channel_mappings`, and nulls `mcp_client_bindings.profile_id` /
    `capture_settings.default_playback_voice_id`.
  - Generation deletion now also purges `story_items` (all three call sites) —
    they'd dangle otherwise, and the story query inner-joins too.
  - Audio unlink in `delete_generations_by_profile` is best-effort, matching
    `delete_failed_generations`, so a file locked by playback can't abort the
    delete half-way.
  - `useDeleteProfile` invalidates `['history']` and `['stories']`.

  ## Tests

  `backend/tests/test_profile_delete_cascade.py` — 7 tests covering the cascade,
  scoping to a single profile, story-item cleanup, the locked-file path, and the
  invisible-orphan symptom. 5 of them fail on `main`.

      python -m pytest backend/tests/test_profile_delete_cascade.py -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a profile now removes its associated generations, versions, audio files, story items, samples, and channel mappings.
  * Profile deletion now clears related settings and references while preserving stories and unrelated profiles.
  * Deletion continues successfully if an associated audio file cannot be removed.
  * History and story views now refresh correctly after profile deletion.
  * Deleting a nonexistent profile is handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->