### PR TITLE
Update PyTorch installation for ROCm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,12 @@ COPY backend/requirements.txt .
 ARG ROCM_VERSION=6.3
 
 # For ROCm, make the PyTorch ROCm index primary so every install below resolves
-# torch to ROCm wheels instead of the default CUDA build.
+# torch to ROCm wheels instead of the default CUDA build. Fix it to torch 2.7.1 as
+# it is actually the only working version for rocm. 
 RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
       pip install --no-cache-dir --prefix=/install \
         --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
-        torch torchaudio && \
+        torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 && \
       printf '[global]\nindex-url = https://download.pytorch.org/whl/rocm%s\nextra-index-url = https://pypi.org/simple\n' "$ROCM_VERSION" > /etc/pip.conf; \
     fi
 
@@ -66,6 +67,35 @@ RUN pip install --no-cache-dir --prefix=/install --no-deps hume-tada
 RUN pip install --no-cache-dir --prefix=/install \
     git+https://github.com/QwenLM/Qwen3-TTS.git
 
+# Qwen3-TTS's setup.py pulls in plain PyPI "triton" (CUDA-oriented) as an
+# unconstrained dependency, alongside its nvidia-cuda-*/cuda-bindings/
+# cuda-toolkit sub-deps. This shadows the correct pytorch-triton-rocm
+# that shipped with our pinned ROCm torch, and breaks at runtime with
+# "libcudart.so.13: cannot open shared object file" since no real NVIDIA
+# driver is present. Strip the stray CUDA packages on ROCm builds.
+RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      SITE=/install/lib/python3.11/site-packages && \
+      rm -rf "$SITE"/triton "$SITE"/triton-*.dist-info \
+             "$SITE"/nvidia "$SITE"/nvidia_*.dist-info \
+             "$SITE"/cuda_bindings "$SITE"/cuda_bindings-*.dist-info \
+             "$SITE"/cuda_pathfinder "$SITE"/cuda_pathfinder-*.dist-info \
+             "$SITE"/cuda_toolkit "$SITE"/cuda_toolkit-*.dist-info \
+             "$SITE"/torch "$SITE"/torch-*.dist-info \
+             "$SITE"/torchaudio "$SITE"/torchaudio-*.dist-info \
+             "$SITE"/torchvision "$SITE"/torchvision-*.dist-info \
+             "$SITE"/functorch \
+             "$SITE"/*.dist-info/../nvidia* 2>/dev/null; \
+      true; \
+    fi
+
+# Re-pin torch/torchaudio to the ROCm build. requirements.txt (unpinned
+# torch/torchvision) can pull the default CUDA wheels from pypi.org via
+# the extra-index-url fallback and silently clobber the ROCm install above.
+RUN if [ "$PYTORCH_VARIANT" = "rocm" ]; then \
+      PIP_EXTRA_INDEX_URL= pip install --no-cache-dir --prefix=/install --force-reinstall --no-deps \
+        --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
+        torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1; \
+    fi
 
 # === Stage 3: Runtime ===
 FROM python:3.11-slim


### PR DESCRIPTION
## Fix ROCm/AMD GPU support in Docker build

### Problem

The ROCm build path in the Dockerfile silently falls back to a CUDA-only PyTorch build even when `PYTORCH_VARIANT=rocm` is set, causing `torch.cuda.is_available()` to return `False` on AMD GPUs and, once partially fixed, `ImportError: libcudart.so.13: cannot open shared object file` when loading models (e.g. Qwen3-TTS) that depend on `torchaudio`'s compiled extension.

Root causes (two separate issues stacked on top of each other):

1. **PyTorch's "wheel variant" system (introduced in 2.9)** relies on a provider plugin to detect the local ROCm environment and pick the right backend variant. That detection can't work inside a `docker build` context (no ROCm runtime present at build time), so an unpinned `torch` install resolves to the default CUDA build even when pointed at the ROCm-specific package index (`--index-url https://download.pytorch.org/whl/rocm6.3`).

2. **`git+https://github.com/QwenLM/Qwen3-TTS.git` is installed without `--no-deps`** (unlike `chatterbox-tts` and `hume-tada`, which correctly use `--no-deps`). This pulls in unconstrained, CUDA-oriented transitive dependencies (`triton`, `nvidia-*`, `cuda-bindings`, `cuda-toolkit`) and a second, unpinned `torch`/`torchaudio` install. Because these installs happen across separate `pip install --prefix=/install` invocations, `pip --force-reinstall` does not reliably remove the stale `.dist-info` directories from the first install — both versions end up coexisting in the final image, and the wrong one gets loaded at runtime.

### Fix

- Pin `torch`, `torchvision`, and `torchaudio` to explicit versions (`2.7.1` / `0.22.1` / `2.7.1`) in the initial ROCm install step, since this is the last PyTorch generation using classic (non-variant) `+rocm6.3`-tagged wheels — avoids the wheel-variant auto-detection problem entirely.
- Add `PIP_EXTRA_INDEX_URL=` (empty) to the final pinned reinstall step, since `/etc/pip.conf` (written by the initial ROCm install) sets `extra-index-url = https://pypi.org/simple`, which otherwise lets pip silently fall back to PyPI's default CUDA build even with an explicit `--index-url`.
- Add a cleanup step after the Qwen3-TTS install that explicitly removes the stray CUDA-oriented packages (`triton`, `nvidia-*`, `cuda_bindings`, `cuda_pathfinder`, `cuda_toolkit`) and the unpinned `torch`/`torchaudio`/`torchvision`/`functorch` directories/dist-info from `/install`, so the subsequent pinned reinstall starts from a clean slate instead of relying on `pip`'s reinstall detection across separate invocations.

### Verification

```
docker build --target backend-builder --build-arg PYTORCH_VARIANT=rocm --build-arg ROCM_VERSION=6.3 -t voicebox-builder-debug .
docker run --rm voicebox-builder-debug find /install -maxdepth 4 -iname "torch*-*.dist-info"
```
Before: `torch-2.13.0.dist-info` and `torch-2.7.1+rocm6.3.dist-info` (and same for torchaudio) present simultaneously.
After: only `torch-2.7.1+rocm6.3.dist-info`, `torchvision-0.22.1+rocm6.3.dist-info`, `torchaudio-2.7.1+rocm6.3.dist-info`.

Full container startup log now reports:
```
INFO:     GPU: ROCm (AMD Radeon RX 7900 XT)
```
and
```
python3 -c "from qwen_tts import Qwen3TTSModel; print('OK')"
```
completes without the `libcudart.so.13` error.

### Note for maintainers

`scripts/package_rocm.py` declares `torch_compat=">=2.9.0,<2.10.0"` as the default compatibility range, which conflicts with the `2.7.1` pin needed here to avoid the wheel-variant detection issue. I haven't touched that file — flagging it separately since reconciling it (e.g. testing whether a 2.9.x pin can be made to work with an explicit provider override, or updating the declared range) seems like a separate discussion from this build fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROCm build reliability by ensuring the correct hardware-accelerated PyTorch components are installed.
  * Prevented CUDA-specific components from being included in ROCm builds, reducing installation conflicts and setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->