### PR TITLE
feat(tts): add Qwen VoiceDesign — voices from a written description

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Full API documentation available at `http://127.0.0.1:17493/docs`.
 | Frontend      | React, TypeScript, Tailwind CSS                                                 |
 | State         | Zustand, React Query                                                            |
 | Backend       | FastAPI (Python)                                                                |
-| TTS Engines   | Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
+| TTS Engines   | Qwen3-TTS, Qwen CustomVoice, Qwen VoiceDesign, LuxTTS, Chatterbox, Chatterbox Turbo, TADA, Kokoro |
 | STT           | Whisper / Whisper Turbo (PyTorch or MLX)                                        |
 | Local LLM     | Qwen3 (0.6B / 1.7B / 4B), shared runtime with TTS / STT                         |
 | MCP Server    | FastMCP mounted at `/mcp` (Streamable HTTP) + bundled stdio shim binary         |

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@
 
 ## What is Voicebox?
 
-Voicebox is a **local-first AI voice studio** — a free and open-source alternative to **ElevenLabs** and **WisprFlow** in one app. Clone voices from a few seconds of audio, generate speech in 23 languages across 7 TTS engines, dictate into any text field with a global hotkey, and give any MCP-aware AI agent a voice of your choosing.
+Voicebox is a **local-first AI voice studio** — a free and open-source alternative to **ElevenLabs** and **WisprFlow** in one app. Clone voices from a few seconds of audio, generate speech in 23 languages across 8 TTS engines, dictate into any text field with a global hotkey, and give any MCP-aware AI agent a voice of your choosing.
 
 The two cloud incumbents sit on opposite halves of the voice I/O loop — ElevenLabs on output, WisprFlow on input. Voicebox does both, bridges them with a bundled local LLM for refinement and per-profile personas, and runs the whole thing on your machine.
 
 - **Complete privacy** — models, voice data, and captures never leave your machine
-- **7 TTS engines** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, and Kokoro
+- **8 TTS engines** — Qwen3-TTS, Qwen CustomVoice, Qwen VoiceDesign, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, and Kokoro
 - **Voice cloning and preset voices** — zero-shot cloning from a reference sample, or 50+ curated preset voices via Kokoro and Qwen CustomVoice
 - **23 languages** — from English to Arabic, Japanese, Hindi, Swahili, and more
 - **Post-processing effects** — pitch shift, reverb, delay, chorus, compression, and filters
-- **Expressive speech** — paralinguistic tags like `[laugh]`, `[sigh]`, `[gasp]` via Chatterbox Turbo; natural-language delivery control via Qwen CustomVoice
+- **Expressive speech** — paralinguistic tags like `[laugh]`, `[sigh]`, `[gasp]` via Chatterbox Turbo; natural-language delivery control via Qwen CustomVoice; voices described in plain language via Qwen VoiceDesign
 - **Unlimited length** — auto-chunking with crossfade for scripts, articles, and chapters
 - **Stories editor** — multi-track timeline for conversations, podcasts, and narratives
 - **Voice input** — global dictation hotkey with push-to-talk and toggle modes, accessibility-verified auto-paste on macOS, in-app mic on every text field, Whisper-based STT
@@ -109,12 +109,13 @@ The two cloud incumbents sit on opposite halves of the voice I/O loop — Eleven
 
 ### Multi-Engine Voice Cloning
 
-Seven TTS engines with different strengths, switchable per-generation:
+Eight TTS engines with different strengths, switchable per-generation:
 
 | Engine                      | Languages | Strengths                                                                                                                                |
 | --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | **Qwen3-TTS** (0.6B / 1.7B) | 10        | High-quality multilingual cloning, delivery instructions ("speak slowly", "whisper")                                                     |
 | **Qwen CustomVoice**        | 10        | 9 curated preset voices with natural-language delivery control — no reference audio required                                             |
+| **Qwen VoiceDesign**        | 10        | Builds a voice from a written description — no reference audio or preset needed                                                         |
 | **LuxTTS**                  | English   | Lightweight (~1GB VRAM), 48kHz output, 150x realtime on CPU                                                                              |
 | **Chatterbox Multilingual** | 23        | Broadest language coverage — Arabic, Danish, Finnish, Greek, Hebrew, Hindi, Malay, Norwegian, Polish, Swahili, Swedish, Turkish and more |
 | **Chatterbox Turbo**        | English   | Fast 350M model with paralinguistic emotion/sound tags                                                                                   |

--- a/app/src/components/CapturesTab/CapturesTab.tsx
+++ b/app/src/components/CapturesTab/CapturesTab.tsx
@@ -268,7 +268,7 @@ export function CapturesTab() {
       // profile's stored engine preference. Cloned profiles without an
       // override fall through to whatever the backend picks.
       const engine = voice.default_engine as
-        | 'qwen' | 'qwen_custom_voice' | 'luxtts' | 'chatterbox'
+        | 'qwen' | 'qwen_custom_voice' | 'qwen_voice_design' | 'luxtts' | 'chatterbox'
         | 'chatterbox_turbo' | 'tada' | 'kokoro'
         | undefined;
       return apiClient.generateSpeech({

--- a/app/src/components/Generation/EngineModelSelector.tsx
+++ b/app/src/components/Generation/EngineModelSelector.tsx
@@ -21,6 +21,7 @@ const ENGINE_OPTIONS = [
   { value: 'qwen:0.6B', label: 'Qwen3-TTS 0.6B', engine: 'qwen' },
   { value: 'qwen_custom_voice:1.7B', label: 'Qwen CustomVoice 1.7B', engine: 'qwen_custom_voice' },
   { value: 'qwen_custom_voice:0.6B', label: 'Qwen CustomVoice 0.6B', engine: 'qwen_custom_voice' },
+  { value: 'qwen_voice_design', label: 'Qwen VoiceDesign 1.7B', engine: 'qwen_voice_design' },
   { value: 'luxtts', label: 'LuxTTS', engine: 'luxtts' },
   { value: 'chatterbox', label: 'Chatterbox', engine: 'chatterbox' },
   { value: 'chatterbox_turbo', label: 'Chatterbox Turbo', engine: 'chatterbox_turbo' },
@@ -32,6 +33,7 @@ const ENGINE_OPTIONS = [
 const ENGINE_DESCRIPTIONS: Record<string, string> = {
   qwen: 'Multi-language, two sizes',
   qwen_custom_voice: '9 preset voices, instruct control',
+  qwen_voice_design: 'Voices described in plain language',
   luxtts: 'Fast, English-focused',
   chatterbox: '23 languages, incl. Hebrew',
   chatterbox_turbo: 'English, [laugh] [cough] tags',
@@ -44,6 +46,19 @@ const ENGLISH_ONLY_ENGINES = new Set(['luxtts', 'chatterbox_turbo']);
 
 /** Engines that support cloned (reference audio) profiles. */
 const CLONING_ENGINES = new Set(['qwen', 'luxtts', 'chatterbox', 'chatterbox_turbo', 'tada']);
+
+/** Engines that synthesise a voice from a written description. */
+export const DESIGN_ENGINES = new Set(['qwen_voice_design']);
+
+/**
+ * Engines that actually honor the instruct kwarg at model level. Base
+ * Qwen3-TTS accepts it but ignores it, so it is deliberately absent.
+ */
+const INSTRUCT_ENGINES = new Set(['qwen_custom_voice', 'qwen_voice_design']);
+
+export function engineSupportsInstruct(engine?: string): boolean {
+  return !!engine && INSTRUCT_ENGINES.has(engine);
+}
 
 function getAvailableOptions(selectedProfile?: VoiceProfileResponse | null) {
   if (!selectedProfile) return ENGINE_OPTIONS;
@@ -166,5 +181,6 @@ export function isProfileCompatibleWithEngine(
   const voiceType = profile.voice_type || 'cloned';
   if (voiceType === 'preset') return profile.preset_engine === engine;
   if (voiceType === 'cloned') return CLONING_ENGINES.has(engine);
-  return true; // designed — future
+  if (voiceType === 'designed') return DESIGN_ENGINES.has(engine);
+  return true;
 }

--- a/app/src/components/Generation/FloatingGenerateBox.tsx
+++ b/app/src/components/Generation/FloatingGenerateBox.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/lib/utils/cn';
 import { useGenerationStore } from '@/stores/generationStore';
 import { useStoryStore } from '@/stores/storyStore';
 import { useUIStore } from '@/stores/uiStore';
-import { EngineModelSelector } from './EngineModelSelector';
+import { EngineModelSelector, engineSupportsInstruct } from './EngineModelSelector';
 import { ParalinguisticInput } from './ParalinguisticInput';
 
 interface FloatingGenerateBoxProps {
@@ -151,7 +151,8 @@ export function FloatingGenerateBox({
     | 'chatterbox_turbo'
     | 'tada'
     | 'kokoro'
-    | 'qwen_custom_voice';
+    | 'qwen_custom_voice'
+    | 'qwen_voice_design';
   useEffect(() => {
     if (selectedProfile?.language) {
       form.setValue('language', selectedProfile.language as LanguageCode);
@@ -160,10 +161,16 @@ export function FloatingGenerateBox({
     const engine = selectedProfile?.default_engine ?? selectedProfile?.preset_engine;
     if (engine) {
       form.setValue('engine', engine as EngineValue);
-    } else if (selectedProfile && selectedProfile.voice_type !== 'preset') {
-      // Cloned/designed profile with no default — ensure a compatible (non-preset) engine
+    } else if (
+      selectedProfile &&
+      selectedProfile.voice_type !== 'preset' &&
+      selectedProfile.voice_type !== 'designed'
+    ) {
+      // Cloned profile with no default — ensure a compatible (non-preset) engine.
+      // Designed profiles are excluded: they always carry a design engine and
+      // would be broken by a fallback to qwen.
       const currentEngine = form.getValues('engine');
-      const presetEngines = new Set(['kokoro', 'qwen_custom_voice']);
+      const presetEngines = new Set(['kokoro', 'qwen_custom_voice', 'qwen_voice_design']);
       if (currentEngine && presetEngines.has(currentEngine)) {
         form.setValue('engine', 'qwen');
       }
@@ -436,9 +443,9 @@ export function FloatingGenerateBox({
                   )}
                 </AnimatePresence>
 
-                {/* Instruct toggle — only for Qwen CustomVoice, which actually honors the kwarg */}
+                {/* Instruct toggle — only for engines that actually honor the kwarg */}
                 <AnimatePresence>
-                  {isExpanded && form.watch('engine') === 'qwen_custom_voice' && (
+                  {isExpanded && engineSupportsInstruct(form.watch('engine')) && (
                     <motion.div
                       initial={{ opacity: 0, scale: 0.8 }}
                       animate={{ opacity: 1, scale: 1 }}
@@ -507,7 +514,7 @@ export function FloatingGenerateBox({
 
             {/* Additive instruct textarea — shown below main text when toggle is on and engine supports it */}
             <AnimatePresence>
-              {isInstructExpanded && form.watch('engine') === 'qwen_custom_voice' && (
+              {isInstructExpanded && engineSupportsInstruct(form.watch('engine')) && (
                 <motion.div
                   initial={{ opacity: 0, height: 0 }}
                   animate={{ opacity: 1, height: 'auto' }}

--- a/app/src/components/ServerSettings/ModelManagement.tsx
+++ b/app/src/components/ServerSettings/ModelManagement.tsx
@@ -73,6 +73,8 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
     'Qwen3-TTS CustomVoice 1.7B by Alibaba. 9 premium preset voices with instruct-based style control for tone, emotion, and prosody. Supports 10 languages.',
   'qwen-custom-voice-0.6B':
     'Qwen3-TTS CustomVoice 0.6B by Alibaba. Lightweight version with the same 9 preset voices and instruct control. Faster inference for lower-end hardware.',
+  'qwen-voice-design-1.7B':
+    'Qwen3-TTS VoiceDesign 1.7B by Alibaba. Builds a voice from a written description instead of reference audio or a preset. Supports the same 10 languages.',
   'whisper-base':
     'Smallest Whisper model (74M parameters). Fast transcription with moderate accuracy.',
   'whisper-small':
@@ -411,6 +413,7 @@ export function ModelManagement() {
       (m) =>
         m.model_name.startsWith('qwen-tts') ||
         m.model_name.startsWith('qwen-custom-voice') ||
+        m.model_name.startsWith('qwen-voice-design') ||
         m.model_name.startsWith('luxtts') ||
         m.model_name.startsWith('chatterbox') ||
         m.model_name.startsWith('tada') ||

--- a/app/src/components/VoiceProfiles/ProfileCard.tsx
+++ b/app/src/components/VoiceProfiles/ProfileCard.tsx
@@ -22,6 +22,7 @@ import { useUIStore } from '@/stores/uiStore';
 const ENGINE_DISPLAY_NAMES: Record<string, string> = {
   kokoro: 'Kokoro',
   qwen_custom_voice: 'CustomVoice',
+  qwen_voice_design: 'VoiceDesign',
 };
 
 interface ProfileCardProps {

--- a/app/src/components/VoiceProfiles/ProfileForm.tsx
+++ b/app/src/components/VoiceProfiles/ProfileForm.tsx
@@ -360,6 +360,10 @@ export function ProfileForm() {
         avatarFile: undefined,
       });
       setSampleMode(profileFormDraft.sampleMode);
+      // Reopen in the mode the draft was written in, otherwise a designed
+      // draft comes back as a clone with its description dropped.
+      setVoiceSource(profileFormDraft.voiceSource ?? 'clone');
+      setDesignPrompt(profileFormDraft.designPrompt ?? '');
       // Restore the file if we have it saved
       if (
         profileFormDraft.sampleFileData &&
@@ -810,7 +814,11 @@ export function ProfileForm() {
       // Save draft when closing the create modal
       const values = form.getValues();
       const hasContent =
-        values.name || values.description || values.referenceText || values.sampleFile;
+        values.name ||
+        values.description ||
+        values.referenceText ||
+        values.sampleFile ||
+        designPrompt.trim();
 
       if (hasContent) {
         const draft: ProfileFormDraft = {
@@ -820,6 +828,8 @@ export function ProfileForm() {
           personality: values.personality || '',
           referenceText: values.referenceText || '',
           sampleMode,
+          voiceSource,
+          designPrompt,
         };
 
         // Save file as base64 if present

--- a/app/src/components/VoiceProfiles/ProfileForm.tsx
+++ b/app/src/components/VoiceProfiles/ProfileForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
-import { Edit2, Mic, Monitor, Music, Upload, X } from 'lucide-react';
+import { Edit2, Mic, Monitor, Music, Sparkles, Upload, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -61,10 +61,15 @@ import { AudioSampleUpload } from './AudioSampleUpload';
 import { SampleList } from './SampleList';
 
 const MAX_AUDIO_DURATION_SECONDS = 30;
-const PRESET_ONLY_ENGINES = new Set(['kokoro', 'qwen_custom_voice']);
+const MAX_DESIGN_PROMPT_LENGTH = 500;
+/** Engines that can't be a default for a sample-based (cloned) profile. */
+const PRESET_ONLY_ENGINES = new Set(['kokoro', 'qwen_custom_voice', 'qwen_voice_design']);
+/** The engine a designed profile is created against. */
+const DESIGN_ENGINE = 'qwen_voice_design';
 const DEFAULT_ENGINE_OPTIONS = [
   { value: 'qwen', label: 'Qwen3-TTS' },
   { value: 'qwen_custom_voice', label: 'Qwen CustomVoice' },
+  { value: 'qwen_voice_design', label: 'Qwen VoiceDesign' },
   { value: 'luxtts', label: 'LuxTTS' },
   { value: 'chatterbox', label: 'Chatterbox' },
   { value: 'chatterbox_turbo', label: 'Chatterbox Turbo' },
@@ -147,7 +152,8 @@ export function ProfileForm() {
   const deleteAvatar = useDeleteAvatar();
   const transcribe = useTranscription();
   const { toast } = useToast();
-  const [voiceSource, setVoiceSource] = useState<'clone' | 'builtin'>('clone');
+  const [voiceSource, setVoiceSource] = useState<'clone' | 'builtin' | 'design'>('clone');
+  const [designPrompt, setDesignPrompt] = useState<string>('');
   const [sampleMode, setSampleMode] = useState<'upload' | 'record' | 'system'>('record');
   const [audioDuration, setAudioDuration] = useState<number | null>(null);
   const [isValidatingAudio, setIsValidatingAudio] = useState(false);
@@ -288,7 +294,7 @@ export function ProfileForm() {
   const presetVoices = presetVoicesData?.voices ?? [];
   const isSampleBasedProfile = isCreating
     ? voiceSource === 'clone'
-    : editingProfile?.voice_type !== 'preset';
+    : editingProfile?.voice_type !== 'preset' && editingProfile?.voice_type !== 'designed';
   const availableDefaultEngines = DEFAULT_ENGINE_OPTIONS.filter(
     (option) => !isSampleBasedProfile || !PRESET_ONLY_ENGINES.has(option.value),
   );
@@ -591,6 +597,51 @@ export function ProfileForm() {
           title: t('profileForm.toast.profileCreated'),
           description: t('profileForm.toast.profileCreatedBuiltin', { name: data.name }),
         });
+      } else if (voiceSource === 'design') {
+        // Creating a designed profile from a written voice description
+        const trimmedDesign = designPrompt.trim();
+        if (!trimmedDesign) {
+          toast({
+            title: t('profileForm.toast.noDesignPrompt'),
+            description: t('profileForm.toast.noDesignPromptDescription'),
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        const profile = await createProfile.mutateAsync({
+          name: data.name,
+          description: data.description,
+          language: data.language,
+          voice_type: 'designed' as VoiceType,
+          design_prompt: trimmedDesign,
+          default_engine: DESIGN_ENGINE,
+          personality: data.personality?.trim() ? data.personality.trim() : undefined,
+        });
+
+        // Handle avatar upload if provided
+        if (data.avatarFile) {
+          try {
+            await uploadAvatar.mutateAsync({
+              profileId: profile.id,
+              file: data.avatarFile,
+            });
+          } catch (avatarError) {
+            toast({
+              title: t('profileForm.toast.avatarUploadFailed'),
+              description:
+                avatarError instanceof Error
+                  ? avatarError.message
+                  : t('profileForm.toast.avatarUploadFailedFallback'),
+              variant: 'destructive',
+            });
+          }
+        }
+
+        toast({
+          title: t('profileForm.toast.profileCreated'),
+          description: t('profileForm.toast.profileCreatedDesigned', { name: data.name }),
+        });
       } else {
         // Creating cloned profile: require sample file and reference text
         const sampleFile = form.getValues('sampleFile');
@@ -742,6 +793,7 @@ export function ProfileForm() {
       // Clear draft and reset form on success
       setProfileFormDraft(null);
       form.reset();
+      setDesignPrompt('');
       setEditingProfileId(null);
       setOpen(false);
     } catch (error) {
@@ -834,6 +886,7 @@ export function ProfileForm() {
                       avatarFile: undefined,
                     });
                     setSampleMode('record');
+                    setDesignPrompt('');
                   }}
                 >
                   <X className="h-3 w-3 mr-1" />
@@ -877,10 +930,48 @@ export function ProfileForm() {
                             <Music className="h-3.5 w-3.5" />
                             {t('profileForm.source.builtin')}
                           </button>
+                          <button
+                            type="button"
+                            onClick={() => setVoiceSource('design')}
+                            className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition-colors ${
+                              voiceSource === 'design'
+                                ? 'bg-accent text-accent-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground'
+                            }`}
+                          >
+                            <Sparkles className="h-3.5 w-3.5" />
+                            {t('profileForm.source.design')}
+                          </button>
                         </div>
                       </div>
 
-                      {voiceSource === 'builtin' ? (
+                      {voiceSource === 'design' ? (
+                        <div className="space-y-4">
+                          <FormDescription>{t('profileForm.design.hint')}</FormDescription>
+
+                          <FormItem>
+                            <FormLabel>{t('profileForm.fields.designPrompt')}</FormLabel>
+                            <FormControl>
+                              <Textarea
+                                value={designPrompt}
+                                onChange={(e) => setDesignPrompt(e.target.value)}
+                                placeholder={t('profileForm.design.placeholder')}
+                                maxLength={MAX_DESIGN_PROMPT_LENGTH}
+                                rows={6}
+                                className="resize-none"
+                              />
+                            </FormControl>
+                            <div className="flex justify-between">
+                              <p className="text-xs text-muted-foreground">
+                                {t('profileForm.design.engineNote')}
+                              </p>
+                              <p className="text-xs text-muted-foreground tabular-nums">
+                                {designPrompt.length}/{MAX_DESIGN_PROMPT_LENGTH}
+                              </p>
+                            </div>
+                          </FormItem>
+                        </div>
+                      ) : voiceSource === 'builtin' ? (
                         <div className="space-y-4">
                           <FormDescription>{t('profileForm.builtin.hint')}</FormDescription>
 
@@ -1101,6 +1192,23 @@ export function ProfileForm() {
                           {t('profileForm.builtin.note')}
                         </p>
                       </div>
+                    ) : editingProfile.voice_type === 'designed' ? (
+                      <div className="space-y-4 pt-4">
+                        <div className="rounded-lg border border-border p-4 space-y-3">
+                          <div className="text-sm font-medium text-muted-foreground">
+                            {t('profileForm.design.badge')}
+                          </div>
+                          <p className="text-sm leading-relaxed">
+                            {editingProfile.design_prompt}
+                          </p>
+                          <Badge variant="secondary" className="text-xs">
+                            {editingProfile.default_engine}
+                          </Badge>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {t('profileForm.design.note')}
+                        </p>
+                      </div>
                     ) : (
                       <div>
                         <SampleList profileId={editingProfileId} />
@@ -1248,7 +1356,10 @@ export function ProfileForm() {
                         setDefaultEngine(v === '_none' ? '' : v);
                       }}
                       disabled={
-                        voiceSource === 'builtin' || editingProfile?.voice_type === 'preset'
+                        voiceSource === 'builtin' ||
+                        voiceSource === 'design' ||
+                        editingProfile?.voice_type === 'preset' ||
+                        editingProfile?.voice_type === 'designed'
                       }
                     >
                       <FormControl>

--- a/app/src/components/VoiceProfiles/ProfileList.tsx
+++ b/app/src/components/VoiceProfiles/ProfileList.tsx
@@ -5,11 +5,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useProfiles } from '@/lib/hooks/useProfiles';
 import { useUIStore } from '@/stores/uiStore';
+import { isProfileCompatibleWithEngine } from '@/components/Generation/EngineModelSelector';
 import { ProfileCard } from './ProfileCard';
 import { ProfileForm } from './ProfileForm';
-
-/** Engines that use preset (built-in) voices instead of cloned profiles. */
-const PRESET_ENGINES = new Set(['kokoro', 'qwen_custom_voice']);
 
 export function ProfileList() {
   const { t } = useTranslation();
@@ -55,13 +53,10 @@ export function ProfileList() {
   }
 
   const allProfiles = profiles || [];
-  const isPresetEngine = PRESET_ENGINES.has(selectedEngine);
 
   /** Whether a profile is supported by the currently selected engine. */
   const isSupported = (p: (typeof allProfiles)[number]) =>
-    isPresetEngine
-      ? p.voice_type === 'preset' && p.preset_engine === selectedEngine
-      : p.voice_type !== 'preset';
+    isProfileCompatibleWithEngine(p, selectedEngine);
 
   // Sort so supported profiles come first
   const sortedProfiles = [...allProfiles].sort(

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -243,12 +243,20 @@
     "discard": "Discard",
     "source": {
       "clone": "Clone from audio",
-      "builtin": "Built-in voice"
+      "builtin": "Built-in voice",
+      "design": "Describe a voice"
     },
     "builtin": {
       "hint": "Choose a pre-built voice. These don't require an audio sample.",
       "badge": "Built-in Voice",
       "note": "This profile uses a built-in voice. The voice cannot be changed after creation."
+    },
+    "design": {
+      "hint": "Describe the voice you want in plain language. No audio sample needed.",
+      "placeholder": "A warm, gravelly older man with a slow Scottish lilt and a hint of amusement.",
+      "engineNote": "Uses Qwen VoiceDesign",
+      "badge": "Designed Voice",
+      "note": "This profile uses a described voice. The description cannot be changed after creation."
     },
     "sampleTabs": {
       "upload": "Upload",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "Describe this voice…",
       "language": "Language",
       "referenceText": "Reference Text",
+      "designPrompt": "Voice Description",
       "referenceTextPlaceholder": "Enter the exact text spoken in the audio…",
       "defaultEngine": "Default Engine",
       "noPreference": "No preference",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" has been updated successfully.",
       "noVoiceSelected": "No voice selected",
       "noVoiceSelectedDescription": "Please select a built-in voice.",
+      "noDesignPrompt": "No description given",
+      "noDesignPromptDescription": "Please describe the voice you want.",
       "profileCreated": "Profile created",
       "profileCreatedBuiltin": "\"{{name}}\" has been created with a built-in voice.",
+      "profileCreatedDesigned": "\"{{name}}\" has been created from a voice description.",
       "profileCreatedSample": "\"{{name}}\" has been created with a sample.",
       "sampleRequired": "Audio sample required",
       "sampleRequiredDescription": "Please provide an audio sample to create the voice profile.",

--- a/app/src/i18n/locales/es/translation.json
+++ b/app/src/i18n/locales/es/translation.json
@@ -243,12 +243,20 @@
     "discard": "Descartar",
     "source": {
       "clone": "Clonar desde audio",
-      "builtin": "Voz integrada"
+      "builtin": "Voz integrada",
+      "design": "Describir una voz"
     },
     "builtin": {
       "hint": "Elige una voz prediseñada. Estas no requieren una muestra de audio.",
       "badge": "Voz integrada",
       "note": "Este perfil usa una voz integrada. La voz no se puede cambiar después de crearlo."
+    },
+    "design": {
+      "hint": "Describe la voz que quieres en lenguaje natural. No hace falta una muestra de audio.",
+      "placeholder": "Un hombre mayor de voz cálida y rasposa, con un acento escocés pausado y un punto de guasa.",
+      "engineNote": "Usa Qwen VoiceDesign",
+      "badge": "Voz diseñada",
+      "note": "Este perfil usa una voz descrita. La descripción no se puede cambiar después de crearla."
     },
     "sampleTabs": {
       "upload": "Subir",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "Describe esta voz…",
       "language": "Idioma",
       "referenceText": "Texto de referencia",
+      "designPrompt": "Descripción de la voz",
       "referenceTextPlaceholder": "Introduce el texto exacto hablado en el audio…",
       "defaultEngine": "Motor predeterminado",
       "noPreference": "Sin preferencia",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" se ha actualizado correctamente.",
       "noVoiceSelected": "Ninguna voz seleccionada",
       "noVoiceSelectedDescription": "Selecciona una voz integrada.",
+      "noDesignPrompt": "No se indicó descripción",
+      "noDesignPromptDescription": "Describe la voz que quieres.",
       "profileCreated": "Perfil creado",
       "profileCreatedBuiltin": "\"{{name}}\" se ha creado con una voz integrada.",
+      "profileCreatedDesigned": "\"{{name}}\" se ha creado a partir de una descripción de voz.",
       "profileCreatedSample": "\"{{name}}\" se ha creado con una muestra.",
       "sampleRequired": "Muestra de audio obligatoria",
       "sampleRequiredDescription": "Proporciona una muestra de audio para crear el perfil de voz.",

--- a/app/src/i18n/locales/fr/translation.json
+++ b/app/src/i18n/locales/fr/translation.json
@@ -243,12 +243,20 @@
     "discard": "Annuler",
     "source": {
       "clone": "Cloner à partir de l'audio",
-      "builtin": "Voix intégrée"
+      "builtin": "Voix intégrée",
+      "design": "Décrire une voix"
     },
     "builtin": {
       "hint": "Choisissez une voix pré-construite. Ces voix ne nécessitent pas d'échantillon audio.",
       "badge": "Voix intégrée",
       "note": "Ce profil utilise une voix intégrée. La voix ne peut pas être modifiée après la création."
+    },
+    "design": {
+      "hint": "Décrivez la voix souhaitée en langage courant. Aucun échantillon audio requis.",
+      "placeholder": "Un homme âgé à la voix chaude et rocailleuse, avec un accent écossais lent et une pointe d'amusement.",
+      "engineNote": "Utilise Qwen VoiceDesign",
+      "badge": "Voix conçue",
+      "note": "Ce profil utilise une voix décrite. La description ne peut pas être modifiée après la création."
     },
     "sampleTabs": {
       "upload": "Importer",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "Décrivez cette voix…",
       "language": "Langue",
       "referenceText": "Texte de référence",
+      "designPrompt": "Description de la voix",
       "referenceTextPlaceholder": "Saisissez le texte exact prononcé dans l'audio…",
       "defaultEngine": "Moteur par défaut",
       "noPreference": "Aucune préférence",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" a été mis à jour avec succès.",
       "noVoiceSelected": "Aucune voix sélectionnée",
       "noVoiceSelectedDescription": "Veuillez sélectionner une voix intégrée.",
+      "noDesignPrompt": "Aucune description fournie",
+      "noDesignPromptDescription": "Veuillez décrire la voix souhaitée.",
       "profileCreated": "Profil créé",
       "profileCreatedBuiltin": "\"{{name}}\" a été créé avec une voix intégrée.",
+      "profileCreatedDesigned": "\"{{name}}\" a été créé à partir d'une description de voix.",
       "profileCreatedSample": "\"{{name}}\" a été créé avec un échantillon.",
       "sampleRequired": "Échantillon audio requis",
       "sampleRequiredDescription": "Veuillez fournir un échantillon audio pour créer le profil vocal.",

--- a/app/src/i18n/locales/it/translation.json
+++ b/app/src/i18n/locales/it/translation.json
@@ -243,12 +243,20 @@
     "discard": "Scarta",
     "source": {
       "clone": "Clona da audio",
-      "builtin": "Voce integrata"
+      "builtin": "Voce integrata",
+      "design": "Descrivi una voce"
     },
     "builtin": {
       "hint": "Scegli una voce predefinita. Queste non richiedono un campione audio.",
       "badge": "Voce integrata",
       "note": "Questo profilo utilizza una voce integrata. La voce non può essere modificata dopo la creazione."
+    },
+    "design": {
+      "hint": "Descrivi la voce che vuoi in linguaggio naturale. Non serve un campione audio.",
+      "placeholder": "Un uomo anziano dalla voce calda e roca, con una lenta cadenza scozzese e un pizzico di ironia.",
+      "engineNote": "Usa Qwen VoiceDesign",
+      "badge": "Voce progettata",
+      "note": "Questo profilo usa una voce descritta. La descrizione non può essere modificata dopo la creazione."
     },
     "sampleTabs": {
       "upload": "Carica",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "Descrivi questa voce…",
       "language": "Lingua",
       "referenceText": "Testo di riferimento",
+      "designPrompt": "Descrizione della voce",
       "referenceTextPlaceholder": "Inserisci il testo esatto pronunciato nell'audio…",
       "defaultEngine": "Motore predefinito",
       "noPreference": "Nessuna preferenza",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" è stata aggiornata con successo.",
       "noVoiceSelected": "Nessuna voce selezionata",
       "noVoiceSelectedDescription": "Seleziona una voce integrata.",
+      "noDesignPrompt": "Nessuna descrizione fornita",
+      "noDesignPromptDescription": "Descrivi la voce che desideri.",
       "profileCreated": "Profilo creato",
       "profileCreatedBuiltin": "\"{{name}}\" è stato creato con una voce integrata.",
+      "profileCreatedDesigned": "\"{{name}}\" è stato creato da una descrizione vocale.",
       "profileCreatedSample": "\"{{name}}\" è stato creato con un campione.",
       "sampleRequired": "Campione audio richiesto",
       "sampleRequiredDescription": "Fornisci un campione audio per creare il profilo vocale.",

--- a/app/src/i18n/locales/ja/translation.json
+++ b/app/src/i18n/locales/ja/translation.json
@@ -243,12 +243,20 @@
     "discard": "破棄",
     "source": {
       "clone": "オーディオから複製",
-      "builtin": "ビルトインボイス"
+      "builtin": "ビルトインボイス",
+      "design": "声を説明する"
     },
     "builtin": {
       "hint": "あらかじめ用意されたボイスを選択してください。オーディオサンプルは不要です。",
       "badge": "ビルトインボイス",
       "note": "このプロファイルはビルトインボイスを使用しています。作成後はボイスを変更できません。"
+    },
+    "design": {
+      "hint": "欲しい声を普通の言葉で説明してください。音声サンプルは不要です。",
+      "placeholder": "温かくしゃがれた年配の男性の声。ゆっくりしたスコットランド訛りで、少し愉快そうな響き。",
+      "engineNote": "Qwen VoiceDesign を使用",
+      "badge": "設計された声",
+      "note": "このプロファイルは説明から生成した声を使います。説明は作成後に変更できません。"
     },
     "sampleTabs": {
       "upload": "アップロード",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "このボイスを説明してください…",
       "language": "言語",
       "referenceText": "リファレンステキスト",
+      "designPrompt": "声の説明",
       "referenceTextPlaceholder": "オーディオで話されている正確なテキストを入力してください…",
       "defaultEngine": "デフォルトエンジン",
       "noPreference": "指定なし",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "「{{name}}」を正常に更新しました。",
       "noVoiceSelected": "ボイスが選択されていません",
       "noVoiceSelectedDescription": "ビルトインボイスを選択してください。",
+      "noDesignPrompt": "説明がありません",
+      "noDesignPromptDescription": "欲しい声を説明してください。",
       "profileCreated": "プロファイルを作成しました",
       "profileCreatedBuiltin": "「{{name}}」をビルトインボイスで作成しました。",
+      "profileCreatedDesigned": "「{{name}}」を声の説明から作成しました。",
       "profileCreatedSample": "「{{name}}」をサンプルで作成しました。",
       "sampleRequired": "オーディオサンプルが必要です",
       "sampleRequiredDescription": "ボイスプロファイルを作成するには、オーディオサンプルを用意してください。",

--- a/app/src/i18n/locales/ko/translation.json
+++ b/app/src/i18n/locales/ko/translation.json
@@ -243,12 +243,20 @@
     "discard": "취소",
     "source": {
       "clone": "오디오에서 복제",
-      "builtin": "내장 음성"
+      "builtin": "내장 음성",
+      "design": "목소리 설명하기"
     },
     "builtin": {
       "hint": "미리 제작된 음성을 선택하세요. 오디오 샘플이 필요하지 않습니다.",
       "badge": "내장 음성",
       "note": "이 프로필은 내장 음성을 사용합니다. 생성 후에는 음성을 변경할 수 없습니다."
+    },
+    "design": {
+      "hint": "원하는 목소리를 일상적인 말로 설명하세요. 오디오 샘플은 필요 없습니다.",
+      "placeholder": "따뜻하고 거친 노년 남성의 목소리. 느릿한 스코틀랜드 억양에 약간의 유머가 묻어남.",
+      "engineNote": "Qwen VoiceDesign 사용",
+      "badge": "디자인된 목소리",
+      "note": "이 프로필은 설명으로 만든 목소리를 사용합니다. 설명은 생성 후 변경할 수 없습니다."
     },
     "sampleTabs": {
       "upload": "업로드",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "이 음성에 대해 설명해 주세요…",
       "language": "언어",
       "referenceText": "참조 텍스트",
+      "designPrompt": "목소리 설명",
       "referenceTextPlaceholder": "오디오에서 말한 텍스트를 정확히 입력하세요…",
       "defaultEngine": "기본 엔진",
       "noPreference": "선택 안 함",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\"이(가) 성공적으로 업데이트되었습니다.",
       "noVoiceSelected": "선택된 음성 없음",
       "noVoiceSelectedDescription": "내장 음성을 선택해 주세요.",
+      "noDesignPrompt": "설명이 없습니다",
+      "noDesignPromptDescription": "원하는 목소리를 설명해 주세요.",
       "profileCreated": "프로필 생성됨",
       "profileCreatedBuiltin": "\"{{name}}\"이(가) 내장 음성으로 생성되었습니다.",
+      "profileCreatedDesigned": "\"{{name}}\"이(가) 목소리 설명으로 생성되었습니다.",
       "profileCreatedSample": "\"{{name}}\"이(가) 샘플로 생성되었습니다.",
       "sampleRequired": "오디오 샘플 필요",
       "sampleRequiredDescription": "음성 프로필을 만들려면 오디오 샘플을 제공해 주세요.",

--- a/app/src/i18n/locales/pt-BR/translation.json
+++ b/app/src/i18n/locales/pt-BR/translation.json
@@ -243,12 +243,20 @@
     "discard": "Descartar",
     "source": {
       "clone": "Clonar de áudio",
-      "builtin": "Voz integrada"
+      "builtin": "Voz integrada",
+      "design": "Descrever uma voz"
     },
     "builtin": {
       "hint": "Escolha uma voz pré-construída. Estas não precisam de uma amostra de áudio.",
       "badge": "Voz Integrada",
       "note": "Este perfil usa uma voz integrada. A voz não pode ser alterada após a criação."
+    },
+    "design": {
+      "hint": "Descreva a voz que você quer em linguagem natural. Não é preciso amostra de áudio.",
+      "placeholder": "Um homem mais velho de voz quente e rouca, com sotaque escocês pausado e um toque de humor.",
+      "engineNote": "Usa Qwen VoiceDesign",
+      "badge": "Voz projetada",
+      "note": "Este perfil usa uma voz descrita. A descrição não pode ser alterada após a criação."
     },
     "sampleTabs": {
       "upload": "Enviar",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "Descreva esta voz…",
       "language": "Idioma",
       "referenceText": "Texto de Referência",
+      "designPrompt": "Descrição da voz",
       "referenceTextPlaceholder": "Digite o texto exato falado no áudio…",
       "defaultEngine": "Motor Padrão",
       "noPreference": "Sem preferência",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" foi atualizada com sucesso.",
       "noVoiceSelected": "Nenhuma voz selecionada",
       "noVoiceSelectedDescription": "Selecione uma voz integrada.",
+      "noDesignPrompt": "Nenhuma descrição informada",
+      "noDesignPromptDescription": "Descreva a voz que você quer.",
       "profileCreated": "Perfil criado",
       "profileCreatedBuiltin": "\"{{name}}\" foi criado com uma voz integrada.",
+      "profileCreatedDesigned": "\"{{name}}\" foi criado a partir de uma descrição de voz.",
       "profileCreatedSample": "\"{{name}}\" foi criado com uma amostra.",
       "sampleRequired": "Amostra de áudio obrigatória",
       "sampleRequiredDescription": "Forneça uma amostra de áudio para criar o perfil de voz.",

--- a/app/src/i18n/locales/zh-CN/translation.json
+++ b/app/src/i18n/locales/zh-CN/translation.json
@@ -243,12 +243,20 @@
     "discard": "丢弃",
     "source": {
       "clone": "从音频克隆",
-      "builtin": "内置声音"
+      "builtin": "内置声音",
+      "design": "描述声音"
     },
     "builtin": {
       "hint": "选择一个预建的声音。这些不需要音频样本。",
       "badge": "内置声音",
       "note": "此档案使用内置声音。创建后声音无法更改。"
+    },
+    "design": {
+      "hint": "用日常语言描述你想要的声音，无需音频样本。",
+      "placeholder": "一位声音温暖沙哑的年长男性，带着缓慢的苏格兰口音和一丝笑意。",
+      "engineNote": "使用 Qwen VoiceDesign",
+      "badge": "设计的声音",
+      "note": "此配置使用描述生成的声音。创建后描述不可更改。"
     },
     "sampleTabs": {
       "upload": "上传",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "描述此声音……",
       "language": "语言",
       "referenceText": "参考文本",
+      "designPrompt": "声音描述",
       "referenceTextPlaceholder": "输入音频中所说的准确文字……",
       "defaultEngine": "默认引擎",
       "noPreference": "无偏好",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" 已成功更新。",
       "noVoiceSelected": "未选择声音",
       "noVoiceSelectedDescription": "请选择内置声音。",
+      "noDesignPrompt": "未填写描述",
+      "noDesignPromptDescription": "请描述你想要的声音。",
       "profileCreated": "档案已创建",
       "profileCreatedBuiltin": "\"{{name}}\" 已使用内置声音创建。",
+      "profileCreatedDesigned": "“{{name}}”已根据声音描述创建。",
       "profileCreatedSample": "\"{{name}}\" 已使用样本创建。",
       "sampleRequired": "需要音频样本",
       "sampleRequiredDescription": "请提供音频样本以创建声音档案。",

--- a/app/src/i18n/locales/zh-TW/translation.json
+++ b/app/src/i18n/locales/zh-TW/translation.json
@@ -243,12 +243,20 @@
     "discard": "捨棄",
     "source": {
       "clone": "從音訊複製",
-      "builtin": "內建聲音"
+      "builtin": "內建聲音",
+      "design": "描述聲音"
     },
     "builtin": {
       "hint": "選擇預建的聲音。這些不需要音訊樣本。",
       "badge": "內建聲音",
       "note": "此檔案使用內建聲音。建立後聲音無法變更。"
+    },
+    "design": {
+      "hint": "用日常語言描述你想要的聲音，不需要音訊樣本。",
+      "placeholder": "一位聲音溫暖沙啞的年長男性，帶著緩慢的蘇格蘭口音和一絲笑意。",
+      "engineNote": "使用 Qwen VoiceDesign",
+      "badge": "設計的聲音",
+      "note": "此設定檔使用描述產生的聲音。建立後描述無法變更。"
     },
     "sampleTabs": {
       "upload": "上傳",
@@ -264,6 +272,7 @@
       "descriptionPlaceholder": "描述此聲音……",
       "language": "語言",
       "referenceText": "參考文字",
+      "designPrompt": "聲音描述",
       "referenceTextPlaceholder": "輸入音訊中所說的確切文字……",
       "defaultEngine": "預設引擎",
       "noPreference": "無偏好",
@@ -316,8 +325,11 @@
       "voiceUpdatedDescription": "\"{{name}}\" 已成功更新。",
       "noVoiceSelected": "未選擇聲音",
       "noVoiceSelectedDescription": "請選擇內建聲音。",
+      "noDesignPrompt": "未填寫描述",
+      "noDesignPromptDescription": "請描述你想要的聲音。",
       "profileCreated": "已建立檔案",
       "profileCreatedBuiltin": "\"{{name}}\" 已使用內建聲音建立。",
+      "profileCreatedDesigned": "「{{name}}」已根據聲音描述建立。",
       "profileCreatedSample": "\"{{name}}\" 已使用樣本建立。",
       "sampleRequired": "需要音訊樣本",
       "sampleRequiredDescription": "請提供音訊樣本以建立聲音檔案。",

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -74,6 +74,7 @@ export interface GenerationRequest {
   engine?:
     | 'qwen'
     | 'qwen_custom_voice'
+    | 'qwen_voice_design'
     | 'luxtts'
     | 'chatterbox'
     | 'chatterbox_turbo'

--- a/app/src/lib/constants/languages.ts
+++ b/app/src/lib/constants/languages.ts
@@ -70,6 +70,7 @@ export const ENGINE_LANGUAGES: Record<string, readonly LanguageCode[]> = {
   tada: ['en', 'ar', 'zh', 'de', 'es', 'fr', 'it', 'ja', 'pl', 'pt'],
   kokoro: ['en', 'es', 'fr', 'hi', 'it', 'pt', 'ja', 'zh'],
   qwen_custom_voice: ['zh', 'en', 'ja', 'ko', 'de', 'fr', 'ru', 'pt', 'es', 'it'],
+  qwen_voice_design: ['zh', 'en', 'ja', 'ko', 'de', 'fr', 'ru', 'pt', 'es', 'it'],
 } as const;
 
 /** Helper: get language options for a given engine. */

--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -22,6 +22,7 @@ const generationSchema = z.object({
     .enum([
       'qwen',
       'qwen_custom_voice',
+      'qwen_voice_design',
       'luxtts',
       'chatterbox',
       'chatterbox_turbo',
@@ -100,9 +101,11 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'tada-1b'
                 : engine === 'kokoro'
                   ? 'kokoro'
-                  : engine === 'qwen_custom_voice'
-                    ? `qwen-custom-voice-${data.modelSize}`
-                    : `qwen-tts-${data.modelSize}`;
+                  : engine === 'qwen_voice_design'
+                    ? 'qwen-voice-design-1.7B'
+                    : engine === 'qwen_custom_voice'
+                      ? `qwen-custom-voice-${data.modelSize}`
+                      : `qwen-tts-${data.modelSize}`;
       const displayName =
         engine === 'luxtts'
           ? 'LuxTTS'
@@ -116,13 +119,15 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
                   : 'TADA 1B'
                 : engine === 'kokoro'
                   ? 'Kokoro 82M'
-                  : engine === 'qwen_custom_voice'
-                    ? data.modelSize === '1.7B'
-                      ? 'Qwen CustomVoice 1.7B'
-                      : 'Qwen CustomVoice 0.6B'
-                    : data.modelSize === '1.7B'
-                      ? 'Qwen TTS 1.7B'
-                      : 'Qwen TTS 0.6B';
+                  : engine === 'qwen_voice_design'
+                    ? 'Qwen VoiceDesign 1.7B'
+                    : engine === 'qwen_custom_voice'
+                      ? data.modelSize === '1.7B'
+                        ? 'Qwen CustomVoice 1.7B'
+                        : 'Qwen CustomVoice 0.6B'
+                      : data.modelSize === '1.7B'
+                        ? 'Qwen TTS 1.7B'
+                        : 'Qwen TTS 0.6B';
 
       // Check if model needs downloading
       try {
@@ -139,9 +144,9 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
 
       const hasModelSizes =
         engine === 'qwen' || engine === 'qwen_custom_voice' || engine === 'tada';
-      // Only Qwen CustomVoice actually honors the instruct kwarg at model level.
-      // Base Qwen3-TTS accepts the kwarg but ignores it.
-      const supportsInstruct = engine === 'qwen_custom_voice';
+      // Only Qwen CustomVoice and VoiceDesign actually honor the instruct kwarg
+      // at model level. Base Qwen3-TTS accepts the kwarg but ignores it.
+      const supportsInstruct = engine === 'qwen_custom_voice' || engine === 'qwen_voice_design';
       const effectsChain = options.getEffectsChain?.();
       // This now returns immediately with status="generating"
       const result = await generation.mutateAsync({

--- a/app/src/lib/utils/format.ts
+++ b/app/src/lib/utils/format.ts
@@ -57,9 +57,13 @@ export function formatAbsoluteDate(date: string | Date): string {
 
 const ENGINE_DISPLAY_NAMES: Record<string, string> = {
   qwen: 'Qwen',
+  qwen_custom_voice: 'Qwen CustomVoice',
+  qwen_voice_design: 'Qwen VoiceDesign',
   luxtts: 'LuxTTS',
   chatterbox: 'Chatterbox',
   chatterbox_turbo: 'Chatterbox Turbo',
+  tada: 'TADA',
+  kokoro: 'Kokoro 82M',
 };
 
 export function formatEngineName(engine?: string, modelSize?: string): string {

--- a/app/src/stores/uiStore.ts
+++ b/app/src/stores/uiStore.ts
@@ -22,6 +22,10 @@ export interface ProfileFormDraft {
   personality: string;
   referenceText: string;
   sampleMode: 'upload' | 'record' | 'system';
+  /** Which creation mode was open, so a restored draft reopens as itself. */
+  voiceSource?: 'clone' | 'builtin' | 'design';
+  /** Voice description for a designed profile. */
+  designPrompt?: string;
   // Note: File objects can't be persisted, so we store metadata
   sampleFileName?: string;
   sampleFileType?: string;

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -211,6 +211,7 @@ _llm_backends_lock = threading.Lock()
 TTS_ENGINES = {
     "qwen": "Qwen TTS",
     "qwen_custom_voice": "Qwen CustomVoice",
+    "qwen_voice_design": "Qwen VoiceDesign",
     "luxtts": "LuxTTS",
     "chatterbox": "Chatterbox TTS",
     "chatterbox_turbo": "Chatterbox Turbo",
@@ -283,6 +284,25 @@ def _get_qwen_custom_voice_configs() -> list[ModelConfig]:
             hf_repo_id="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
             model_size="0.6B",
             size_mb=1200,
+            supports_instruct=True,
+            languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
+        ),
+    ]
+
+
+def _get_qwen_voice_design_configs() -> list[ModelConfig]:
+    """Return Qwen VoiceDesign model configs.
+
+    Upstream ships a single 1.7B checkpoint — there is no 0.6B VoiceDesign.
+    """
+    return [
+        ModelConfig(
+            model_name="qwen-voice-design-1.7B",
+            display_name="Qwen VoiceDesign 1.7B",
+            engine="qwen_voice_design",
+            hf_repo_id="Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+            model_size="1.7B",
+            size_mb=3500,
             supports_instruct=True,
             languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
         ),
@@ -471,6 +491,7 @@ def get_all_model_configs() -> list[ModelConfig]:
     return (
         _get_qwen_model_configs()
         + _get_qwen_custom_voice_configs()
+        + _get_qwen_voice_design_configs()
         + _get_non_qwen_tts_configs()
         + _get_whisper_configs()
         + _get_qwen_llm_configs()
@@ -479,7 +500,12 @@ def get_all_model_configs() -> list[ModelConfig]:
 
 def get_tts_model_configs() -> list[ModelConfig]:
     """Return only TTS model configs."""
-    return _get_qwen_model_configs() + _get_qwen_custom_voice_configs() + _get_non_qwen_tts_configs()
+    return (
+        _get_qwen_model_configs()
+        + _get_qwen_custom_voice_configs()
+        + _get_qwen_voice_design_configs()
+        + _get_non_qwen_tts_configs()
+    )
 
 
 def get_llm_model_configs() -> list[ModelConfig]:
@@ -723,6 +749,10 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
             from .qwen_custom_voice_backend import QwenCustomVoiceBackend
 
             backend = QwenCustomVoiceBackend()
+        elif engine == "qwen_voice_design":
+            from .qwen_voice_design_backend import QwenVoiceDesignBackend
+
+            backend = QwenVoiceDesignBackend()
         else:
             raise ValueError(f"Unknown TTS engine: {engine}. Supported: {list(TTS_ENGINES.keys())}")
 

--- a/backend/backends/qwen_voice_design_backend.py
+++ b/backend/backends/qwen_voice_design_backend.py
@@ -1,0 +1,213 @@
+"""
+Qwen3-TTS VoiceDesign backend implementation.
+
+Wraps the Qwen3-TTS-12Hz VoiceDesign model, which synthesises a voice from a
+natural-language description instead of a reference recording or a preset
+speaker id. Uses the same qwen_tts library as the Base model
+(pytorch_backend.py) but loads a different checkpoint and calls
+generate_voice_design() instead of generate_voice_clone().
+
+Key differences from the CustomVoice engine:
+  - The voice identity is a free-text description carried on the profile
+    (voice_type "designed", design_prompt column), not one of 9 preset ids
+  - Only one checkpoint exists upstream: 1.7B. There is no 0.6B VoiceDesign.
+
+Languages supported: zh, en, ja, ko, de, fr, ru, pt, es, it
+"""
+
+import asyncio
+import logging
+from typing import Optional
+
+import numpy as np
+import torch
+
+from . import TTSBackend, LANGUAGE_CODE_TO_NAME
+from .base import (
+    is_model_cached,
+    get_torch_device,
+    combine_voice_prompts as _combine_voice_prompts,
+    model_load_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+# Used when an engine-level voice prompt is requested without a designed
+# profile behind it — mirrors QWEN_CV_DEFAULT_SPEAKER in the CustomVoice
+# backend. Deliberately plain so it reads as "unstyled" rather than as a
+# character.
+QWEN_VD_DEFAULT_DESIGN = "A clear, neutral voice with natural pacing."
+
+# HuggingFace repo IDs per model size. VoiceDesign ships 1.7B only.
+QWEN_VD_HF_REPOS = {
+    "1.7B": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+}
+
+
+class QwenVoiceDesignBackend:
+    """Qwen3-TTS VoiceDesign backend — voices described in natural language."""
+
+    def __init__(self, model_size: str = "1.7B"):
+        self.model = None
+        self.model_size = model_size
+        self.device = self._get_device()
+        self._current_model_size: Optional[str] = None
+
+    def _get_device(self) -> str:
+        return get_torch_device(allow_xpu=True, allow_directml=True)
+
+    def is_loaded(self) -> bool:
+        return self.model is not None
+
+    def _get_model_path(self, model_size: str) -> str:
+        if model_size not in QWEN_VD_HF_REPOS:
+            raise ValueError(f"Unknown model size: {model_size}")
+        return QWEN_VD_HF_REPOS[model_size]
+
+    def _is_model_cached(self, model_size: Optional[str] = None) -> bool:
+        size = model_size or self.model_size
+        return is_model_cached(self._get_model_path(size))
+
+    async def load_model_async(self, model_size: Optional[str] = None) -> None:
+        if model_size is None:
+            model_size = self.model_size
+
+        if self.model is not None and self._current_model_size == model_size:
+            return
+
+        if self.model is not None and self._current_model_size != model_size:
+            self.unload_model()
+
+        await asyncio.to_thread(self._load_model_sync, model_size)
+
+    # Alias for compatibility with the TTSBackend protocol
+    load_model = load_model_async
+
+    def _load_model_sync(self, model_size: str) -> None:
+        model_name = f"qwen-voice-design-{model_size}"
+        is_cached = self._is_model_cached(model_size)
+
+        with model_load_progress(model_name, is_cached):
+            from qwen_tts import Qwen3TTSModel
+
+            # generate_voice_design landed after the 0.0.x line. Fail with
+            # something readable instead of an AttributeError mid-generation.
+            if not hasattr(Qwen3TTSModel, "generate_voice_design"):
+                raise RuntimeError(
+                    "The installed qwen-tts is too old for VoiceDesign. "
+                    "Upgrade with: pip install -U 'qwen-tts>=0.1.1'"
+                )
+
+            model_path = self._get_model_path(model_size)
+            logger.info("Loading Qwen VoiceDesign %s on %s...", model_size, self.device)
+
+            if self.device == "cpu":
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    torch_dtype=torch.float32,
+                    low_cpu_mem_usage=False,
+                )
+            else:
+                self.model = Qwen3TTSModel.from_pretrained(
+                    model_path,
+                    device_map=self.device,
+                    torch_dtype=torch.bfloat16,
+                )
+
+        self._current_model_size = model_size
+        self.model_size = model_size
+        logger.info("Qwen VoiceDesign %s loaded successfully", model_size)
+
+    def unload_model(self) -> None:
+        if self.model is not None:
+            del self.model
+            self.model = None
+            self._current_model_size = None
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+            logger.info("Qwen VoiceDesign unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> tuple[dict, bool]:
+        """
+        Create voice prompt for VoiceDesign.
+
+        VoiceDesign doesn't use reference audio — the voice is described in
+        text. When called for a cloned profile (fallback), uses the neutral
+        default description. For designed profiles, the voice_prompt dict is
+        built by the profile service and bypasses this method entirely.
+        """
+        return {
+            "voice_type": "designed",
+            "design_prompt": QWEN_VD_DEFAULT_DESIGN,
+        }, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
+        return await _combine_voice_prompts(audio_paths, reference_texts)
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> tuple[np.ndarray, int]:
+        """
+        Generate audio using Qwen VoiceDesign.
+
+        Args:
+            text: Text to synthesize
+            voice_prompt: Dict with design_prompt (the voice description)
+            language: Language code (zh, en, ja, ko, etc.)
+            seed: Random seed for reproducibility
+            instruct: Per-generation style instruction, layered on top of the
+                      profile's design_prompt rather than replacing it
+
+        Returns:
+            Tuple of (audio_array, sample_rate)
+        """
+        await self.load_model_async(None)
+
+        design_prompt = voice_prompt.get("design_prompt") or QWEN_VD_DEFAULT_DESIGN
+
+        # For this model `instruct` carries the voice identity itself, so the
+        # profile's description has to lead. A per-request instruct is appended
+        # so style tweaks layer on rather than replacing the designed voice.
+        if instruct:
+            logger.debug("Layering per-request instruct on top of design_prompt")
+            combined_instruct = f"{design_prompt.rstrip('. ')}. {instruct}"
+        else:
+            combined_instruct = design_prompt
+
+        def _generate_sync():
+            if seed is not None:
+                torch.manual_seed(seed)
+                if torch.cuda.is_available():
+                    torch.cuda.manual_seed(seed)
+
+            lang_name = LANGUAGE_CODE_TO_NAME.get(language, "auto")
+
+            # Inference runs with the process's default HF_HUB_OFFLINE
+            # state. Forcing offline here (issue #462) regressed online
+            # users whose libraries issue legitimate metadata lookups
+            # during generation.
+            wavs, sample_rate = self.model.generate_voice_design(
+                text=text,
+                instruct=combined_instruct,
+                language=lang_name.capitalize() if lang_name != "auto" else "Auto",
+            )
+            return wavs[0], sample_rate
+
+        audio, sample_rate = await asyncio.to_thread(_generate_sync)
+        return audio, sample_rate

--- a/backend/backends/qwen_voice_design_backend.py
+++ b/backend/backends/qwen_voice_design_backend.py
@@ -52,6 +52,10 @@ class QwenVoiceDesignBackend:
         self.model_size = model_size
         self.device = self._get_device()
         self._current_model_size: Optional[str] = None
+        # Without this, two concurrent generations can both see model is None
+        # and each load the 3.5 GB checkpoint. Same pattern as the Chatterbox
+        # and TADA backends.
+        self._model_load_lock = asyncio.Lock()
 
     def _get_device(self) -> str:
         return get_torch_device(allow_xpu=True, allow_directml=True)
@@ -75,10 +79,16 @@ class QwenVoiceDesignBackend:
         if self.model is not None and self._current_model_size == model_size:
             return
 
-        if self.model is not None and self._current_model_size != model_size:
-            self.unload_model()
+        async with self._model_load_lock:
+            # Re-check: another request may have finished loading while this
+            # one waited for the lock.
+            if self.model is not None and self._current_model_size == model_size:
+                return
 
-        await asyncio.to_thread(self._load_model_sync, model_size)
+            if self.model is not None and self._current_model_size != model_size:
+                self.unload_model()
+
+            await asyncio.to_thread(self._load_model_sync, model_size)
 
     # Alias for compatibility with the TTSBackend protocol
     load_model = load_model_async

--- a/backend/models.py
+++ b/backend/models.py
@@ -85,7 +85,7 @@ class GenerationRequest(BaseModel):
     seed: Optional[int] = Field(None, ge=0)
     model_size: Optional[str] = Field(default="1.7B", pattern="^(1\\.7B|0\\.6B|1B|3B)$")
     instruct: Optional[str] = Field(None, max_length=500)
-    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
+    engine: Optional[str] = Field(default="qwen", pattern="^(qwen|qwen_custom_voice|qwen_voice_design|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$")
     personality: bool = Field(
         default=False,
         description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
@@ -317,7 +317,7 @@ class MCPClientBindingResponse(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|qwen_voice_design|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
     )
     default_personality: bool = False
     last_seen_at: Optional[datetime] = None
@@ -336,7 +336,7 @@ class MCPClientBindingUpsert(BaseModel):
     profile_id: Optional[str] = None
     default_engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|qwen_voice_design|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
     )
     default_personality: bool = False
 
@@ -355,7 +355,7 @@ class SpeakRequest(BaseModel):
     )
     engine: Optional[str] = Field(
         None,
-        pattern="^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+        pattern="^(qwen|qwen_custom_voice|qwen_voice_design|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
     )
     personality: Optional[bool] = Field(
         None,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,8 @@ torch>=2.2.0
 transformers>=4.36.0,<=4.57.6
 accelerate>=0.26.0
 huggingface_hub>=0.20.0
-qwen-tts>=0.0.5
+# >=0.1.1 for Qwen3TTSModel.generate_voice_design (the qwen_voice_design engine)
+qwen-tts>=0.1.1
 
 # LuxTTS (voice cloning engine)
 # piper-phonemize needs custom index (no PyPI wheels)

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(__name__)
 
 CLONING_ENGINES = {"qwen", "luxtts", "chatterbox", "chatterbox_turbo", "tada"}
 
+# Engines that synthesise a voice from a natural-language description
+# (voice_type "designed") rather than from samples or a preset id.
+DEFAULT_DESIGN_ENGINE = "qwen_voice_design"
+DESIGN_ENGINES = {DEFAULT_DESIGN_ENGINE}
+
 
 def _profile_to_response(
     profile: DBVoiceProfile,
@@ -100,6 +105,8 @@ def _validate_profile_fields(
             return "Designed profiles require a design_prompt"
         if preset_engine or preset_voice_id:
             return "Designed profiles cannot set preset_engine or preset_voice_id"
+        if default_engine and default_engine not in DESIGN_ENGINES:
+            return f"Designed profiles cannot use default engine '{default_engine}'"
         return None
 
     if preset_engine or preset_voice_id:
@@ -129,6 +136,8 @@ def validate_profile_engine(profile, engine: str) -> None:
         design_prompt = getattr(profile, "design_prompt", None)
         if not design_prompt or not design_prompt.strip():
             raise ValueError(f"Designed profile {profile.id} is missing design_prompt")
+        if engine not in DESIGN_ENGINES:
+            raise ValueError(f"Engine '{engine}' does not support designed voice profiles")
         return
 
     if engine not in CLONING_ENGINES:
@@ -156,11 +165,15 @@ async def create_profile(
     if existing_profile:
         raise ValueError(f"A profile with the name '{data.name}' already exists. Please choose a different name.")
 
-    # Auto-set default_engine for preset profiles
+    # Auto-set default_engine for preset and designed profiles
     default_engine = data.default_engine
     voice_type = data.voice_type or "cloned"
     if voice_type == "preset" and data.preset_engine and not default_engine:
         default_engine = data.preset_engine
+    elif voice_type == "designed" and not default_engine:
+        # Pick the design engine so the profile is usable straight after
+        # creation without the client having to know the engine name.
+        default_engine = DEFAULT_DESIGN_ENGINE
 
     validation_error = _validate_profile_fields(
         voice_type=voice_type,
@@ -524,7 +537,7 @@ async def create_voice_prompt_for_profile(
 
     For cloned profiles: combines all audio samples into a voice prompt.
     For preset profiles: returns the engine-specific preset voice reference.
-    For designed profiles: returns the text design prompt (future).
+    For designed profiles: returns the text design prompt.
 
     Args:
         profile_id: Profile ID
@@ -558,7 +571,7 @@ async def create_voice_prompt_for_profile(
             "preset_voice_id": profile.preset_voice_id,
         }
 
-    # ── Designed profiles: return text description (future) ──
+    # ── Designed profiles: return text description ──
     if voice_type == "designed":
         if not profile.design_prompt or not profile.design_prompt.strip():
             raise ValueError(f"Designed profile {profile_id} is missing design_prompt")

--- a/backend/tests/test_all_models_e2e.py
+++ b/backend/tests/test_all_models_e2e.py
@@ -47,7 +47,7 @@ class MatrixRow:
     label: str            # human-readable (appears in report)
     engine: str           # /generate engine
     model_size: Optional[str]  # /generate model_size (None = omit)
-    profile_kind: str     # "cloned" | "preset_kokoro" | "preset_qwen_cv"
+    profile_kind: str     # "cloned" | "preset_kokoro" | "preset_qwen_cv" | "designed"
     model_name: str       # /models/status key for cache lookup
 
 
@@ -56,6 +56,7 @@ MATRIX: list[MatrixRow] = [
     MatrixRow("qwen 0.6B",              "qwen",              "0.6B", "cloned",          "qwen-tts-0.6B"),
     MatrixRow("qwen_custom_voice 1.7B", "qwen_custom_voice", "1.7B", "preset_qwen_cv",  "qwen-custom-voice-1.7B"),
     MatrixRow("qwen_custom_voice 0.6B", "qwen_custom_voice", "0.6B", "preset_qwen_cv",  "qwen-custom-voice-0.6B"),
+    MatrixRow("qwen_voice_design 1.7B", "qwen_voice_design", None,   "designed",        "qwen-voice-design-1.7B"),
     MatrixRow("luxtts",                 "luxtts",            None,   "cloned",          "luxtts"),
     MatrixRow("chatterbox",             "chatterbox",        None,   "cloned",          "chatterbox-tts"),
     MatrixRow("chatterbox_turbo",       "chatterbox_turbo",  None,   "cloned",          "chatterbox-turbo"),
@@ -266,6 +267,17 @@ def create_preset_profile(client: httpx.Client, base_url: str, name: str, engine
         "language": "en",
         "preset_engine": engine,
         "preset_voice_id": voice_id,
+    })
+    r.raise_for_status()
+    return r.json()["id"]
+
+
+def create_designed_profile(client: httpx.Client, base_url: str, name: str, design_prompt: str) -> str:
+    r = client.post(f"{base_url}/profiles", json={
+        "name": name,
+        "voice_type": "designed",
+        "language": "en",
+        "design_prompt": design_prompt,
     })
     r.raise_for_status()
     return r.json()["id"]
@@ -539,6 +551,7 @@ def main() -> int:
             cloned_profile_id: Optional[str] = None
             kokoro_profile_id: Optional[str] = None
             qwen_cv_profile_id: Optional[str] = None
+            designed_profile_id: Optional[str] = None
             needed_kinds = {r.profile_kind for r in rows}
             if "cloned" in needed_kinds:
                 assert ref_wav is not None and ref_text is not None
@@ -550,11 +563,20 @@ def main() -> int:
             if "preset_qwen_cv" in needed_kinds:
                 print("[profile] creating qwen_custom_voice preset...", flush=True)
                 qwen_cv_profile_id = create_preset_profile(client, base_url, "e2e-qwen-cv", "qwen_custom_voice", "Ryan")
+            if "designed" in needed_kinds:
+                print("[profile] creating designed profile...", flush=True)
+                designed_profile_id = create_designed_profile(
+                    client,
+                    base_url,
+                    "e2e-designed",
+                    "A calm, warm middle-aged woman with a measured, unhurried delivery.",
+                )
 
             profile_lookup = {
                 "cloned": cloned_profile_id,
                 "preset_kokoro": kokoro_profile_id,
                 "preset_qwen_cv": qwen_cv_profile_id,
+                "designed": designed_profile_id,
             }
 
             # Matrix loop

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -687,7 +687,7 @@ The generation form now uses a flat model dropdown with engine-based routing. Pe
 
 ### 7. Engine Sprawl — NEW
 
-Seven TTS engines shipped, more candidates queued. Issue #419 asks for a first-class vs experimental distinction. Related: issue #420 asks for formalized platform support tiers. Combined, these would let us ship more engines more confidently with clearer expectations for users.
+Eight TTS engines shipped, more candidates queued. Issue #419 asks for a first-class vs experimental distinction. Related: issue #420 asks for formalized platform support tiers. Combined, these would let us ship more engines more confidently with clearer expectations for users.
 
 ---
 

--- a/docs/content/docs/developer/model-management.mdx
+++ b/docs/content/docs/developer/model-management.mdx
@@ -21,6 +21,7 @@ Every model is described by a `ModelConfig` entry in `backend/backends/__init__.
 | **Qwen TTS 0.6B** | `qwen` | `Qwen/Qwen3-TTS-12Hz-0.6B-Base` | 1.2 GB | ~2 GB | 10 |
 | **Qwen CustomVoice 1.7B** | `qwen_custom_voice` | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` | 3.5 GB | ~6 GB | 10 |
 | **Qwen CustomVoice 0.6B** | `qwen_custom_voice` | `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` | 1.2 GB | ~2 GB | 10 |
+| **Qwen VoiceDesign 1.7B** | `qwen_voice_design` | `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign` | 3.5 GB | ~6 GB | 10 |
 | **LuxTTS** | `luxtts` | `YatharthS/LuxTTS` | 300 MB | ~1 GB | English |
 | **Chatterbox Multilingual** | `chatterbox` | `ResembleAI/chatterbox` | 3.2 GB | ~3 GB | 23 |
 | **Chatterbox Turbo** | `chatterbox_turbo` | `ResembleAI/chatterbox-turbo` | 1.5 GB | ~1.5 GB | English |
@@ -28,7 +29,9 @@ Every model is described by a `ModelConfig` entry in `backend/backends/__init__.
 | **TADA 3B Multilingual** | `tada` | `HumeAI/tada-3b-ml` | 8 GB | ~8 GB | 10 |
 | **Kokoro 82M** | `kokoro` | `hexgrad/Kokoro-82M` | 350 MB | ~150 MB | 8 |
 
-On Apple Silicon, Qwen TTS uses MLX-optimized repos from `mlx-community` instead of the PyTorch repos. The backend picks automatically via `get_backend_type()`.
+On Apple Silicon, Qwen TTS uses MLX-optimized repos from `mlx-community` instead of the PyTorch repos. The backend picks automatically via `get_backend_type()`. CustomVoice and VoiceDesign are PyTorch-only — upstream publishes no MLX conversion.
+
+Qwen VoiceDesign ships a single 1.7B checkpoint; there is no 0.6B variant. It is the only engine that consumes `voice_type: "designed"` profiles, where the voice identity is the profile's `design_prompt` rather than reference audio or a preset id.
 
 ## Available Whisper Models
 

--- a/docs/content/docs/developer/model-management.mdx
+++ b/docs/content/docs/developer/model-management.mdx
@@ -7,7 +7,7 @@ description: "How model downloading, loading, and status tracking works across a
 
 Voicebox manages two categories of models:
 
-**TTS Models** — Seven engines covering zero-shot cloning and preset voices. Each engine may have one or more size variants.
+**TTS Models** — Eight engines covering zero-shot cloning, preset voices and voice design. Each engine may have one or more size variants.
 
 **ASR Models** — Whisper for transcription. Five sizes, plus MLX-Whisper on Apple Silicon for ~8× faster transcription.
 

--- a/docs/content/docs/developer/tts-generation.mdx
+++ b/docs/content/docs/developer/tts-generation.mdx
@@ -5,7 +5,7 @@ description: "How text-to-speech generation works across Voicebox's multi-engine
 
 ## Overview
 
-Voicebox ships seven TTS engines — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, TADA, and Kokoro — behind a single `TTSBackend` Protocol. All of them expose the same async interface so the routes and services don't need per-engine branching.
+Voicebox ships eight TTS engines — Qwen3-TTS, Qwen CustomVoice, Qwen VoiceDesign, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, TADA, and Kokoro — behind a single `TTSBackend` Protocol. All of them expose the same async interface so the routes and services don't need per-engine branching.
 
 This page covers how generation flows through that abstraction. For the step-by-step guide to adding a new engine, see [TTS Engines](/developer/tts-engines).
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: "Voicebox is the open-source, local-first AI voice studio — a fre
 
 Voicebox is the **open-source, local-first AI voice studio** — a free
 alternative to ElevenLabs and WisprFlow in one app. Clone voices, generate
-speech across 7 TTS engines, dictate into any app with a global hotkey,
+speech across 8 TTS engines, dictate into any app with a global hotkey,
 compose multi-voice projects, and let any MCP-aware agent speak in a voice
 you own. Everything runs on your hardware.
 
@@ -15,7 +15,7 @@ you own. Everything runs on your hardware.
 - **Captures tab** — paired audio + transcript archive, retranscribe / refine / play-as-voice
 - **Voice personalities** — per-profile compose button + persona-rewrite toggle, powered by a local LLM
 - **Agents speak back** — any MCP-aware agent can call Voicebox to speak in one of your cloned voices
-- **7 TTS engines** — Qwen3-TTS, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, Kokoro
+- **8 TTS engines** — Qwen3-TTS, Qwen CustomVoice, Qwen VoiceDesign, LuxTTS, Chatterbox Multilingual, Chatterbox Turbo, HumeAI TADA, Kokoro
 - **Cloning and preset voices** — zero-shot cloning or 50+ curated preset voices
 - **23 languages** — from English to Arabic, Japanese, Hindi, Swahili
 - **Post-processing effects** — pitch shift, reverb, delay, chorus, compression, filters

--- a/docs/content/docs/overview/introduction.mdx
+++ b/docs/content/docs/overview/introduction.mdx
@@ -46,12 +46,13 @@ shared between input and output.
 
 ## TTS Engines
 
-Seven engines with different strengths, switchable per-generation:
+Eight engines with different strengths, switchable per-generation:
 
 | Engine | Profile Type | Languages | Strengths |
 |--------|--------------|-----------|-----------|
 | **Qwen3-TTS** (0.6B / 1.7B) | Cloned | 10 | High-quality multilingual cloning |
 | **Qwen CustomVoice** (0.6B / 1.7B) | Preset (9 voices) | 10 | Natural-language delivery control (tone, emotion, pace) |
+| **Qwen VoiceDesign** (1.7B) | Designed | 10 | Builds a voice from a written description — no reference audio or preset |
 | **LuxTTS** | Cloned | English | Lightweight (~1GB VRAM), 48kHz output, 150x realtime on CPU |
 | **Chatterbox Multilingual** | Cloned | 23 | Broadest language coverage |
 | **Chatterbox Turbo** | Cloned | English | Fast 350M model with paralinguistic emotion/sound tags |

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
 						className="fade-in mx-auto mt-6 max-w-2xl text-lg text-muted-foreground md:text-xl"
 						style={{animationDelay: "200ms"}}
 					>
-						Clone voices, generate speech across seven TTS engines, dictate into
+						Clone voices, generate speech across eight TTS engines, dictate into
 						any app, and talk to agents in voices you own. A free and local alternative
 						to ElevenLabs and WisprFlow, running{" "}
 						<b className="text-white">entirely on your machine.</b>

--- a/landing/src/components/SupportedModels.tsx
+++ b/landing/src/components/SupportedModels.tsx
@@ -85,6 +85,17 @@ const MODEL_GROUPS: ModelGroup[] = [
         ],
       },
       {
+        name: 'Qwen VoiceDesign',
+        author: 'Alibaba',
+        sizes: ['1.7B'],
+        description:
+          'Write the voice you want and it gets built. "A warm, gravelly older man with a slow Scottish lilt" — no reference recording, no preset list.',
+        tags: [
+          { icon: SlidersHorizontal, label: 'Voice design' },
+          { icon: Globe, label: '10 langs' },
+        ],
+      },
+      {
         name: 'TADA',
         author: 'Hume AI',
         sizes: ['3B', '1B'],


### PR DESCRIPTION
Adds `qwen_voice_design` as an eighth TTS engine. Instead of a reference recording or a preset id, the voice identity is a sentence — *"a warm, gravelly older man with a slow Scottish lilt"*.

This fills the text-to-voice-design gap listed under **Low-hanging Qwen-family variants** in `docs/PROJECT_STATUS.md`.

## Why this is a small change

Two halves already existed:

- **`Qwen3TTSModel.generate_voice_design()` is already in the vendored `qwen_tts` package.** No new dependency, and no PyInstaller work — the usual phase-0/4/5 cost from `tts-engines.mdx` drops out entirely.
- **`voice_type: "designed"` was already scaffolded end to end** — schema, validation, the `design_prompt` column and migration, the profile badges, and i18n in all 9 locales. `services/profiles.py` literally read `# ── Designed profiles: return text description (future) ──`. This is that future.

## What is new

- `backend/backends/qwen_voice_design_backend.py`, modeled on the CustomVoice backend. Upstream ships a single 1.7B checkpoint; there is no 0.6B.
- `ModelConfig` entry, `TTS_ENGINES` entry, factory branch, engine regex.
- `DESIGN_ENGINES` in `services/profiles.py`, so a designed profile is rejected on a cloning engine and vice versa, and `default_engine` is auto-set at creation the way preset profiles already are.
- A third **"Describe a voice"** source in the profile form, with strings in all 9 locales.

For this model `instruct` **is** the voice identity, not a per-generation tweak, so the profile's `design_prompt` leads and a per-request `instruct` is appended rather than replacing it.

## Dependency floor

Raised `qwen-tts` from `>=0.0.5` to `>=0.1.1` — the earlier floor predates `generate_voice_design`. There is a `hasattr` guard with an actionable message if an older copy is installed.

## Also included

`ENGINE_DISPLAY_NAMES` in `format.ts` listed 4 of 8 engines, so the History table rendered raw ids — `kokoro`, `tada`, `qwen_custom_voice`. Completed while adding the new entry.

## Testing

16 service-level checks pass, covering profile creation, voice-prompt construction, instruct layering, language mapping, and four negative paths (designed profile on a cloning engine, empty `design_prompt`, mismatched `default_engine`). A row was added to the `test_all_models_e2e.py` matrix with a new `designed` profile kind.

**Generating real audio has not been run** — that needs the 3.5 GB checkpoint. Worth a maintainer confirming before merge.

## Related

`Qwen3-TTS-25Hz` is announced but unreleased ([QwenLM/Qwen3-TTS#34](https://github.com/QwenLM/Qwen3-TTS/issues/34)); the vendored `qwen_tts` already carries a `tokenizer_25hz` module, so that should be config-only when the weights land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qwen VoiceDesign as a text-to-speech engine.
  * Create voices from natural-language descriptions without reference audio or presets.
  * Added designed voice profiles with prompts, avatars, editing, and compatibility support.
  * Supports 10 languages, optional instructions, and deterministic generation.
  * Added model management and VoiceDesign availability details.

* **Documentation**
  * Updated product, developer, model, and localized voice-profile documentation to cover VoiceDesign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->