### PR TITLE
Disable JIT compilation for Numba

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       - LOG_LEVEL=info
       - NUMBA_CACHE_DIR=/tmp/numba_cache
+      - NUMBA_DISABLE_JIT=1
 
     networks:
       - voicebox-net


### PR DESCRIPTION
## Fix librosa/numba caching crash on model load

### Problem

Loading TTS models that depend on `librosa` (e.g. Qwen3-TTS) fails with:

```
RuntimeError: cannot cache function '__o_fold': no locator available for file
'/usr/local/lib/python3.11/site-packages/librosa/core/notation.py'
```

This is not a filesystem permissions issue — `NUMBA_CACHE_DIR=/tmp/numba_cache`
(already set in this file) is being picked up correctly, and numba successfully
caches other functions in the same run (verified: `core_*` and `librosa_*` cache
directories are created and writable before the crash). The failure is specific
to `__o_fold`, a double-underscore-prefixed function — numba's cache locators
have a known inability to resolve a cache path for this kind of name-mangled/
private function (see e.g. numba/numba#9668, numba/numba#4908), independent of
directory permissions.

### Fix

Add `NUMBA_DISABLE_JIT=1` to disable numba's JIT compilation entirely for the
container process:

```yaml
environment:
  - LOG_LEVEL=info
  - NUMBA_CACHE_DIR=/tmp/numba_cache
  - NUMBA_DISABLE_JIT=1
```

### Trade-off

The handful of numba-accelerated helper functions in `librosa` (note-name
conversion, some signal-processing utilities) run as plain interpreted Python
instead of JIT-compiled machine code — measurably slower per-call, but this
only affects small pre/post-processing steps in the audio pipeline, not the
actual TTS model inference (which runs entirely through Torch/ROCm on GPU and
has no numba dependency). Not noticeable in practice for typical usage.

### Verification

```
docker-compose -f docker-compose.yml -f docker-compose.rocm.yml up -d --force-recreate
docker-compose exec voicebox python3 -c "from qwen_tts import Qwen3TTSModel; print('OK')"
```
Model download and load now complete without the RuntimeError.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Voicebox container compatibility by disabling just-in-time compilation at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->