### PR TITLE
fix: honor VOICEBOX_DATA_DIR in both the backend and the desktop app

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -18,8 +18,10 @@ if _custom_models_dir:
     os.environ["HF_HUB_CACHE"] = _custom_models_dir
     logger.info("Model download path set to: %s", _custom_models_dir)
 
-# Default data directory (used in development)
-_data_dir = Path("data").resolve()
+# Default data directory (used in development). VOICEBOX_DATA_DIR lets a bare
+# `uvicorn backend.main:app` point at the packaged app's data dir without a CLI
+# flag. The --data-dir argument still wins: it calls set_data_dir() after import.
+_data_dir = Path(os.environ.get("VOICEBOX_DATA_DIR") or "data").resolve()
 
 
 def _path_relative_to_any_data_dir(path: Path) -> Path | None:

--- a/backend/tests/test_data_dir_env.py
+++ b/backend/tests/test_data_dir_env.py
@@ -15,14 +15,11 @@ reloads.
 """
 
 import importlib
-import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-import config  # noqa: E402
+from backend import config
 
 
 @pytest.fixture
@@ -37,6 +34,10 @@ def reload_config(monkeypatch):
         return importlib.reload(config)
 
     yield _reload
+    # Undo before the reload, not after: pytest restores monkeypatch once the
+    # fixture has finished, so reloading first would bake the last test's
+    # VOICEBOX_DATA_DIR into the module for everything that follows.
+    monkeypatch.undo()
     # Leave the module matching the real process environment for later tests.
     importlib.reload(config)
 

--- a/backend/tests/test_data_dir_env.py
+++ b/backend/tests/test_data_dir_env.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for the ``VOICEBOX_DATA_DIR`` environment variable.
+
+``backend/README.md`` documents ``VOICEBOX_DATA_DIR`` alongside ``--data-dir``,
+but the default was previously hardcoded to ``./data``, so a bare
+``uvicorn backend.main:app`` (how ``just dev`` starts the backend) always wrote
+to the repo instead of the app data dir.
+
+The variable is read at import time, so each test reloads the module under a
+patched environment.
+
+NOTE: These tests reload ``config``, which rebinds its module-global
+``_data_dir``. Import the module fresh rather than holding a reference across
+reloads.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import config  # noqa: E402
+
+
+@pytest.fixture
+def reload_config(monkeypatch):
+    """Reload ``config`` with a patched environment, restoring it afterwards."""
+
+    def _reload(data_dir: str | None):
+        if data_dir is None:
+            monkeypatch.delenv("VOICEBOX_DATA_DIR", raising=False)
+        else:
+            monkeypatch.setenv("VOICEBOX_DATA_DIR", data_dir)
+        return importlib.reload(config)
+
+    yield _reload
+    # Leave the module matching the real process environment for later tests.
+    importlib.reload(config)
+
+
+def test_env_var_sets_data_dir(reload_config, tmp_path):
+    target = tmp_path / "appdata"
+    cfg = reload_config(str(target))
+
+    assert cfg.get_data_dir() == target.resolve()
+
+
+def test_defaults_to_local_data_dir_when_unset(reload_config):
+    cfg = reload_config(None)
+
+    assert cfg.get_data_dir() == Path("data").resolve()
+
+
+def test_empty_env_var_falls_back_to_default(reload_config):
+    cfg = reload_config("")
+
+    assert cfg.get_data_dir() == Path("data").resolve()
+
+
+def test_relative_env_var_is_resolved_to_absolute(reload_config):
+    cfg = reload_config("relative/data")
+
+    assert cfg.get_data_dir().is_absolute()
+    assert cfg.get_data_dir() == Path("relative/data").resolve()
+
+
+def test_set_data_dir_still_wins_over_env_var(reload_config, tmp_path):
+    """``--data-dir`` calls set_data_dir() after import, so it must take
+    precedence over the environment variable."""
+    cfg = reload_config(str(tmp_path / "from-env"))
+    explicit = tmp_path / "from-flag"
+
+    cfg.set_data_dir(explicit)
+
+    assert cfg.get_data_dir() == explicit.resolve()

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -213,15 +213,30 @@ struct ServerState {
     backend_override: Mutex<Option<String>>,
 }
 
-/// The data directory requested via `VOICEBOX_DATA_DIR`, if any.
+/// The data directory requested via `VOICEBOX_DATA_DIR`, if any, resolved
+/// against `base` when the value is relative.
 ///
 /// Unset, empty and whitespace-only all mean "no override", so an env var
 /// cleared to "" falls back to the platform path rather than resolving to the
 /// current working directory.
-fn data_dir_override(env_value: Option<String>) -> Option<std::path::PathBuf> {
+///
+/// Relative values must be made absolute here. The ROCm and CUDA branches
+/// spawn the sidecar with `current_dir()` set to the backend's onedir folder,
+/// so a relative `--data-dir` would resolve against that folder instead of
+/// where the user meant — and to a different place than the CPU path, which
+/// does not change the working directory.
+fn data_dir_override(
+    env_value: Option<String>,
+    base: &std::path::Path,
+) -> Option<std::path::PathBuf> {
     match env_value {
         Some(value) if !value.trim().is_empty() => {
-            Some(std::path::PathBuf::from(value.trim()))
+            let path = std::path::Path::new(value.trim());
+            Some(if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base.join(path)
+            })
         }
         _ => None,
     }
@@ -425,8 +440,10 @@ async fn start_server(
     // --data-dir, and that argument beats the environment variable on the
     // Python side, so resolving it here is the only place the documented
     // override can reach the desktop app.
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("Failed to read the current directory: {}", e))?;
     let (data_dir, data_dir_source) =
-        match data_dir_override(std::env::var("VOICEBOX_DATA_DIR").ok()) {
+        match data_dir_override(std::env::var("VOICEBOX_DATA_DIR").ok(), &cwd) {
             Some(path) => (path, "VOICEBOX_DATA_DIR"),
             None => (
                 app.path()
@@ -1686,39 +1703,66 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::data_dir_override;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    /// Stand-in for the process working directory. Absolute on both platforms
+    /// so `is_absolute()` behaves the same in CI as it does locally.
+    fn base() -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(r"C:\work")
+        } else {
+            PathBuf::from("/work")
+        }
+    }
 
     #[test]
     fn unset_means_no_override() {
-        assert_eq!(data_dir_override(None), None);
+        assert_eq!(data_dir_override(None, &base()), None);
     }
 
     #[test]
     fn empty_and_whitespace_mean_no_override() {
         // An env var cleared to "" must not resolve to the process CWD.
-        assert_eq!(data_dir_override(Some(String::new())), None);
-        assert_eq!(data_dir_override(Some("   ".to_string())), None);
-        assert_eq!(data_dir_override(Some("\t\n".to_string())), None);
+        assert_eq!(data_dir_override(Some(String::new()), &base()), None);
+        assert_eq!(data_dir_override(Some("   ".to_string()), &base()), None);
+        assert_eq!(data_dir_override(Some("\t\n".to_string()), &base()), None);
     }
 
     #[test]
-    fn a_path_is_used_verbatim() {
+    fn an_absolute_path_is_used_verbatim() {
+        let absolute = if cfg!(windows) {
+            r"C:\Users\me\Audio\Voicebox"
+        } else {
+            "/home/me/voicebox"
+        };
         assert_eq!(
-            data_dir_override(Some(r"C:\Users\me\Audio\Voicebox".to_string())),
-            Some(PathBuf::from(r"C:\Users\me\Audio\Voicebox"))
-        );
-        assert_eq!(
-            data_dir_override(Some("/home/me/voicebox".to_string())),
-            Some(PathBuf::from("/home/me/voicebox"))
+            data_dir_override(Some(absolute.to_string()), &base()),
+            Some(PathBuf::from(absolute))
         );
     }
 
     #[test]
     fn surrounding_whitespace_is_trimmed() {
         // Windows env vars set through the GUI often carry a trailing space.
+        let absolute = if cfg!(windows) {
+            r"C:\Users\me\Audio\Voicebox"
+        } else {
+            "/home/me/voicebox"
+        };
         assert_eq!(
-            data_dir_override(Some("  /home/me/voicebox  ".to_string())),
-            Some(PathBuf::from("/home/me/voicebox"))
+            data_dir_override(Some(format!("  {}  ", absolute)), &base()),
+            Some(PathBuf::from(absolute))
         );
+    }
+
+    #[test]
+    fn a_relative_path_is_resolved_against_the_base() {
+        // The ROCm and CUDA branches spawn with a different working directory,
+        // so a relative value must be pinned before it reaches --data-dir.
+        let resolved = data_dir_override(Some("voicebox-data".to_string()), &base())
+            .expect("relative value should still be an override");
+        assert!(resolved.is_absolute(), "{:?} should be absolute", resolved);
+        assert_eq!(resolved, base().join("voicebox-data"));
+        assert!(!resolved.starts_with(Path::new("backends")));
     }
 }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -213,6 +213,20 @@ struct ServerState {
     backend_override: Mutex<Option<String>>,
 }
 
+/// The data directory requested via `VOICEBOX_DATA_DIR`, if any.
+///
+/// Unset, empty and whitespace-only all mean "no override", so an env var
+/// cleared to "" falls back to the platform path rather than resolving to the
+/// current working directory.
+fn data_dir_override(env_value: Option<String>) -> Option<std::path::PathBuf> {
+    match env_value {
+        Some(value) if !value.trim().is_empty() => {
+            Some(std::path::PathBuf::from(value.trim()))
+        }
+        _ => None,
+    }
+}
+
 fn backend_override_file(data_dir: &std::path::Path) -> std::path::PathBuf {
     data_dir.join("backend_override")
 }
@@ -406,19 +420,30 @@ async fn start_server(
     // Brief wait for port to be released
     std::thread::sleep(std::time::Duration::from_millis(200));
 
-    // Get app data directory
-    let data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    // Get app data directory. VOICEBOX_DATA_DIR takes precedence over the
+    // platform app-data path: the sidecar is always spawned with an explicit
+    // --data-dir, and that argument beats the environment variable on the
+    // Python side, so resolving it here is the only place the documented
+    // override can reach the desktop app.
+    let (data_dir, data_dir_source) =
+        match data_dir_override(std::env::var("VOICEBOX_DATA_DIR").ok()) {
+            Some(path) => (path, "VOICEBOX_DATA_DIR"),
+            None => (
+                app.path()
+                    .app_data_dir()
+                    .map_err(|e| format!("Failed to get app data dir: {}", e))?,
+                "app data dir",
+            ),
+        };
 
-    // Ensure data directory exists
+    // Ensure data directory exists. Naming the path matters here: a typo in
+    // VOICEBOX_DATA_DIR surfaces as a startup error the user can act on.
     std::fs::create_dir_all(&data_dir)
-        .map_err(|e| format!("Failed to create data dir: {}", e))?;
+        .map_err(|e| format!("Failed to create data dir {:?}: {}", data_dir, e))?;
 
     println!("=================================================================");
     println!("Starting voicebox-server sidecar");
-    println!("Data directory: {:?}", data_dir);
+    println!("Data directory: {:?} (from {})", data_dir, data_dir_source);
     println!("Remote mode: {}", remote.unwrap_or(false));
 
     // Check for ROCm backend in data directory (onedir layout: backends/rocm/)
@@ -1656,4 +1681,44 @@ pub fn run() {
 
 fn main() {
     run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::data_dir_override;
+    use std::path::PathBuf;
+
+    #[test]
+    fn unset_means_no_override() {
+        assert_eq!(data_dir_override(None), None);
+    }
+
+    #[test]
+    fn empty_and_whitespace_mean_no_override() {
+        // An env var cleared to "" must not resolve to the process CWD.
+        assert_eq!(data_dir_override(Some(String::new())), None);
+        assert_eq!(data_dir_override(Some("   ".to_string())), None);
+        assert_eq!(data_dir_override(Some("\t\n".to_string())), None);
+    }
+
+    #[test]
+    fn a_path_is_used_verbatim() {
+        assert_eq!(
+            data_dir_override(Some(r"C:\Users\me\Audio\Voicebox".to_string())),
+            Some(PathBuf::from(r"C:\Users\me\Audio\Voicebox"))
+        );
+        assert_eq!(
+            data_dir_override(Some("/home/me/voicebox".to_string())),
+            Some(PathBuf::from("/home/me/voicebox"))
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        // Windows env vars set through the GUI often carry a trailing space.
+        assert_eq!(
+            data_dir_override(Some("  /home/me/voicebox  ".to_string())),
+            Some(PathBuf::from("/home/me/voicebox"))
+        );
+    }
 }


### PR DESCRIPTION
`backend/README.md` documents `VOICEBOX_DATA_DIR` alongside `--data-dir` as a way to override the data directory, but it never worked. Two open issues report this: #981 and #533.

## Why it was broken in two places

**Backend.** `config.py` only wired up `VOICEBOX_MODELS_DIR`; the data directory default stayed hardcoded to `./data`.

**Desktop app.** Fixing the backend alone is not enough. The Tauri shell resolved the directory from `app.path().app_data_dir()` unconditionally and passed it to the sidecar as an explicit `--data-dir`, which beats the environment variable on the Python side. Both issue reports show it in the log:

```
Arguments: [...'voicebox-server.exe', '--data-dir',
            'C:\Users\<user>\AppData\Roaming\sh.voicebox.app', ...]
```

So the variable could only ever reach a bare `uvicorn backend.main:app`, never the packaged app.

## Changes

- `backend/config.py` — read `VOICEBOX_DATA_DIR` when computing the default. `--data-dir` still takes precedence, since it calls `set_data_dir()` after import. This is also the only override that reaches `just dev`, which starts uvicorn directly and never parses CLI arguments.
- `tauri/src-tauri/src/main.rs` — resolve the override before the argument is built. `data_dir_str` feeds all four sidecar spawn sites, so one change covers the plain, ROCm, CUDA and fallback paths.

Unset, empty and whitespace-only all mean "no override", so a variable cleared to `""` falls back to the platform path rather than the process working directory. Surrounding whitespace is trimmed, since variables set through the Windows GUI often carry a trailing space.

The startup log now names which source won, and the `create_dir_all` failure names the path, so a typo surfaces as an actionable error rather than a silent fallback.

## Behaviour note

The Tauri `data_dir` also anchors `backends/rocm`, `backends/cuda` and the `backend_override` file, so those move under the overridden directory too. That seemed right — the point of the variable is to put app data somewhere else — but flagging it in case you'd rather scope the override more narrowly.

## Tests

- `backend/tests/test_data_dir_env.py` covers the precedence rules on the Python side.
- Four unit tests in `main.rs` cover the override decision: unset, empty, whitespace-only, verbatim path, and trimming. `cargo test --bin voicebox` passes.

No UI changes, so no screenshots apply.

Fixes #981
Fixes #533

## Also partially addresses #577

#577 asks for the `Generated` and `Captured` folder locations to be configurable. Both sit under the data directory, so both move with this change — two of that issue's three asks. What it does *not* cover is downloading models straight to a chosen location (the issue's first point; `VOICEBOX_MODELS_DIR` plus the existing migration flow is the current answer), or a folder picker in Settings. Leaving #577 open on that basis rather than claiming it.

Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure the application’s data directory with the `VOICEBOX_DATA_DIR` environment variable.
  * Relative paths are resolved consistently, and surrounding whitespace is removed.
  * Explicit data-directory settings continue to take precedence over the environment variable.

* **Bug Fixes**
  * Improved fallback behavior when the variable is missing, empty, or whitespace-only.

* **Tests**
  * Added coverage for configuration, path resolution, defaults, trimming, and overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
