### PR TITLE
feat(api): report engine capabilities instead of declaring them twice

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -525,6 +525,59 @@ def engine_has_model_sizes(engine: str) -> bool:
     return len(configs) > 1
 
 
+def engine_supports_instruct(engine: str) -> bool:
+    """Whether this engine honours the ``instruct`` kwarg.
+
+    Base Qwen3-TTS accepts the argument and ignores it, so passing delivery
+    instructions there is silently ineffective — hence the flag rather than
+    inferring support from the signature.
+
+    An engine whose variants disagree is treated as unsupported: a request
+    carries one engine but the model size can change under it, so the
+    conservative answer is the only one that stays true for every variant.
+    """
+    configs = [c for c in get_tts_model_configs() if c.engine == engine]
+    return bool(configs) and all(c.supports_instruct for c in configs)
+
+
+def engine_languages(engine: str) -> list[str]:
+    """Language codes this engine can generate.
+
+    Union across the engine's variants — a language available on only one
+    model size is still reachable, just not on every size.
+    """
+    langs: list[str] = []
+    for cfg in get_tts_model_configs():
+        if cfg.engine == engine:
+            langs.extend(lang for lang in cfg.languages if lang not in langs)
+    return langs
+
+
+def engine_model_sizes(engine: str) -> list[str]:
+    """Model sizes registered for this engine, in registry order."""
+    return [c.model_size for c in get_tts_model_configs() if c.engine == engine]
+
+
+def get_engine_capabilities() -> list[dict]:
+    """Per-engine capability summary, derived from the model registry.
+
+    The registry is the single source of truth: clients read this instead of
+    keeping their own list of which engines honour what, which is how the two
+    drift apart.
+    """
+    return [
+        {
+            "engine": engine,
+            "display_name": display_name,
+            "supports_instruct": engine_supports_instruct(engine),
+            "languages": engine_languages(engine),
+            "model_sizes": engine_model_sizes(engine),
+            "has_model_sizes": engine_has_model_sizes(engine),
+        }
+        for engine, display_name in TTS_ENGINES.items()
+    ]
+
+
 async def load_engine_model(engine: str, model_size: str = "default") -> None:
     """Load a model for the given engine, handling engines with multiple model sizes."""
     backend = get_tts_backend_for_engine(engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -483,6 +483,32 @@ class ModelStatusListResponse(BaseModel):
     models: List[ModelStatus]
 
 
+class EngineCapabilities(BaseModel):
+    """What one TTS engine can actually do.
+
+    Derived from the model registry rather than hand-maintained, so a client
+    never has to keep its own copy of which engines honour what.
+    """
+
+    engine: str
+    display_name: str
+    supports_instruct: bool = Field(
+        description=(
+            "Whether the engine honours the instruct kwarg. Base Qwen3-TTS "
+            "accepts it and ignores it, so this is False there."
+        )
+    )
+    languages: List[str]
+    model_sizes: List[str]
+    has_model_sizes: bool
+
+
+class EngineCapabilitiesListResponse(BaseModel):
+    """Response model for the engine capability list."""
+
+    engines: List[EngineCapabilities]
+
+
 class ModelDownloadRequest(BaseModel):
     """Request model for triggering model download."""
 

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -4,12 +4,14 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
+from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import config, models
+from ..backends import engine_supports_instruct, get_engine_capabilities
 from ..services import history, personality, profiles, tts
 from ..database import Generation as DBGeneration, VoiceProfile as DBVoiceProfile, get_db
 from ..services.generation import run_generation
@@ -53,6 +55,27 @@ def _resolve_generation_engine(data: models.GenerationRequest, profile) -> str:
     return data.engine or getattr(profile, "default_engine", None) or getattr(profile, "preset_engine", None) or "qwen"
 
 
+def _warn_if_instruct_ignored(instruct: Optional[str], engine: str) -> None:
+    """Log when delivery instructions are about to be discarded.
+
+    Base Qwen3-TTS takes ``instruct`` and ignores it. The desktop app hides
+    the field for such engines, but API and MCP callers have no such cue and
+    would otherwise watch their instructions vanish with no signal anywhere —
+    which reads as the model refusing to follow them.
+    """
+    if not instruct or not instruct.strip():
+        return
+    if engine_supports_instruct(engine):
+        return
+    logger.warning(
+        "Engine %r does not honour `instruct`; the delivery instruction was "
+        "ignored. Engines that honour it: %s. See GET /engines.",
+        engine,
+        ", ".join(sorted(e["engine"] for e in get_engine_capabilities() if e["supports_instruct"]))
+        or "none",
+    )
+
+
 @router.post("/generate", response_model=models.GenerationResponse)
 async def generate_speech(
     data: models.GenerationRequest,
@@ -73,6 +96,7 @@ async def generate_speech(
         profiles.validate_profile_engine(profile, engine)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    _warn_if_instruct_ignored(data.instruct, engine)
 
     model_size = (data.model_size or "1.7B") if engine_has_model_sizes(engine) else None
 
@@ -338,6 +362,7 @@ async def stream_speech(
         profiles.validate_profile_engine(profile, engine)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    _warn_if_instruct_ignored(data.instruct, engine)
     tts_model = get_tts_backend_for_engine(engine)
     model_size = data.model_size or "1.7B"
 

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -47,6 +47,19 @@ def _copy_with_progress(src: Path, dst: Path, progress_manager, copied_so_far: i
     return copied_so_far
 
 
+@router.get("/engines", response_model=models.EngineCapabilitiesListResponse)
+async def list_engine_capabilities():
+    """What each TTS engine supports, derived from the model registry.
+
+    Clients should gate features on these flags rather than matching engine
+    names — the registry is where support is declared, so a new engine that
+    honours ``instruct`` becomes usable without a client change.
+    """
+    from ..backends import get_engine_capabilities
+
+    return {"engines": get_engine_capabilities()}
+
+
 @router.post("/models/load")
 async def load_model(model_size: str = "1.7B"):
     """Manually load TTS model."""

--- a/backend/tests/test_engine_capabilities.py
+++ b/backend/tests/test_engine_capabilities.py
@@ -1,0 +1,167 @@
+"""
+Tests for engine capability reporting.
+
+``ModelConfig.supports_instruct`` was declared and then read nowhere, while the
+desktop app kept its own hard-coded set of instruct-capable engines. Two
+sources of truth for the same fact drift the moment an engine is added. These
+tests pin the registry as the authority and pin the one behaviour that has no
+UI to warn about it: an API caller passing ``instruct`` to an engine that
+throws it away.
+
+Usage:
+    python -m pytest backend/tests/test_engine_capabilities.py -v
+"""
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+_DATA_DIR = tempfile.mkdtemp(prefix="voicebox-engine-caps-test-")
+os.environ["VOICEBOX_DATA_DIR"] = _DATA_DIR
+
+from starlette.testclient import TestClient  # noqa: E402
+
+from backend.app import app  # noqa: E402
+from backend.backends import (  # noqa: E402
+    TTS_ENGINES,
+    engine_languages,
+    engine_model_sizes,
+    engine_supports_instruct,
+    get_tts_model_configs,
+)
+from backend.routes.generations import _warn_if_instruct_ignored  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ── The flag is finally read ─────────────────────────────────────────
+
+
+def test_base_qwen_does_not_support_instruct():
+    """The whole reason the flag exists: base Qwen3-TTS accepts instruct and
+    silently ignores it, so it must not be advertised as supporting it."""
+    assert engine_supports_instruct("qwen") is False
+
+
+def test_custom_voice_supports_instruct():
+    assert engine_supports_instruct("qwen_custom_voice") is True
+
+
+def test_unknown_engine_is_not_supported():
+    """An engine with no registry entry must not read as capable — otherwise a
+    typo in an engine name silently 'supports' everything."""
+    assert engine_supports_instruct("no-such-engine") is False
+
+
+def test_helper_agrees_with_the_registry():
+    """The helper must not develop its own opinion: for every engine, it has to
+    match what the configs declare."""
+    for engine in TTS_ENGINES:
+        configs = [c for c in get_tts_model_configs() if c.engine == engine]
+        expected = bool(configs) and all(c.supports_instruct for c in configs)
+        assert engine_supports_instruct(engine) is expected, engine
+
+
+def test_mixed_variants_resolve_conservatively(monkeypatch):
+    """If one model size honours instruct and another doesn't, the engine must
+    report False — a request names an engine, and the size can change under it,
+    so only the pessimistic answer is true for every variant."""
+    configs = list(get_tts_model_configs())
+    target = next(c for c in configs if c.engine == "qwen_custom_voice")
+
+    from dataclasses import replace
+
+    downgraded = replace(target, supports_instruct=False, model_name=target.model_name + "-x")
+    monkeypatch.setattr(
+        "backend.backends.get_tts_model_configs",
+        lambda: [*configs, downgraded],
+    )
+    assert engine_supports_instruct("qwen_custom_voice") is False
+
+
+# ── Derived metadata ─────────────────────────────────────────────────
+
+
+def test_languages_are_unioned_across_variants():
+    langs = engine_languages("qwen")
+    assert "en" in langs
+    assert "es" in langs
+    assert len(langs) == len(set(langs)), "duplicates across variants"
+
+
+def test_model_sizes_reported_for_multi_size_engines():
+    assert set(engine_model_sizes("qwen")) == {"1.7B", "0.6B"}
+
+
+def test_unknown_engine_has_no_metadata():
+    assert engine_languages("no-such-engine") == []
+    assert engine_model_sizes("no-such-engine") == []
+
+
+# ── The endpoint ─────────────────────────────────────────────────────
+
+
+def test_engines_endpoint_lists_every_tts_engine(client):
+    r = client.get("/engines")
+    assert r.status_code == 200, r.text
+    engines = {e["engine"] for e in r.json()["engines"]}
+    assert engines == set(TTS_ENGINES)
+
+
+def test_engines_endpoint_matches_the_helpers(client):
+    """The endpoint is what clients gate features on, so it must not diverge
+    from the helpers the backend itself uses."""
+    for entry in client.get("/engines").json()["engines"]:
+        assert entry["supports_instruct"] == engine_supports_instruct(entry["engine"])
+        assert entry["languages"] == engine_languages(entry["engine"])
+        assert entry["model_sizes"] == engine_model_sizes(entry["engine"])
+
+
+def test_engines_endpoint_reports_qwen_correctly(client):
+    entry = next(e for e in client.get("/engines").json()["engines"] if e["engine"] == "qwen")
+    assert entry["supports_instruct"] is False
+    assert entry["has_model_sizes"] is True
+    assert entry["display_name"] == "Qwen TTS"
+
+
+# ── No more silent drops ─────────────────────────────────────────────
+
+
+def test_warns_when_instruct_would_be_discarded(caplog):
+    with caplog.at_level(logging.WARNING, logger="backend.routes.generations"):
+        _warn_if_instruct_ignored("speak angrily", "qwen")
+    assert any("does not honour" in r.getMessage() for r in caplog.records)
+
+
+def test_no_warning_when_the_engine_honours_instruct(caplog):
+    with caplog.at_level(logging.WARNING, logger="backend.routes.generations"):
+        _warn_if_instruct_ignored("speak angrily", "qwen_custom_voice")
+    assert not caplog.records
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_no_warning_without_an_instruction(caplog, value):
+    """Every generate call passes instruct=None. Warning on that would bury the
+    real case in noise."""
+    with caplog.at_level(logging.WARNING, logger="backend.routes.generations"):
+        _warn_if_instruct_ignored(value, "qwen")
+    assert not caplog.records
+
+
+def test_warning_names_a_working_alternative(caplog):
+    """A warning that only says 'no' costs the caller another round of
+    guessing; it should say what does work."""
+    with caplog.at_level(logging.WARNING, logger="backend.routes.generations"):
+        _warn_if_instruct_ignored("speak angrily", "qwen")
+    rendered = caplog.records[0].getMessage()
+    assert "qwen_custom_voice" in rendered


### PR DESCRIPTION
`ModelConfig.supports_instruct` is set deliberately on four configs and **read nowhere**. The desktop app gates its instruct field on its own hard-coded set instead:

```ts
// app/src/components/Generation/EngineModelSelector.tsx
const INSTRUCT_ENGINES = new Set(['qwen_custom_voice']);
```

Two places declaring the same fact. They drift the first time an engine is added — a new engine that honours `instruct` needs a frontend edit before the field appears, even though the registry already says it works.

## Changes

**`engine_supports_instruct()`**, alongside the existing `engine_needs_trim()` and `engine_retries_runaway()`, so the flag is read where it is declared. Plus `engine_languages()` and `engine_model_sizes()` derived the same way.

**`GET /engines`** exposes the lot, so clients gate on capability rather than matching engine names:

```json
{"engines": [
  {"engine": "qwen", "display_name": "Qwen TTS", "supports_instruct": false,
   "languages": ["zh","en","ja","ko","de","fr","ru","pt","es","it"],
   "model_sizes": ["1.7B","0.6B"], "has_model_sizes": true},
  {"engine": "qwen_custom_voice", "supports_instruct": true, ...}
]}
```

An engine whose variants disagree reports `False`. A request names an engine and the model size can change under it, so the conservative answer is the only one true for every variant.

**No more silent drop.** Base Qwen3-TTS accepts `instruct` and ignores it — `backends/__init__.py:249` has said so all along:

```python
supports_instruct=False,  # Base model drops instruct silently
```

The app hides the field there, so desktop users are fine. API and MCP callers get no such cue and watch their delivery instructions vanish with nothing logged anywhere — which reads as the model refusing to follow them rather than never receiving them. `POST /generate` and `POST /generate/stream` now log a warning naming the engines that do honour it.

## Scope

No behaviour change to generation, and no change to which engines support what — only to whether that is discoverable. The frontend still uses its local set; swapping it to read `/engines` is a follow-up, and deliberately not bundled here so this stays backend-only and reviewable on its own.

Worth noting this does **not** fix #579. That reporter is putting delivery cues inline in the text on base Qwen, which has no instruct field at all — a different problem.

## Tests

17, in `backend/tests/test_engine_capabilities.py`: the flag checked against the registry rather than restating it, the mixed-variant rule, derived languages and sizes, the endpoint checked against the helpers so the two can't diverge, and the warning including its negative cases — absent, empty, whitespace-only, and a capable engine.

Branched off `main`, independent of my other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint for viewing text-to-speech engine capabilities, including supported languages, model sizes, and instruction support.
  * Added consolidated capability information for each available engine.

* **Bug Fixes**
  * Added warnings when delivery instructions are provided to engines that do not support them.
  * Improved handling of unsupported or unknown engines without reporting false capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->