### PR TITLE
fix(audio): add input device selection setting (#979)

### DIFF
--- a/app/src/components/ServerTab/CapturesPage.tsx
+++ b/app/src/components/ServerTab/CapturesPage.tsx
@@ -1,4 +1,13 @@
-import { Check, ChevronDown, FolderOpen, Info, Keyboard, Laptop, Lock, Volume2 } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  FolderOpen,
+  Info,
+  Keyboard,
+  Laptop,
+  Lock,
+  Volume2,
+} from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AccessibilityNotice } from '@/components/AccessibilityGate/AccessibilityGate';
@@ -27,6 +36,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { useDictationReadiness } from '@/lib/hooks/useDictationReadiness';
 import { useCaptureSettings } from '@/lib/hooks/useSettings';
 import { useProfiles } from '@/lib/hooks/useProfiles';
+import { useAudioInputDevices } from '@/lib/hooks/useAudioInputDevices';
 import { usePlatform } from '@/platform/PlatformContext';
 import { useServerStore } from '@/stores/serverStore';
 import { cn } from '@/lib/utils/cn';
@@ -37,7 +47,9 @@ import { SettingRow, SettingSection } from './SettingRow';
 function ChordPreview({ keys }: { keys: string[] }) {
   const { t } = useTranslation();
   if (keys.length === 0) {
-    return <span className="text-xs text-muted-foreground italic">{t('captures.chord.notSet')}</span>;
+    return (
+      <span className="text-xs text-muted-foreground italic">{t('captures.chord.notSet')}</span>
+    );
   }
   return (
     <div className="flex items-center gap-1">
@@ -61,8 +73,7 @@ function ChordPreview({ keys }: { keys: string[] }) {
   );
 }
 
-const isWindows =
-  typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
+const isWindows = typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows');
 
 const PILL_SEQUENCE: PillState[] = ['recording', 'transcribing', 'refining', 'rest'];
 const PILL_DURATIONS: Partial<Record<PillState, number>> = {
@@ -137,9 +148,11 @@ export function CapturesPage() {
   const preserveTechnical = settings?.preserve_technical ?? true;
   const allowAutoPaste = settings?.allow_auto_paste ?? true;
   const defaultVoiceId = settings?.default_playback_voice_id ?? null;
+  const inputDeviceId = settings?.input_device_id ?? null;
   const hotkeyEnabled = settings?.hotkey_enabled ?? false;
   const pushToTalkKeys = settings?.chord_push_to_talk_keys ?? defaultChordKeys('push');
   const toggleToTalkKeys = settings?.chord_toggle_to_talk_keys ?? defaultChordKeys('toggle');
+  const { devices: inputDevices } = useAudioInputDevices();
 
   const [chordEditor, setChordEditor] = useState<'push' | 'toggle' | null>(null);
   const [opening, setOpening] = useState(false);
@@ -149,9 +162,7 @@ export function CapturesPage() {
     fetch(`${serverUrl}/health/filesystem`)
       .then((res) => res.json())
       .then((data) => {
-        const dir = data.directories?.find((d: { path: string }) =>
-          d.path.includes('captures'),
-        );
+        const dir = data.directories?.find((d: { path: string }) => d.path.includes('captures'));
         if (dir?.path) setCapturesPath(dir.path);
       })
       .catch(() => {});
@@ -170,369 +181,426 @@ export function CapturesPage() {
   }, [platform, capturesPath]);
 
   const voices: VoiceProfileResponse[] = profiles ?? [];
-  const defaultVoice =
-    voices.find((v) => v.id === defaultVoiceId) ?? null;
+  const defaultVoice = voices.find((v) => v.id === defaultVoiceId) ?? null;
 
   return (
     <div className="flex gap-8 items-start max-w-5xl">
       <div className="flex-1 min-w-0 max-w-2xl space-y-10">
-      <SettingSection
-        title={t('settings.captures.dictation.title')}
-        description={t('settings.captures.dictation.description')}
-      >
-        <div>
-          <SettingRow
-            title={t('settings.captures.dictation.globalShortcut.title')}
-            description={t('settings.captures.dictation.globalShortcut.description')}
-            htmlFor="hotkeyEnabled"
-            action={
-              <Toggle
-                id="hotkeyEnabled"
-                checked={hotkeyEnabled}
-                onCheckedChange={(v) => {
-                  update({ hotkey_enabled: v });
-                  // Surface model-readiness blocks at the toggle. The
-                  // InputMonitoringNotice below already covers TCC, but
-                  // missing models would otherwise be invisible from this
-                  // page — the user toggles on, presses the chord, and
-                  // nothing happens because useChordSync gates on readiness.
-                  if (!v) return;
-                  const missingModels = readiness.missing.filter(
-                    (g) => g === 'stt' || g === 'llm',
-                  );
-                  if (missingModels.length === 0) return;
-                  const names = [
-                    missingModels.includes('stt') ? readiness.stt?.display_name : null,
-                    missingModels.includes('llm') ? readiness.llm?.display_name : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' and ');
-                  toast({
-                    title: t('captures.toast.shortcutNotArmed'),
-                    description: t('captures.toast.shortcutNotArmedDescription', {
-                      names,
-                      count: missingModels.length,
-                    }),
-                  });
-                }}
-              />
-            }
-          />
-          <InputMonitoringNotice enabled={hotkeyEnabled} />
-        </div>
-
-        <SettingRow
-          title={t('settings.captures.dictation.pushToTalk.title')}
-          description={t('settings.captures.dictation.pushToTalk.description')}
-          action={
-            <div className="flex items-center gap-2">
-              <ChordPreview keys={pushToTalkKeys} />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hotkeyEnabled}
-                onClick={() => setChordEditor('push')}
-              >
-                <Keyboard className="h-3.5 w-3.5 mr-1.5" />
-                {t('settings.captures.dictation.pushToTalk.change')}
-              </Button>
-            </div>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.dictation.toggle.title')}
-          description={t('settings.captures.dictation.toggle.description')}
-          action={
-            <div className="flex items-center gap-2">
-              <ChordPreview keys={toggleToTalkKeys} />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hotkeyEnabled}
-                onClick={() => setChordEditor('toggle')}
-              >
-                <Keyboard className="h-3.5 w-3.5 mr-1.5" />
-                {t('settings.captures.dictation.toggle.change')}
-              </Button>
-            </div>
-          }
-        />
-
-        <ChordPicker
-          open={chordEditor === 'push'}
-          title={t('settings.captures.dictation.chordPicker.pttTitle')}
-          description={t('settings.captures.dictation.chordPicker.pttDescription')}
-          initialKeys={pushToTalkKeys}
-          onCancel={() => setChordEditor(null)}
-          onSave={(keys) => {
-            update({ chord_push_to_talk_keys: keys });
-            setChordEditor(null);
-          }}
-        />
-
-        <ChordPicker
-          open={chordEditor === 'toggle'}
-          title={t('settings.captures.dictation.chordPicker.toggleTitle')}
-          description={t('settings.captures.dictation.chordPicker.toggleDescription')}
-          initialKeys={toggleToTalkKeys}
-          onCancel={() => setChordEditor(null)}
-          onSave={(keys) => {
-            update({ chord_toggle_to_talk_keys: keys });
-            setChordEditor(null);
-          }}
-        />
-
-        <SettingRow
-          title={t('settings.captures.dictation.preview.title')}
-          description={t('settings.captures.dictation.preview.description')}
+        <SettingSection
+          title={t('settings.captures.dictation.title')}
+          description={t('settings.captures.dictation.description')}
         >
-          <HotkeyPillPreview enabled={hotkeyEnabled} />
-        </SettingRow>
+          <div>
+            <SettingRow
+              title={t('settings.captures.dictation.globalShortcut.title')}
+              description={t('settings.captures.dictation.globalShortcut.description')}
+              htmlFor="hotkeyEnabled"
+              action={
+                <Toggle
+                  id="hotkeyEnabled"
+                  checked={hotkeyEnabled}
+                  onCheckedChange={(v) => {
+                    update({ hotkey_enabled: v });
+                    // Surface model-readiness blocks at the toggle. The
+                    // InputMonitoringNotice below already covers TCC, but
+                    // missing models would otherwise be invisible from this
+                    // page — the user toggles on, presses the chord, and
+                    // nothing happens because useChordSync gates on readiness.
+                    if (!v) return;
+                    const missingModels = readiness.missing.filter(
+                      (g) => g === 'stt' || g === 'llm',
+                    );
+                    if (missingModels.length === 0) return;
+                    const names = [
+                      missingModels.includes('stt') ? readiness.stt?.display_name : null,
+                      missingModels.includes('llm') ? readiness.llm?.display_name : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' and ');
+                    toast({
+                      title: t('captures.toast.shortcutNotArmed'),
+                      description: t('captures.toast.shortcutNotArmedDescription', {
+                        names,
+                        count: missingModels.length,
+                      }),
+                    });
+                  }}
+                />
+              }
+            />
+            <InputMonitoringNotice enabled={hotkeyEnabled} />
+          </div>
 
-        <div>
           <SettingRow
-            title={t('settings.captures.dictation.autoPaste.title')}
-            description={t('settings.captures.dictation.autoPaste.description')}
-            htmlFor="autoPaste"
+            title={t('settings.captures.dictation.inputDevice.title')}
+            description={t('settings.captures.dictation.inputDevice.description')}
             action={
-              <Toggle
-                id="autoPaste"
-                checked={allowAutoPaste}
-                onCheckedChange={(v) => update({ allow_auto_paste: v })}
-                disabled={!hotkeyEnabled}
-              />
+              <Select
+                value={inputDeviceId ?? 'default'}
+                onValueChange={(v) => update({ input_device_id: v === 'default' ? null : v })}
+              >
+                <SelectTrigger className="w-[240px]">
+                  <SelectValue placeholder={t('settings.captures.dictation.inputDevice.default')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">
+                    {t('settings.captures.dictation.inputDevice.default')}
+                  </SelectItem>
+                  {inputDevices.map((d) => (
+                    <SelectItem key={d.deviceId} value={d.deviceId}>
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             }
           />
-          <AccessibilityNotice />
-        </div>
-      </SettingSection>
 
-      <SettingSection
-        title={t('settings.captures.transcription.title')}
-        description={t('settings.captures.transcription.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.transcription.model.title')}
-          description={t('settings.captures.transcription.model.description')}
-          action={
-            <Select
-              value={sttModel}
-              onValueChange={(v) => update({ stt_model: v as WhisperModelSize })}
-            >
-              <SelectTrigger className="w-[300px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="base">
-                  {t('settings.captures.transcription.model.base', { tail: t('settings.captures.transcription.model.tail.fast') })}
-                </SelectItem>
-                <SelectItem value="small">
-                  {t('settings.captures.transcription.model.small', { tail: t('settings.captures.transcription.model.tail.balanced') })}
-                </SelectItem>
-                <SelectItem value="medium">
-                  {t('settings.captures.transcription.model.medium', { tail: t('settings.captures.transcription.model.tail.higher') })}
-                </SelectItem>
-                <SelectItem value="large">
-                  {t('settings.captures.transcription.model.large', { tail: t('settings.captures.transcription.model.tail.best') })}
-                </SelectItem>
-                <SelectItem value="turbo">
-                  {t('settings.captures.transcription.model.turbo', { tail: t('settings.captures.transcription.model.tail.nearBest') })}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.transcription.language.title')}
-          description={t('settings.captures.transcription.language.description')}
-          action={
-            <Select value={language} onValueChange={(v) => update({ language: v })}>
-              <SelectTrigger className="w-[180px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">{t('settings.captures.transcription.language.auto')}</SelectItem>
-                <SelectItem value="en">{t('settings.captures.transcription.language.en')}</SelectItem>
-                <SelectItem value="es">{t('settings.captures.transcription.language.es')}</SelectItem>
-                <SelectItem value="fr">{t('settings.captures.transcription.language.fr')}</SelectItem>
-                <SelectItem value="de">{t('settings.captures.transcription.language.de')}</SelectItem>
-                <SelectItem value="ja">{t('settings.captures.transcription.language.ja')}</SelectItem>
-                <SelectItem value="zh">{t('settings.captures.transcription.language.zh')}</SelectItem>
-                <SelectItem value="hi">{t('settings.captures.transcription.language.hi')}</SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-      </SettingSection>
-
-      <SettingSection
-        title={t('settings.captures.refinement.title')}
-        description={t('settings.captures.refinement.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.refinement.auto.title')}
-          description={t('settings.captures.refinement.auto.description')}
-          htmlFor="autoRefine"
-          action={
-            <Toggle
-              id="autoRefine"
-              checked={autoRefine}
-              onCheckedChange={(v) => update({ auto_refine: v })}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.model.title')}
-          description={t('settings.captures.refinement.model.description')}
-          action={
-            <Select
-              value={llmModel}
-              onValueChange={(v) => update({ llm_model: v as Qwen3ModelSize })}
-              disabled={!autoRefine}
-            >
-              <SelectTrigger className="w-[260px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="0.6B">
-                  {t('settings.captures.refinement.model.size06', { tail: t('settings.captures.refinement.model.tail.veryFast') })}
-                </SelectItem>
-                <SelectItem value="1.7B">
-                  {t('settings.captures.refinement.model.size17', { tail: t('settings.captures.refinement.model.tail.fast') })}
-                </SelectItem>
-                <SelectItem value="4B">
-                  {t('settings.captures.refinement.model.size40', { tail: t('settings.captures.refinement.model.tail.fullQuality') })}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.smartCleanup.title')}
-          description={t('settings.captures.refinement.smartCleanup.description')}
-          htmlFor="smartCleanup"
-          action={
-            <Toggle
-              id="smartCleanup"
-              checked={smartCleanup}
-              onCheckedChange={(v) => update({ smart_cleanup: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.selfCorrection.title')}
-          description={t('settings.captures.refinement.selfCorrection.description')}
-          htmlFor="selfCorrection"
-          action={
-            <Toggle
-              id="selfCorrection"
-              checked={selfCorrection}
-              onCheckedChange={(v) => update({ self_correction: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-
-        <SettingRow
-          title={t('settings.captures.refinement.preserveTechnical.title')}
-          description={t('settings.captures.refinement.preserveTechnical.description')}
-          htmlFor="preserveTechnical"
-          action={
-            <Toggle
-              id="preserveTechnical"
-              checked={preserveTechnical}
-              onCheckedChange={(v) => update({ preserve_technical: v })}
-              disabled={!autoRefine}
-            />
-          }
-        />
-      </SettingSection>
-
-      <SettingSection
-        title={t('settings.captures.playback.title')}
-        description={t('settings.captures.playback.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.playback.defaultVoice.title')}
-          description={t('settings.captures.playback.defaultVoice.description')}
-          action={
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+          <SettingRow
+            title={t('settings.captures.dictation.pushToTalk.title')}
+            description={t('settings.captures.dictation.pushToTalk.description')}
+            action={
+              <div className="flex items-center gap-2">
+                <ChordPreview keys={pushToTalkKeys} />
                 <Button
                   variant="outline"
                   size="sm"
-                  className="gap-2 min-w-[220px] justify-between"
-                  disabled={voices.length === 0}
+                  disabled={!hotkeyEnabled}
+                  onClick={() => setChordEditor('push')}
                 >
-                  <div className="flex items-center gap-2 min-w-0">
-                    {defaultVoice ? (
-                      <span className="truncate">{defaultVoice.name}</span>
-                    ) : (
-                      <span className="truncate text-muted-foreground">
-                        {voices.length === 0
-                          ? t('settings.captures.playback.defaultVoice.noClonedVoices')
-                          : t('settings.captures.playback.defaultVoice.noneSelected')}
-                      </span>
-                    )}
-                  </div>
-                  <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
+                  <Keyboard className="h-3.5 w-3.5 mr-1.5" />
+                  {t('settings.captures.dictation.pushToTalk.change')}
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-64">
-                <DropdownMenuLabel className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                  {t('settings.captures.playback.defaultVoice.clonedVoices')}
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {voices.map((v) => (
-                  <DropdownMenuItem
-                    key={v.id}
-                    onClick={() => update({ default_playback_voice_id: v.id })}
-                    className="gap-2.5 py-2"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium truncate">{v.name}</div>
-                      {v.description ? (
-                        <div className="text-[11px] text-muted-foreground truncate">
-                          {v.description}
-                        </div>
-                      ) : null}
-                    </div>
-                    {v.id === defaultVoiceId && <Check className="h-3.5 w-3.5 text-accent shrink-0" />}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          }
-        />
-      </SettingSection>
+              </div>
+            }
+          />
 
-      <SettingSection
-        title={t('settings.captures.storage.title')}
-        description={t('settings.captures.storage.description')}
-      >
-        <SettingRow
-          title={t('settings.captures.storage.folder.title')}
-          description={capturesPath ?? t('settings.captures.storage.folder.description')}
-          action={
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openCapturesFolder}
-              disabled={opening || !capturesPath}
-            >
-              <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
-              {t('settings.captures.storage.folder.open')}
-            </Button>
-          }
-        />
-      </SettingSection>
+          <SettingRow
+            title={t('settings.captures.dictation.toggle.title')}
+            description={t('settings.captures.dictation.toggle.description')}
+            action={
+              <div className="flex items-center gap-2">
+                <ChordPreview keys={toggleToTalkKeys} />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!hotkeyEnabled}
+                  onClick={() => setChordEditor('toggle')}
+                >
+                  <Keyboard className="h-3.5 w-3.5 mr-1.5" />
+                  {t('settings.captures.dictation.toggle.change')}
+                </Button>
+              </div>
+            }
+          />
+
+          <ChordPicker
+            open={chordEditor === 'push'}
+            title={t('settings.captures.dictation.chordPicker.pttTitle')}
+            description={t('settings.captures.dictation.chordPicker.pttDescription')}
+            initialKeys={pushToTalkKeys}
+            onCancel={() => setChordEditor(null)}
+            onSave={(keys) => {
+              update({ chord_push_to_talk_keys: keys });
+              setChordEditor(null);
+            }}
+          />
+
+          <ChordPicker
+            open={chordEditor === 'toggle'}
+            title={t('settings.captures.dictation.chordPicker.toggleTitle')}
+            description={t('settings.captures.dictation.chordPicker.toggleDescription')}
+            initialKeys={toggleToTalkKeys}
+            onCancel={() => setChordEditor(null)}
+            onSave={(keys) => {
+              update({ chord_toggle_to_talk_keys: keys });
+              setChordEditor(null);
+            }}
+          />
+
+          <SettingRow
+            title={t('settings.captures.dictation.preview.title')}
+            description={t('settings.captures.dictation.preview.description')}
+          >
+            <HotkeyPillPreview enabled={hotkeyEnabled} />
+          </SettingRow>
+
+          <div>
+            <SettingRow
+              title={t('settings.captures.dictation.autoPaste.title')}
+              description={t('settings.captures.dictation.autoPaste.description')}
+              htmlFor="autoPaste"
+              action={
+                <Toggle
+                  id="autoPaste"
+                  checked={allowAutoPaste}
+                  onCheckedChange={(v) => update({ allow_auto_paste: v })}
+                  disabled={!hotkeyEnabled}
+                />
+              }
+            />
+            <AccessibilityNotice />
+          </div>
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.transcription.title')}
+          description={t('settings.captures.transcription.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.transcription.model.title')}
+            description={t('settings.captures.transcription.model.description')}
+            action={
+              <Select
+                value={sttModel}
+                onValueChange={(v) => update({ stt_model: v as WhisperModelSize })}
+              >
+                <SelectTrigger className="w-[300px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="base">
+                    {t('settings.captures.transcription.model.base', {
+                      tail: t('settings.captures.transcription.model.tail.fast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="small">
+                    {t('settings.captures.transcription.model.small', {
+                      tail: t('settings.captures.transcription.model.tail.balanced'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="medium">
+                    {t('settings.captures.transcription.model.medium', {
+                      tail: t('settings.captures.transcription.model.tail.higher'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="large">
+                    {t('settings.captures.transcription.model.large', {
+                      tail: t('settings.captures.transcription.model.tail.best'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="turbo">
+                    {t('settings.captures.transcription.model.turbo', {
+                      tail: t('settings.captures.transcription.model.tail.nearBest'),
+                    })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.transcription.language.title')}
+            description={t('settings.captures.transcription.language.description')}
+            action={
+              <Select value={language} onValueChange={(v) => update({ language: v })}>
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">
+                    {t('settings.captures.transcription.language.auto')}
+                  </SelectItem>
+                  <SelectItem value="en">
+                    {t('settings.captures.transcription.language.en')}
+                  </SelectItem>
+                  <SelectItem value="es">
+                    {t('settings.captures.transcription.language.es')}
+                  </SelectItem>
+                  <SelectItem value="fr">
+                    {t('settings.captures.transcription.language.fr')}
+                  </SelectItem>
+                  <SelectItem value="de">
+                    {t('settings.captures.transcription.language.de')}
+                  </SelectItem>
+                  <SelectItem value="ja">
+                    {t('settings.captures.transcription.language.ja')}
+                  </SelectItem>
+                  <SelectItem value="zh">
+                    {t('settings.captures.transcription.language.zh')}
+                  </SelectItem>
+                  <SelectItem value="hi">
+                    {t('settings.captures.transcription.language.hi')}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.refinement.title')}
+          description={t('settings.captures.refinement.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.refinement.auto.title')}
+            description={t('settings.captures.refinement.auto.description')}
+            htmlFor="autoRefine"
+            action={
+              <Toggle
+                id="autoRefine"
+                checked={autoRefine}
+                onCheckedChange={(v) => update({ auto_refine: v })}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.model.title')}
+            description={t('settings.captures.refinement.model.description')}
+            action={
+              <Select
+                value={llmModel}
+                onValueChange={(v) => update({ llm_model: v as Qwen3ModelSize })}
+                disabled={!autoRefine}
+              >
+                <SelectTrigger className="w-[260px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="0.6B">
+                    {t('settings.captures.refinement.model.size06', {
+                      tail: t('settings.captures.refinement.model.tail.veryFast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="1.7B">
+                    {t('settings.captures.refinement.model.size17', {
+                      tail: t('settings.captures.refinement.model.tail.fast'),
+                    })}
+                  </SelectItem>
+                  <SelectItem value="4B">
+                    {t('settings.captures.refinement.model.size40', {
+                      tail: t('settings.captures.refinement.model.tail.fullQuality'),
+                    })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.smartCleanup.title')}
+            description={t('settings.captures.refinement.smartCleanup.description')}
+            htmlFor="smartCleanup"
+            action={
+              <Toggle
+                id="smartCleanup"
+                checked={smartCleanup}
+                onCheckedChange={(v) => update({ smart_cleanup: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.selfCorrection.title')}
+            description={t('settings.captures.refinement.selfCorrection.description')}
+            htmlFor="selfCorrection"
+            action={
+              <Toggle
+                id="selfCorrection"
+                checked={selfCorrection}
+                onCheckedChange={(v) => update({ self_correction: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+
+          <SettingRow
+            title={t('settings.captures.refinement.preserveTechnical.title')}
+            description={t('settings.captures.refinement.preserveTechnical.description')}
+            htmlFor="preserveTechnical"
+            action={
+              <Toggle
+                id="preserveTechnical"
+                checked={preserveTechnical}
+                onCheckedChange={(v) => update({ preserve_technical: v })}
+                disabled={!autoRefine}
+              />
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.playback.title')}
+          description={t('settings.captures.playback.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.playback.defaultVoice.title')}
+            description={t('settings.captures.playback.defaultVoice.description')}
+            action={
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-2 min-w-[220px] justify-between"
+                    disabled={voices.length === 0}
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      {defaultVoice ? (
+                        <span className="truncate">{defaultVoice.name}</span>
+                      ) : (
+                        <span className="truncate text-muted-foreground">
+                          {voices.length === 0
+                            ? t('settings.captures.playback.defaultVoice.noClonedVoices')
+                            : t('settings.captures.playback.defaultVoice.noneSelected')}
+                        </span>
+                      )}
+                    </div>
+                    <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuLabel className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                    {t('settings.captures.playback.defaultVoice.clonedVoices')}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {voices.map((v) => (
+                    <DropdownMenuItem
+                      key={v.id}
+                      onClick={() => update({ default_playback_voice_id: v.id })}
+                      className="gap-2.5 py-2"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">{v.name}</div>
+                        {v.description ? (
+                          <div className="text-[11px] text-muted-foreground truncate">
+                            {v.description}
+                          </div>
+                        ) : null}
+                      </div>
+                      {v.id === defaultVoiceId && (
+                        <Check className="h-3.5 w-3.5 text-accent shrink-0" />
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            }
+          />
+        </SettingSection>
+
+        <SettingSection
+          title={t('settings.captures.storage.title')}
+          description={t('settings.captures.storage.description')}
+        >
+          <SettingRow
+            title={t('settings.captures.storage.folder.title')}
+            description={capturesPath ?? t('settings.captures.storage.folder.description')}
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openCapturesFolder}
+                disabled={opening || !capturesPath}
+              >
+                <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
+                {t('settings.captures.storage.folder.open')}
+              </Button>
+            }
+          />
+        </SettingSection>
       </div>
 
       <aside className="hidden lg:block w-[280px] shrink-0 space-y-6 sticky top-0">
@@ -544,12 +612,16 @@ export function CapturesPage() {
         </div>
 
         <div className="space-y-3">
-          <h3 className="text-sm font-semibold">{t('settings.captures.sidebar.differencesTitle')}</h3>
+          <h3 className="text-sm font-semibold">
+            {t('settings.captures.sidebar.differencesTitle')}
+          </h3>
           <ul className="space-y-3 text-sm text-muted-foreground">
             <li className="flex gap-2.5">
               <Lock className="h-4 w-4 shrink-0 mt-0.5 text-accent" />
               <span className="leading-relaxed">
-                <span className="text-foreground font-medium">{t('settings.captures.sidebar.local.title')}</span>{' '}
+                <span className="text-foreground font-medium">
+                  {t('settings.captures.sidebar.local.title')}
+                </span>{' '}
                 {t('settings.captures.sidebar.local.body')}
               </span>
             </li>

--- a/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
+++ b/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
@@ -5,6 +5,7 @@ import { Visualizer } from 'react-sound-visualizer';
 import { Button } from '@/components/ui/button';
 import { FormControl, FormItem, FormMessage } from '@/components/ui/form';
 import { formatAudioDuration } from '@/lib/utils/audio';
+import { useCaptureSettings } from '@/lib/hooks/useSettings';
 
 const MemoizedWaveform = memo(function MemoizedWaveform({
   audioStream,
@@ -50,6 +51,7 @@ export function AudioSampleRecording({
   showWaveform = true,
 }: AudioSampleRecordingProps) {
   const { t } = useTranslation();
+  const { settings: captureSettings } = useCaptureSettings();
   const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
 
   // Request microphone access when component mounts
@@ -59,8 +61,22 @@ export function AudioSampleRecording({
 
     let stream: MediaStream | null = null;
 
-    navigator.mediaDevices
-      .getUserMedia({ audio: true, video: false })
+    const inputDeviceId = captureSettings?.input_device_id;
+    const requestStream = async () => {
+      if (inputDeviceId) {
+        try {
+          return await navigator.mediaDevices.getUserMedia({
+            audio: { deviceId: { exact: inputDeviceId } },
+            video: false,
+          });
+        } catch {
+          // Fall back to default microphone
+        }
+      }
+      return await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    };
+
+    requestStream()
       .then((s) => {
         stream = s;
         setAudioStream(s);
@@ -76,7 +92,7 @@ export function AudioSampleRecording({
         });
       }
     };
-  }, [showWaveform]);
+  }, [showWaveform, captureSettings?.input_device_id]);
 
   return (
     <FormItem>

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -887,6 +887,12 @@
           "title": "Global shortcut",
           "description": "Hold the shortcut to record from anywhere on your machine. Release to transcribe."
         },
+        "inputDevice": {
+          "title": "Audio input microphone",
+          "description": "Choose which microphone Voicebox records dictation and audio samples from.",
+          "default": "System Default Microphone",
+          "fallbackLabel": "Microphone {{index}}"
+        },
         "pushToTalk": {
           "title": "Push-to-talk shortcut",
           "description": "Hold these keys anywhere on your system to record. Release to stop and transcribe.",
@@ -1124,7 +1130,8 @@
         "title": "Switch to CPU backend",
         "description": "Disable GPU acceleration. You can re-download the GPU backend later.",
         "button": "Switch"
-      },      "remove": {
+      },
+      "remove": {
         "title": "Remove CUDA backend",
         "description": "Delete the downloaded CUDA binary to free disk space.",
         "button": "Remove"

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -210,6 +210,8 @@ export interface CaptureSettings {
   preserve_technical: boolean;
   allow_auto_paste: boolean;
   default_playback_voice_id: string | null;
+  /** Configured audio input deviceId (null or empty string means system default microphone). */
+  input_device_id: string | null;
   /** Whether the global keyboard hotkey is armed. Off by default — turning
    *  this on triggers the macOS Input Monitoring TCC prompt. */
   hotkey_enabled: boolean;

--- a/app/src/lib/hooks/useAudioInputDevices.ts
+++ b/app/src/lib/hooks/useAudioInputDevices.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/** Represents an enumerated audio input microphone device with its ID and display label. */
+export interface AudioInputDevice {
+  deviceId: string;
+  label: string;
+}
+
+/**
+ * Custom React hook that enumerates available audio input devices (microphones),
+ * formats human-readable device labels, and attaches a listener for hardware 'devicechange'
+ * events to automatically refresh the input list when microphones are plugged or unplugged.
+ *
+ * @returns Object containing the array of enumerated audio input devices, a manual refresh function, and loading state.
+ */
+export function useAudioInputDevices() {
+  const { t } = useTranslation();
+  const [devices, setDevices] = useState<AudioInputDevice[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshDevices = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) {
+      setDevices([]);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const allDevices = await navigator.mediaDevices.enumerateDevices();
+      const audioInputs = allDevices.filter(
+        (d) =>
+          d.kind === 'audioinput' &&
+          Boolean(d.deviceId) &&
+          d.deviceId !== 'default' &&
+          d.deviceId !== 'communications',
+      );
+
+      let fallbackIndex = 1;
+      const formattedDevices: AudioInputDevice[] = audioInputs.map((device) => {
+        let label = device.label?.trim();
+        if (!label) {
+          label = t('settings.captures.dictation.inputDevice.fallbackLabel', {
+            index: fallbackIndex,
+            defaultValue: `Microphone ${fallbackIndex}`,
+          });
+          fallbackIndex++;
+        }
+        return {
+          deviceId: device.deviceId,
+          label,
+        };
+      });
+
+      setDevices(formattedDevices);
+    } catch (err) {
+      console.error('Failed to enumerate audio input devices:', err);
+      setDevices([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refreshDevices();
+
+    if (typeof navigator !== 'undefined' && navigator.mediaDevices) {
+      const mediaDevices = navigator.mediaDevices;
+      mediaDevices.addEventListener('devicechange', refreshDevices);
+      return () => {
+        mediaDevices.removeEventListener('devicechange', refreshDevices);
+      };
+    }
+  }, [refreshDevices]);
+
+  return {
+    devices,
+    refreshDevices,
+    isLoading,
+  };
+}

--- a/app/src/lib/hooks/useAudioRecording.ts
+++ b/app/src/lib/hooks/useAudioRecording.ts
@@ -1,17 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePlatform } from '@/platform/PlatformContext';
 import { convertToWav } from '@/lib/utils/audio';
+import { useCaptureSettings } from '@/lib/hooks/useSettings';
 
 interface UseAudioRecordingOptions {
   maxDurationSeconds?: number;
+  deviceId?: string | null;
   onRecordingComplete?: (blob: Blob, duration?: number) => void;
 }
 
 export function useAudioRecording({
   maxDurationSeconds,
+  deviceId,
   onRecordingComplete,
 }: UseAudioRecordingOptions = {}) {
   const platform = usePlatform();
+  const { settings: captureSettings } = useCaptureSettings();
   const [isRecording, setIsRecording] = useState(false);
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -58,14 +62,37 @@ export function useAudioRecording({
         }
       }
 
-      // Request microphone access
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-        },
-      });
+      // Request microphone access with device constraint and fallback
+      const targetDeviceId = deviceId !== undefined ? deviceId : captureSettings?.input_device_id;
+      const baseAudioConstraints: MediaTrackConstraints = {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      };
+
+      let stream: MediaStream;
+      if (targetDeviceId) {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({
+            audio: {
+              ...baseAudioConstraints,
+              deviceId: { exact: targetDeviceId },
+            },
+          });
+        } catch (deviceErr) {
+          console.warn(
+            `Failed to open configured audio input device "${targetDeviceId}", falling back to default device:`,
+            deviceErr,
+          );
+          stream = await navigator.mediaDevices.getUserMedia({
+            audio: baseAudioConstraints,
+          });
+        }
+      } else {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: baseAudioConstraints,
+        });
+      }
 
       streamRef.current = stream;
 
@@ -162,7 +189,13 @@ export function useAudioRecording({
       setError(errorMessage);
       setIsRecording(false);
     }
-  }, [maxDurationSeconds, onRecordingComplete]);
+  }, [
+    deviceId,
+    captureSettings?.input_device_id,
+    maxDurationSeconds,
+    onRecordingComplete,
+    platform.metadata.isTauri,
+  ]);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -222,6 +222,13 @@ def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
             "default_playback_voice_id VARCHAR",
             "default_playback_voice_id",
         )
+    if "input_device_id" not in columns:
+        _add_column(
+            engine,
+            "capture_settings",
+            "input_device_id VARCHAR",
+            "input_device_id",
+        )
     if "chord_push_to_talk_keys" not in columns:
         _add_column(
             engine,

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -204,6 +204,8 @@ class CaptureSettings(Base):
     preserve_technical = Column(Boolean, nullable=False, default=True)
     allow_auto_paste = Column(Boolean, nullable=False, default=True)
     default_playback_voice_id = Column(String, nullable=True)
+    # Configured audio input deviceId (None means system default microphone)
+    input_device_id = Column(String, nullable=True, default=None)
     # Default OFF — opting in is what triggers the macOS Input Monitoring TCC
     # prompt. We deliberately don't spawn the global keyboard tap until the
     # user flips this on so a fresh-install user doesn't see a scary

--- a/backend/models.py
+++ b/backend/models.py
@@ -257,6 +257,9 @@ class CaptureSettingsResponse(BaseModel):
     preserve_technical: bool = True
     allow_auto_paste: bool = True
     default_playback_voice_id: Optional[str] = None
+    input_device_id: Optional[str] = Field(
+        default=None, description="Configured audio input deviceId (None means default microphone)"
+    )
     hotkey_enabled: bool = False
     chord_push_to_talk_keys: List[str] = Field(
         default_factory=default_push_to_talk_chord
@@ -281,6 +284,9 @@ class CaptureSettingsUpdate(BaseModel):
     preserve_technical: Optional[bool] = None
     allow_auto_paste: Optional[bool] = None
     default_playback_voice_id: Optional[str] = None
+    input_device_id: Optional[str] = Field(
+        default=None, description="Configured audio input deviceId (None means default microphone)"
+    )
     hotkey_enabled: Optional[bool] = None
     chord_push_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)
     chord_toggle_to_talk_keys: Optional[List[str]] = Field(default=None, min_length=1, max_length=6)


### PR DESCRIPTION
### Summary

Resolves #979 by adding support for selecting and persisting a specific audio input device / microphone for dictation and voice recording sessions in Voicebox.

### Changes Made

- **Device Enumeration & Event Listening (`useAudioInputDevices`)**:
  - Implemented `useAudioInputDevices` hook using `navigator.mediaDevices.enumerateDevices()` to filter `audioinput` devices.
  - Added event listener for `devicechange` to automatically refresh available microphones when devices are plugged or unplugged in real time.
  - Formatted human-readable device labels, falling back to "Microphone 1", "Microphone 2" if labels aren't granted yet.
  - Filtered out virtual alias device IDs (`default`, `communications`) to prevent key collisions in dropdown menus.

- **Audio Stream & Fallback Logic (`useAudioRecording` & `AudioSampleRecording`)**:
  - Updated `useAudioRecording` and `AudioSampleRecording` to request audio streams using `{ deviceId: { exact: selectedDeviceId } }`.
  - Added fallback handling: If a saved microphone is unplugged or fails, `getUserMedia` catches the error and seamlessly falls back to the system default microphone without crashing.

- **Settings UI Component**:
  - Added an **Audio input microphone** dropdown in **Settings → Captures** (`/settings/captures`) under the **Dictation** section.
  - Added translation string master in `en/translation.json`.

- **Backend Persistence**:
  - Added `input_device_id` column to `CaptureSettings` model and SQLite database migration in `migrations.py`.
  - Updated Pydantic models in `backend/models.py` and TypeScript interfaces in `types.ts`.

### Verification & Testing

- **Verified on**: Windows 11 / 10 (tested audio stream switching and fallback with built-in Stereo Mix & VB-Audio Virtual Cable).
- **Automated Checks**: `bun run typecheck` passed cleanly (0 errors), Biome formatting passed.
- **Cross-Platform Architecture**: Built strictly on standard W3C Web Media APIs (`navigator.mediaDevices.enumerateDevices` and `getUserMedia`), ensuring identical API behavior across Windows, macOS, and Linux runtimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added microphone selection for dictation and audio-sample recording.
  * Selected input devices are saved and restored automatically.
  * Device lists refresh when audio hardware changes.
  * Added translated labels for available and default microphones.

* **Bug Fixes**
  * Recording now falls back to the system-default microphone if the selected device is unavailable.
  * Improved microphone access when selected devices change or become unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->