### PR TITLE
Add sox package installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     gosu \
+    sox \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed Python packages from builder stage


### PR DESCRIPTION
This is really optional and not really a bugfix. It works without that, but removes a warning you'll face in working with voicebox. The background is completely harmless, but maybe someone triggers that as a "bug". It's up to you to add it or not.

### install sox to silence startup warning

librosa/torchaudio probe for SoX as an optional legacy audio backend at
startup, logging:
    WARNING: SoX could not be found!
This is harmless (soundfile is the active backend, already in requirements.txt)
but noisy in logs. Installing sox removes the warning at negligible image-size
cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoX audio processing support to the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->