### PR TITLE
docs: clarify data directory override scope

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -118,7 +118,16 @@ curl http://localhost:17493/generate/{id}/status
   backends/               # Downloaded CUDA binary (if applicable)
 ```
 
-Default location is the OS-specific app data directory. Override with `--data-dir` or the `VOICEBOX_DATA_DIR` environment variable.
+Standalone backend runs default to the resolved `data/` directory (normally
+`./data` when started from the repository root). When running
+`python -m backend.main` or the backend server directly, override it with
+`--data-dir`.
+
+Packaged Tauri desktop launches currently choose the OS-specific app data
+directory and pass it to the sidecar. The standalone/server override does not
+change the packaged desktop location.
+
+`VOICEBOX_DATA_DIR` is not currently a supported setting.
 
 ## Code quality
 


### PR DESCRIPTION
# Clarify data-directory override scope

## Summary

- document the standalone backend's `data/` default and `--data-dir` override;
- document that packaged Tauri desktop currently selects the OS-specific app-data directory and passes it to the sidecar; and
- remove the unsupported claim that `VOICEBOX_DATA_DIR` relocates Voicebox data.

## Scope

Related issue: #981

This is a documentation-truthfulness correction only. It does not implement packaged-desktop data-directory relocation or migration. The desktop behavior reported in #981 therefore remains unchanged.

## Verification

- focused docs/source-anchor assertions passed;
- `git diff --check` passed;
- no dependency installation, build, runtime, or Windows verification was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data-directory guidance for standalone backend runs, including the `--data-dir` option.
  * Clarified that packaged Tauri launches use the operating system’s app-data directory.
  * Removed outdated documentation for the unsupported `VOICEBOX_DATA_DIR` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->