### PR TITLE
fix(dictation): allow dictation without LLM model when refinement is disabled (#753)

### DIFF
--- a/app/src/components/CapturesTab/DictationReadinessChecklist.tsx
+++ b/app/src/components/CapturesTab/DictationReadinessChecklist.tsx
@@ -222,7 +222,7 @@ export function DictationReadinessChecklist({
         />
       )}
 
-      {readiness.llm && (
+      {readiness.autoRefine && readiness.llm && (
         <ChecklistRow
           icon={<Cpu className="h-3.5 w-3.5" />}
           title={t('captures.readiness.llm.label', { name: readiness.llm.display_name })}

--- a/app/src/lib/hooks/useDictationReadiness.ts
+++ b/app/src/lib/hooks/useDictationReadiness.ts
@@ -3,6 +3,7 @@ import { useAccessibilityPermission } from '@/components/AccessibilityGate/Acces
 import { useInputMonitoringPermission } from '@/components/InputMonitoringGate/InputMonitoringGate';
 import { apiClient } from '@/lib/api/client';
 import type { ModelReadiness } from '@/lib/api/types';
+import { useCaptureSettings } from '@/lib/hooks/useSettings';
 import { usePlatform } from '@/platform/PlatformContext';
 
 const READINESS_POLL_INTERVAL_MS = 5_000;
@@ -17,6 +18,8 @@ export interface DictationReadiness {
   missing: ReadinessGate[];
   stt: ModelReadiness | undefined;
   llm: ModelReadiness | undefined;
+  /** Whether the user has auto-refine (LLM polish) enabled. */
+  autoRefine: boolean;
   inputMonitoring: boolean;
   accessibility: boolean;
   refetch: () => void;
@@ -46,6 +49,8 @@ export interface DictationReadiness {
 export function useDictationReadiness(): DictationReadiness {
   const platform = usePlatform();
   const isTauri = platform.metadata.isTauri;
+  const { settings } = useCaptureSettings();
+  const autoRefine = settings?.auto_refine ?? true;
 
   const {
     needsPermission: inputMonNeeds,
@@ -61,17 +66,19 @@ export function useDictationReadiness(): DictationReadiness {
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['capture-readiness'],
     queryFn: () => apiClient.getCaptureReadiness(),
-    // Poll only while a model is still missing/downloading. Once both are
-    // green the endpoint's answer can't change until the user swaps models
-    // in settings, and that path invalidates the query explicitly from
-    // useSettings. refetchOnWindowFocus stays gated to the same condition.
+    // Poll only while a required model is still missing/downloading. Once
+    // all required models are green the endpoint's answer can't change
+    // until the user swaps models in settings, and that path invalidates
+    // the query explicitly from useSettings. refetchOnWindowFocus stays
+    // gated to the same condition.
     refetchInterval: (query) => {
       const d = query.state.data;
-      return d && d.stt.ready && d.llm.ready ? false : READINESS_POLL_INTERVAL_MS;
+      const allGreen = d && d.stt.ready && (!autoRefine || d.llm.ready);
+      return allGreen ? false : READINESS_POLL_INTERVAL_MS;
     },
     refetchOnWindowFocus: (query) => {
       const d = query.state.data;
-      return !(d && d.stt.ready && d.llm.ready);
+      return !(d && d.stt.ready && (!autoRefine || d.llm.ready));
     },
   });
 
@@ -84,10 +91,10 @@ export function useDictationReadiness(): DictationReadiness {
 
   const missing: ReadinessGate[] = [];
   if (!sttReady) missing.push('stt');
-  if (!llmReady) missing.push('llm');
+  if (autoRefine && !llmReady) missing.push('llm');
   if (!inputMonitoring) missing.push('input_monitoring');
   if (!accessibility) missing.push('accessibility');
-  const canRecord = sttReady && llmReady && inputMonitoring;
+  const canRecord = sttReady && (!autoRefine || llmReady) && inputMonitoring;
 
   return {
     isLoading,
@@ -96,6 +103,7 @@ export function useDictationReadiness(): DictationReadiness {
     missing,
     stt: data?.stt,
     llm: data?.llm,
+    autoRefine,
     inputMonitoring,
     accessibility,
     refetch: () => {

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -48,7 +48,11 @@ export function useCaptureSettings() {
       // call, but its cached response keeps serving the previous
       // model's state until the next 5 s poll. Invalidate on model
       // swaps so the readiness checklist re-checks immediately.
-      if (patch.stt_model !== undefined || patch.llm_model !== undefined) {
+      if (
+        patch.stt_model !== undefined ||
+        patch.llm_model !== undefined ||
+        patch.auto_refine !== undefined
+      ) {
         queryClient.invalidateQueries({ queryKey: ['capture-readiness'] });
       }
     },


### PR DESCRIPTION
### Summary

Resolves [#753](https://github.com/jamiepine/voicebox/issues/753). When transcript refinement (`auto_refine`) is disabled in Settings, Voicebox previously enforced that the Large Language Model (Qwen3 0.6B) be cached locally before global dictation shortcuts could be armed.

Because `useDictationReadiness` evaluated `llmReady` unconditionally within the `canRecord` gate, `useChordSync` disarmed global shortcuts (`disable_hotkey`) whenever the Qwen3 0.6B LLM model was not present locally—even when the user intended only to perform raw Speech-to-Text (STT) dictation via Whisper Large v3 Turbo.

---

### Key Changes

1. **`useDictationReadiness.ts`**:
   - Modified the `canRecord` readiness gate to `sttReady && (!autoRefine || llmReady) && inputMonitoring`.
   - Conditioned `llmReady` evaluation in the `missing` gates array and React Query background polling predicates on `auto_refine`, allowing background network polling to terminate once mandatory Speech-to-Text models are cached.

2. **`DictationReadinessChecklist.tsx`**:
   - Updated the readiness checklist UI component to render the Large Language Model (Qwen3 0.6B) row only when transcript refinement (`auto_refine`) is enabled.

3. **`useSettings.ts`**:
   - Included `patch.auto_refine !== undefined` in the cache invalidation trigger inside `useCaptureSettings()`, ensuring immediate re-evaluation of the dictation readiness state upon user setting changes.

---

### Verification Performed

- [x] **Single-Model Dictation**: Tested dictation recording using only the Whisper Large v3 Turbo model with `auto_refine` disabled and no LLM cached on disk.
- [x] **Readiness UI Checklist**: Confirmed that the Qwen3 0.6B LLM requirement row is hidden from the Captures checklist when refinement is turned off.
- [x] **State Reactivity**: Confirmed instant hotkey arming and UI cache invalidation upon toggling `auto_refine` in Settings.
- [x] **Type Safety**: Ran static analysis via `bun run typecheck` with zero errors across the frontend codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dictation readiness checks to require LLM readiness only when automatic refinement is enabled.
  * Prevented the LLM readiness checklist item from appearing when automatic refinement is unavailable.
  * Readiness status now refreshes promptly when capture settings change, including automatic refinement, speech-to-text, or language model settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->