### PR TITLE
Enable native Intel XPU (torch.xpu) without deprecated IPEX

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -255,19 +255,13 @@ def _get_gpu_status() -> str:
     elif backend_type == "mlx":
         return "Metal (Apple Silicon via MLX)"
 
-    # Intel XPU (Arc / Data Center) via IPEX
-    try:
-        import intel_extension_for_pytorch  # noqa: F401
-
-        if hasattr(torch, "xpu") and torch.xpu.is_available():
-            try:
-                xpu_name = torch.xpu.get_device_name(0)
-            except Exception:
-                xpu_name = "Intel GPU"
-            return f"XPU ({xpu_name})"
-    except ImportError:
-        pass
-
+    # Intel XPU (Arc / Data Center) — native check, no IPEX required
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        try:
+            xpu_name = torch.xpu.get_device_name(0)
+        except Exception:
+            xpu_name = "Intel GPU"
+        return f"XPU ({xpu_name})"
     return "None (CPU only)"
 
 

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -101,14 +101,9 @@ def get_torch_device(
     if torch.cuda.is_available():
         return "cuda"
 
-    if allow_xpu:
-        try:
-            import intel_extension_for_pytorch  # noqa: F401
-
-            if hasattr(torch, "xpu") and torch.xpu.is_available():
-                return "xpu"
-        except ImportError:
-            pass
+        # Native Intel XPU check (IPEX is EOL; PyTorch >= 2.5 exposes torch.xpu natively)
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
 
     if allow_directml:
         try:

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -79,7 +79,7 @@ def is_model_cached(
 
 def get_torch_device(
     *,
-    allow_xpu: bool = False,
+    allow_xpu: bool = True,
     allow_directml: bool = False,
     allow_mps: bool = False,
     force_cpu_on_mac: bool = False,
@@ -88,7 +88,7 @@ def get_torch_device(
     Detect the best available torch device.
 
     Args:
-        allow_xpu: Check for Intel XPU (IPEX) support.
+        allow_xpu: Check for Intel XPU support (native torch.xpu, PyTorch >= 2.5).
         allow_directml: Check for DirectML (Windows) support.
         allow_mps: Allow MPS (Apple Silicon). If False, MPS falls back to CPU.
         force_cpu_on_mac: Force CPU on macOS regardless of GPU availability.
@@ -102,7 +102,7 @@ def get_torch_device(
         return "cuda"
 
         # Native Intel XPU check (IPEX is EOL; PyTorch >= 2.5 exposes torch.xpu natively)
-    if hasattr(torch, "xpu") and torch.xpu.is_available():
+    if allow_xpu and hasattr(torch, "xpu") and torch.xpu.is_available():
         return "xpu"
 
     if allow_directml:

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -68,8 +68,7 @@ async def health():
     has_xpu = False
     xpu_name = None
     try:
-        pass  # IPEX not needed; native torch.xpu check below
-
+        
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             has_xpu = True
             try:

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -68,7 +68,7 @@ async def health():
     has_xpu = False
     xpu_name = None
     try:
-        import intel_extension_for_pytorch as ipex  # noqa: F401 -- side-effect import enables XPU
+        pass  # IPEX not needed; native torch.xpu check below
 
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             has_xpu = True


### PR DESCRIPTION
Fix Intel XPU (Arc) detection: use native torch.xpu instead of the deprecated intel_extension_for_pytorch (IPEX is EOL; PyTorch >= 2.5 has native XPU support). The old code silently swallowed ImportError and fell back to CPU.

Changes:
- `backend/backends/base.py`: `get_torch_device()` now checks `torch.xpu.is_available()` natively.
- `backend/app.py`: `_get_gpu_status()` — same fix; startup log now shows `GPU: XPU (<device name>)`.
- `backend/routes/health.py`: same fix; Settings → GPU tab now shows the Intel GPU as Active.

Tested on Windows with Intel Arc B580, torch 2.13.0+xpu. Startup log: `GPU: XPU (Intel(R) Arc(TM) B580 Graphics)`; Settings → GPU shows the device as Active.

Fixes #867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native PyTorch XPU detection for supported hardware.
  * XPU devices are now recognized automatically without additional opt-in configuration.
  * Device selection now enables XPU support by default when available.

* **Bug Fixes**
  * Improved device-name detection with fallback handling.
  * Health checks now reliably report XPU availability without requiring additional integrations.
  * Improved compatibility by using native PyTorch support for XPU availability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->