### PR TITLE
fix(tests): repair test_profile_duplicate_names so the suite can run

### DIFF
--- a/backend/tests/test_profile_duplicate_names.py
+++ b/backend/tests/test_profile_duplicate_names.py
@@ -12,13 +12,9 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-# Add parent directory to path to import backend modules
-import sys
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from database import Base, VoiceProfile as DBVoiceProfile
-from models import VoiceProfileCreate
-from profiles import create_profile, update_profile
+from backend.database import Base
+from backend.models import VoiceProfileCreate
+from backend.services.profiles import create_profile, update_profile
 
 
 @pytest.fixture
@@ -37,8 +33,11 @@ def test_db():
 
     yield db
 
-    # Cleanup
+    # Cleanup. The engine must be disposed as well as the session closed —
+    # on Windows the pooled connection keeps the .db file open and rmtree
+    # fails with WinError 32.
     db.close()
+    engine.dispose()
     shutil.rmtree(temp_dir)
 
 


### PR DESCRIPTION
`just test` currently runs **zero tests** on `main`.

`backend/tests/test_profile_duplicate_names.py` still uses the pre-refactor flat imports and a `sys.path` hack:

```python
sys.path.insert(0, str(Path(__file__).parent.parent))
from database import Base, VoiceProfile as DBVoiceProfile
from models import VoiceProfileCreate
from profiles import create_profile, update_profile
```

`profiles` now lives at `backend/services/profiles.py`, so collection raises `ImportError`. pytest aborts the entire run on a collection error, so this one file takes the whole suite down:

```
ERROR backend/tests/test_profile_duplicate_names.py
!!!!!! Interrupted: 1 error during collection !!!!!!
```

It is the only test module still importing this way — every other one uses `from backend.<pkg> import`. Duplicate-name validation has therefore had no coverage since the services refactor, and the failure is silent unless you happen to pass `--ignore`.

## Changes

- Package imports, matching the rest of the suite. Dropped the `sys.path` insert and `DBVoiceProfile`, which was imported but never used.
- Fixed a latent Windows bug this exposed. With imports repaired all 6 tests passed but every one **errored in teardown** with `PermissionError: [WinError 32]` — the fixture closed the session and then `rmtree`'d the temp dir, but closing a session does not release SQLAlchemy's pooled connection, so SQLite still held `test.db` open. The engine is now disposed before the directory is removed.

## Result

- `backend/tests/test_profile_duplicate_names.py` — 6 passed, no teardown errors
- Full-suite collection goes from aborting to **170 tests collected**

One file, no behaviour change outside tests. Sent separately from my other PRs because it unblocks test runs for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test database cleanup to prevent temporary-file deletion failures on Windows.
  * Simplified test setup by using standard package imports and removing obsolete imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->