### PR TITLE
fix: Dockerfile HuggingFace cache and generations directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,14 @@ FROM python:3.11-slim
 RUN groupadd -r voicebox && \
     useradd -r -g voicebox -m -s /bin/bash voicebox
 
+# Create HuggingFace cache directory for the named volume
+RUN mkdir -p /home/voicebox/.cache/huggingface \
+    && chown -R voicebox:voicebox /home/voicebox/.cache/huggingface
+
+# Create voice generations directory for the named volume
+RUN mkdir -p /app/data/generations \
+    && chown -R voicebox:voicebox /app/data/generations
+
 WORKDIR /app
 
 # Install only runtime system dependencies (gosu drops root in the entrypoint)


### PR DESCRIPTION
Fixes #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container setup by ensuring required cache and voice-generation directories are available with the correct permissions at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->