### PR TITLE
fix: missing C compiler runtime error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     gosu \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed Python packages from builder stage


### PR DESCRIPTION
Fixes #877

Triton requires a C compiler at runtime for GPU inference. I'm not 100% sure this is the optimal approach, so feel free to reject, though this fix works for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build tools to the runtime environment to support required package compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->