### PR TITLE
fix(mlx): pin all MLX ops to a single worker thread to fix cross-thread Stream crash

### DIFF
--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -141,8 +141,13 @@ class MLXTTSBackend:
         (e.g. from _reload_sync) — use _unload_model_sync directly there, or
         this would deadlock the single-worker executor waiting on itself.
         """
-        if self.model is not None:
-            _mlx_executor.submit(self._unload_model_sync).result()
+        # Submit unconditionally rather than checking self.model here first:
+        # that check would race against a load already queued on the worker
+        # thread (this call could see None, skip, and leave a model that
+        # finishes loading a moment later still resident). The loaded check
+        # belongs inside _unload_model_sync, where it runs atomically with
+        # the teardown itself.
+        _mlx_executor.submit(self._unload_model_sync).result()
 
     def _unload_model_sync(self):
         if self.model is not None:
@@ -296,12 +301,23 @@ class MLXTTSBackend:
 
             return audio, sample_rate
 
-        # Hold the op lock across load + inference so a concurrent request
-        # for a different model_size can't swap self.model in between (the
-        # model is read inside _generate_sync via closure, after this point).
+        def _reload_and_generate_sync():
+            """Ensure the configured model is loaded, then generate — as ONE
+            MLX-worker submission. Two separate submissions (load, then
+            generate) leave a gap after the load future resolves and before
+            the generate future is submitted; an unload_model() call from
+            another thread could land in that gap and tear down the model
+            this call is about to use. Folding both into one callable closes
+            the gap: the executor's own FIFO ordering is the only guarantee
+            this needs, and the reload check here is self-healing even if an
+            unload happened to run just before this callable started.
+            """
+            if self.model is None or self._current_model_size != self.model_size:
+                self._reload_sync(self.model_size)
+            return _generate_sync()
+
         async with self._op_lock:
-            await self.load_model_async(None)
-            audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
+            audio, sample_rate = await _run_on_mlx_thread(_reload_and_generate_sync)
 
         return audio, sample_rate
 
@@ -361,10 +377,11 @@ class MLXSTTBackend:
     def unload_model(self):
         """Unload the model to free memory.
 
-        Safe to call from any thread — see MLXTTSBackend.unload_model for why.
+        Safe to call from any thread — see MLXTTSBackend.unload_model for why,
+        including why this submits unconditionally instead of checking
+        self.model first.
         """
-        if self.model is not None:
-            _mlx_executor.submit(self._unload_model_sync).result()
+        _mlx_executor.submit(self._unload_model_sync).result()
 
     def _unload_model_sync(self):
         if self.model is not None:
@@ -389,6 +406,8 @@ class MLXSTTBackend:
         Returns:
             Transcribed text
         """
+        resolved_size = model_size if model_size is not None else self.model_size
+
         def _transcribe_sync():
             """Run synchronous transcription in thread pool."""
             # MLX Whisper transcription using generate method
@@ -412,8 +431,15 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Hold the op lock across load + inference so a concurrent request
-        # for a different model_size can't swap self.model in between.
+        def _reload_and_transcribe_sync():
+            """Ensure the requested model is loaded, then transcribe — as ONE
+            MLX-worker submission. See MLXTTSBackend._reload_and_generate_sync
+            for why this needs to be a single callable rather than a separate
+            load-then-transcribe pair.
+            """
+            if self.model is None or self.model_size != resolved_size:
+                self._load_model_sync(resolved_size)
+            return _transcribe_sync()
+
         async with self._op_lock:
-            await self.load_model_async(model_size)
-            return await _run_on_mlx_thread(_transcribe_sync)
+            return await _run_on_mlx_thread(_reload_and_transcribe_sync)

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -7,8 +7,23 @@ import asyncio
 import logging
 import numpy as np
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
+
+# MLX's Metal backend keeps a per-thread stream registry. Loading a model on
+# one worker thread (via asyncio.to_thread, which round-robins across the
+# default executor's pool) and then generating on a different worker thread
+# raises "There is no Stream(gpu, N) in current thread." All MLX calls in
+# this module must therefore run on the SAME OS thread for the process
+# lifetime — route them through this single-worker executor instead of
+# asyncio.to_thread's shared multi-worker pool.
+_mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-worker")
+
+
+def _run_on_mlx_thread(func, *args):
+    loop = asyncio.get_running_loop()
+    return loop.run_in_executor(_mlx_executor, func, *args)
 
 # PATCH: Import and apply offline patch BEFORE any huggingface_hub usage
 # This prevents mlx_audio from making network requests when models are cached
@@ -82,7 +97,7 @@ class MLXTTSBackend:
             self.unload_model()
 
         # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -259,7 +274,7 @@ class MLXTTSBackend:
             return audio, sample_rate
 
         # Run blocking inference in thread pool
-        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
 
         return audio, sample_rate
 
@@ -293,7 +308,7 @@ class MLXSTTBackend:
             return
 
         # Run blocking load in thread pool
-        await asyncio.to_thread(self._load_model_sync, model_size)
+        await _run_on_mlx_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
@@ -364,4 +379,4 @@ class MLXSTTBackend:
                 return str(result).strip()
 
         # Run blocking transcription in thread pool
-        return await asyncio.to_thread(_transcribe_sync)
+        return await _run_on_mlx_thread(_transcribe_sync)

--- a/backend/backends/mlx_backend.py
+++ b/backend/backends/mlx_backend.py
@@ -44,6 +44,10 @@ class MLXTTSBackend:
         self.model = None
         self.model_size = model_size
         self._current_model_size = None
+        # Guards the whole load-then-use sequence in generate()/create_voice_prompt()
+        # so a concurrent request for a different model_size can't swap self.model
+        # out from under an in-flight request between its load and its inference.
+        self._op_lock = asyncio.Lock()
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -92,15 +96,22 @@ class MLXTTSBackend:
         if self.model is not None and self._current_model_size == model_size:
             return
 
-        # Unload existing model if different size requested
-        if self.model is not None and self._current_model_size != model_size:
-            self.unload_model()
-
-        # Run blocking load in thread pool
-        await _run_on_mlx_thread(self._load_model_sync, model_size)
+        # Unload (if needed) and load as ONE callable on the MLX worker thread.
+        # Doing this as two separate _run_on_mlx_thread calls would run the
+        # unload on whichever thread issues the second call — usually still
+        # correct, but a caller-side await gap between them would let another
+        # coroutine slip a conflicting load in between. One callable removes
+        # the gap.
+        await _run_on_mlx_thread(self._reload_sync, model_size)
 
     # Alias for compatibility
     load_model = load_model_async
+
+    def _reload_sync(self, model_size: str):
+        """Unload a mismatched model and load the requested one, in one MLX-thread op."""
+        if self.model is not None and self._current_model_size != model_size:
+            self._unload_model_sync()
+        self._load_model_sync(model_size)
 
     def _load_model_sync(self, model_size: str):
         """Synchronous model loading."""
@@ -120,7 +131,20 @@ class MLXTTSBackend:
         logger.info("MLX TTS model %s loaded successfully", model_size)
 
     def unload_model(self):
-        """Unload the model to free memory."""
+        """Unload the model to free memory.
+
+        Safe to call from any thread (e.g. the FastAPI event loop, from the
+        /models/unload routes): the actual teardown is submitted to the MLX
+        worker thread and awaited synchronously here, so Metal resources are
+        always released on the same OS thread that created them. Do not call
+        this from within a callable already running ON the MLX worker thread
+        (e.g. from _reload_sync) — use _unload_model_sync directly there, or
+        this would deadlock the single-worker executor waiting on itself.
+        """
+        if self.model is not None:
+            _mlx_executor.submit(self._unload_model_sync).result()
+
+    def _unload_model_sync(self):
         if self.model is not None:
             del self.model
             self.model = None
@@ -147,7 +171,8 @@ class MLXTTSBackend:
         Returns:
             Tuple of (voice_prompt_dict, was_cached)
         """
-        await self.load_model_async(None)
+        async with self._op_lock:
+            await self.load_model_async(None)
 
         # Check cache if enabled
         if use_cache:
@@ -202,8 +227,6 @@ class MLXTTSBackend:
         Returns:
             Tuple of (audio_array, sample_rate)
         """
-        await self.load_model_async(None)
-
         logger.info("Generating audio for text: %s", text)
 
         def _generate_sync():
@@ -273,8 +296,12 @@ class MLXTTSBackend:
 
             return audio, sample_rate
 
-        # Run blocking inference in thread pool
-        audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
+        # Hold the op lock across load + inference so a concurrent request
+        # for a different model_size can't swap self.model in between (the
+        # model is read inside _generate_sync via closure, after this point).
+        async with self._op_lock:
+            await self.load_model_async(None)
+            audio, sample_rate = await _run_on_mlx_thread(_generate_sync)
 
         return audio, sample_rate
 
@@ -285,6 +312,8 @@ class MLXSTTBackend:
     def __init__(self, model_size: str = "base"):
         self.model = None
         self.model_size = model_size
+        # See MLXTTSBackend._op_lock — same reason.
+        self._op_lock = asyncio.Lock()
 
     def is_loaded(self) -> bool:
         """Check if model is loaded."""
@@ -330,7 +359,14 @@ class MLXSTTBackend:
         logger.info("MLX Whisper model %s loaded successfully", model_size)
 
     def unload_model(self):
-        """Unload the model to free memory."""
+        """Unload the model to free memory.
+
+        Safe to call from any thread — see MLXTTSBackend.unload_model for why.
+        """
+        if self.model is not None:
+            _mlx_executor.submit(self._unload_model_sync).result()
+
+    def _unload_model_sync(self):
         if self.model is not None:
             del self.model
             self.model = None
@@ -353,8 +389,6 @@ class MLXSTTBackend:
         Returns:
             Transcribed text
         """
-        await self.load_model_async(model_size)
-
         def _transcribe_sync():
             """Run synchronous transcription in thread pool."""
             # MLX Whisper transcription using generate method
@@ -378,5 +412,8 @@ class MLXSTTBackend:
             else:
                 return str(result).strip()
 
-        # Run blocking transcription in thread pool
-        return await _run_on_mlx_thread(_transcribe_sync)
+        # Hold the op lock across load + inference so a concurrent request
+        # for a different model_size can't swap self.model in between.
+        async with self._op_lock:
+            await self.load_model_async(model_size)
+            return await _run_on_mlx_thread(_transcribe_sync)


### PR DESCRIPTION
## Bug

Qwen3-TTS generation (both 1.7B and 0.6B) crashes every time with:

```
There is no Stream(gpu, 1) in current thread.
```

Reproduced on macOS/Apple Silicon, via both the app UI and direct `POST /generate` calls, on a freshly-cloned voice profile. Same profile generates fine on Chatterbox, so this is specific to the MLX backend, not the profile/reference audio.

## Root cause

`MLXTTSBackend`/`MLXSTTBackend` dispatch model loading and generation as **separate** `asyncio.to_thread()` calls. `asyncio.to_thread` runs on Python's default executor, which is a multi-worker thread pool — so the thread that loads the model is not guaranteed to be the same thread that later runs generation.

MLX's Metal backend registers GPU streams per-OS-thread. A model (and its associated MLX arrays) loaded on worker thread A, then used for inference on worker thread B, hits a stream that was never registered on B and raises the error above.

## Fix

Added a dedicated single-worker `ThreadPoolExecutor` (`_mlx_executor`) in `mlx_backend.py` and routed all four MLX call sites in the file — TTS load, TTS generate, STT load, STT transcribe — through it instead of `asyncio.to_thread`'s shared pool. This guarantees every MLX operation for the process lifetime runs on the same OS thread, so streams stay valid across load → generate.

## Testing

- Before: `POST /generate` with `engine: "qwen"`, both `model_size: "1.7B"` and `"0.6B"`, failed 100% of the time with the Stream error on a cloned voice profile.
- After: same requests complete cleanly (`status: "completed"`), audio generated correctly.
- Chatterbox/Kokoro (PyTorch/non-MLX backends) were unaffected before and after, confirming this is isolated to `mlx_backend.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of MLX-powered text-to-speech and speech-to-text processing.
  * Reduced thread-related errors during model loading, unloading, and audio generation or transcription.
  * Improved model reload behavior for text-to-speech, helping prevent interruptions during successive requests.
  * Enhanced stability when switching between speech-to-text and text-to-speech operations.
  * Reduced the risk of inconsistent results during concurrent or rapidly repeated audio requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->