### PR TITLE
feat(api): regenerate a take with corrected text or settings

### DIFF
--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -201,6 +201,17 @@ def _migrate_generation_versions(engine, inspector, tables: set[str]) -> None:
     if "source_version_id" not in columns:
         _add_column(engine, "generation_versions", "source_version_id VARCHAR", "source_version_id")
 
+    # Nullable with no default: NULL means "same as the generation", so
+    # existing takes are already correct and need no backfill.
+    for column, ddl in (
+        ("text", "text TEXT"),
+        ("language", "language VARCHAR"),
+        ("instruct", "instruct TEXT"),
+        ("seed", "seed INTEGER"),
+    ):
+        if column not in columns:
+            _add_column(engine, "generation_versions", ddl, column)
+
 
 def _migrate_capture_settings(engine, inspector, tables: set[str]) -> None:
     if "capture_settings" not in tables:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -138,6 +138,20 @@ class GenerationVersion(Base):
     effects_chain = Column(Text, nullable=True)
     source_version_id = Column(String, ForeignKey("generation_versions.id"), nullable=True)
     is_default = Column(Boolean, default=False)
+
+    # What produced this take, when it differs from the generation's own
+    # settings. NULL means "same as the generation" -- so every existing row
+    # stays correct without a backfill, and only an overridden regenerate
+    # writes anything here.
+    #
+    # Without these a corrected take is unattributable: the generation row
+    # would describe the newest text while older takes still point at audio of
+    # the old text, and nothing records which was which.
+    text = Column(Text, nullable=True)
+    language = Column(String, nullable=True)
+    instruct = Column(Text, nullable=True)
+    seed = Column(Integer, nullable=True)
+
     created_at = Column(DateTime, default=datetime.utcnow)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -738,6 +738,23 @@ class EffectPresetResponse(BaseModel):
         from_attributes = True
 
 
+class RegenerateRequest(BaseModel):
+    """Optional overrides for a regenerate.
+
+    Every field is optional; omitted ones reuse the generation's settings.
+    Send ``text`` to fix a typo and re-run without losing the take that had it,
+    or ``language`` to re-read one segment in another language.
+    """
+
+    text: Optional[str] = Field(None, min_length=1, max_length=50000)
+    language: Optional[str] = Field(
+        None, pattern="^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$"
+    )
+    instruct: Optional[str] = Field(None, max_length=500)
+    # A regenerate normally varies the seed. Set this to reproduce a take.
+    seed: Optional[int] = Field(None, ge=0)
+
+
 class GenerationVersionResponse(BaseModel):
     """Response model for a generation version."""
 
@@ -748,6 +765,13 @@ class GenerationVersionResponse(BaseModel):
     effects_chain: Optional[List[EffectConfig]] = None
     source_version_id: Optional[str] = None
     is_default: bool
+    # What produced this take, when it differed from the generation's own
+    # settings. NULL means it used the generation's, so a client showing "the
+    # current take" reads these first and falls back to the generation.
+    text: Optional[str] = None
+    language: Optional[str] = None
+    instruct: Optional[str] = None
+    seed: Optional[int] = None
     created_at: datetime
 
     class Config:

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
+from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
@@ -191,13 +192,34 @@ async def retry_generation(generation_id: str, db: Session = Depends(get_db)):
     "/generate/{generation_id}/regenerate",
     response_model=models.GenerationResponse,
 )
-async def regenerate_generation(generation_id: str, db: Session = Depends(get_db)):
-    """Re-run TTS with the same parameters and save the result as a new version."""
+async def regenerate_generation(
+    generation_id: str,
+    data: Optional[models.RegenerateRequest] = None,
+    db: Session = Depends(get_db),
+):
+    """Re-run TTS and save the result as a new version.
+
+    With no body this reruns the generation unchanged, as before. With
+    overrides it reruns using them -- correcting a typo without discarding the
+    take that had it, or re-reading one segment in another language.
+
+    The generation row is never rewritten. It keeps the text as first written,
+    and each take records what produced it, so the old take stays playable and
+    attributable instead of becoming audio nobody can account for.
+    """
     gen = db.query(DBGeneration).filter_by(id=generation_id).first()
     if not gen:
         raise HTTPException(status_code=404, detail="Generation not found")
     if (gen.status or "completed") != "completed":
         raise HTTPException(status_code=400, detail="Generation must be completed to regenerate")
+
+    overrides = data.model_dump(exclude_unset=True) if data else {}
+    text = overrides.get("text", gen.text)
+    language = overrides.get("language", gen.language)
+    instruct = overrides.get("instruct", gen.instruct)
+    seed = overrides.get("seed", gen.seed)
+
+    engine = gen.engine or "qwen"
 
     gen.status = "generating"
     gen.error = None
@@ -208,7 +230,7 @@ async def regenerate_generation(generation_id: str, db: Session = Depends(get_db
     task_manager.start_generation(
         task_id=generation_id,
         profile_id=gen.profile_id,
-        text=gen.text,
+        text=text,
     )
 
     version_id = str(uuid.uuid4())
@@ -218,14 +240,19 @@ async def regenerate_generation(generation_id: str, db: Session = Depends(get_db
         run_generation(
             generation_id=generation_id,
             profile_id=gen.profile_id,
-            text=gen.text,
-            language=gen.language,
-            engine=gen.engine or "qwen",
+            text=text,
+            language=language,
+            engine=engine,
             model_size=gen.model_size or "1.7B",
-            seed=gen.seed,
-            instruct=gen.instruct,
+            seed=seed,
+            instruct=instruct,
             mode="regenerate",
             version_id=version_id,
+            # Only what the caller actually overrode is recorded. A field that
+            # matched the generation stays NULL, so "same as the generation"
+            # and "explicitly set to the same value" do not become
+            # indistinguishable rows.
+            version_overrides=overrides,
         )
     )
 

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -42,6 +42,7 @@ async def run_generation(
     max_chunk_chars: Optional[int] = None,
     crossfade_ms: Optional[int] = None,
     version_id: Optional[str] = None,
+    version_overrides: Optional[dict] = None,
 ) -> None:
     """Execute TTS inference and persist the result.
 
@@ -81,7 +82,14 @@ async def run_generation(
 
         gen_kwargs: dict = dict(
             language=language,
-            seed=seed if mode != "regenerate" else None,
+            # A regenerate normally drops the seed so the take varies. An
+            # explicitly requested one is the caller asking for a specific
+            # result -- usually to reproduce a take they liked -- so it wins.
+            seed=(
+                seed
+                if mode != "regenerate" or (version_overrides or {}).get("seed") is not None
+                else None
+            ),
             instruct=instruct,
             trim_fn=trim_fn,
             runaway_detector=runaway_detector,
@@ -124,6 +132,7 @@ async def run_generation(
                 sample_rate=sample_rate,
                 save_audio=save_audio,
                 db=bg_db,
+                overrides=version_overrides,
             )
 
         await history.update_generation_status(
@@ -331,8 +340,13 @@ def _save_regenerate(
     sample_rate: int,
     save_audio,
     db,
+    overrides: Optional[dict] = None,
 ) -> str:
     """Save regeneration output as a new version with auto-label.
+
+    ``overrides`` records what produced this take when it differed from the
+    generation's settings, so a corrected take stays attributable to the text
+    that made it rather than being confused with its siblings.
 
     Returns the audio path.
     """
@@ -350,6 +364,7 @@ def _save_regenerate(
     count = db.query(DBGenerationVersion).filter_by(generation_id=generation_id).count()
     label = f"take-{count + 1}"
 
+    overrides = overrides or {}
     versions_mod.create_version(
         generation_id=generation_id,
         label=label,
@@ -357,6 +372,10 @@ def _save_regenerate(
         db=db,
         effects_chain=None,
         is_default=True,
+        text=overrides.get("text"),
+        language=overrides.get("language"),
+        instruct=overrides.get("instruct"),
+        seed=overrides.get("seed"),
     )
 
     return config.to_storage_path(audio_path)

--- a/backend/services/versions.py
+++ b/backend/services/versions.py
@@ -36,6 +36,10 @@ def _version_response(v: DBGenerationVersion) -> GenerationVersionResponse:
         effects_chain=effects_chain,
         source_version_id=v.source_version_id,
         is_default=v.is_default,
+        text=v.text,
+        language=v.language,
+        instruct=v.instruct,
+        seed=v.seed,
         created_at=v.created_at,
     )
 
@@ -87,11 +91,20 @@ def create_version(
     effects_chain: Optional[List[dict]] = None,
     is_default: bool = False,
     source_version_id: Optional[str] = None,
+    text: Optional[str] = None,
+    language: Optional[str] = None,
+    instruct: Optional[str] = None,
+    seed: Optional[int] = None,
 ) -> GenerationVersionResponse:
     """Create a new version for a generation.
 
     If ``is_default`` is True, all other versions for this generation
     are un-defaulted first.
+
+    ``text``, ``language``, ``instruct`` and ``seed`` record what produced this
+    take when it differs from the generation's own settings. Leave them None
+    when the take used the generation's settings unchanged -- NULL reads as
+    "same as the generation", which is what keeps pre-existing rows correct.
     """
     if is_default:
         _clear_defaults(generation_id, db)
@@ -104,6 +117,10 @@ def create_version(
         effects_chain=json.dumps(effects_chain) if effects_chain else None,
         source_version_id=source_version_id,
         is_default=is_default,
+        text=text,
+        language=language,
+        instruct=instruct,
+        seed=seed,
     )
     db.add(version)
     db.commit()

--- a/backend/tests/test_regenerate_overrides.py
+++ b/backend/tests/test_regenerate_overrides.py
@@ -223,7 +223,16 @@ async def test_regenerate_still_accepts_no_body(client, db, profile, mock_tts):
     """Existing callers post nothing; that must keep working."""
     gen = await _make_generation(db, profile["id"])
     r = client.post(f"/generate/{gen.id}/regenerate")
-    assert r.status_code in (200, 400), r.text
+    # Must be 200, not "200 or 400": the generation is created completed, so a
+    # 400 here means the no-body path broke, which is exactly what this test
+    # exists to catch.
+    assert r.status_code == 200, r.text
+
+    # The route enqueues the work and returns, so the background task can
+    # outlive this test and its monkeypatched backend -- at which point it
+    # would reach for the real model. Cancel it; the response is what is under
+    # test here, and the generation path itself is covered above.
+    client.post(f"/generate/{gen.id}/cancel")
 
 
 def test_unknown_generation_404s(client):

--- a/backend/tests/test_regenerate_overrides.py
+++ b/backend/tests/test_regenerate_overrides.py
@@ -1,0 +1,246 @@
+"""
+Tests for regenerating a generation with overrides (#870).
+
+Correcting a typo used to mean creating a whole new generation, which loses the
+timeline placement, fades and track the old one had. Regenerate already saved
+its output as a new *version*; it just could not be told to change anything.
+
+The property that matters: the generation row keeps the text as first written,
+and each take records what produced it. Otherwise a corrected take and the take
+it replaced become indistinguishable audio under one row that describes only
+one of them.
+
+Usage:
+    python -m pytest backend/tests/test_regenerate_overrides.py -v
+"""
+
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+_DATA_DIR = tempfile.mkdtemp(prefix="voicebox-regen-test-")
+os.environ["VOICEBOX_DATA_DIR"] = _DATA_DIR
+
+from starlette.testclient import TestClient  # noqa: E402
+
+from backend.app import app  # noqa: E402
+from backend.database import get_db  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def db(client):
+    session = next(get_db())
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def profile(client):
+    name = f"Regen Test Voice {uuid.uuid4().hex[:8]}"
+    r = client.post("/profiles", json={"name": name, "language": "en"})
+    assert r.status_code == 200, r.text
+    created = r.json()
+    yield created
+    client.delete(f"/profiles/{created['id']}")
+
+
+@pytest.fixture
+def mock_tts(monkeypatch):
+    """Replace the model. What is under test is which strings go where."""
+    seen = []
+
+    class FakeBackend:
+        def is_loaded(self):
+            return True
+
+    async def fake_generate_chunked(_model, text, _vp, **kwargs):
+        seen.append({"text": text, "language": kwargs.get("language"),
+                     "instruct": kwargs.get("instruct"), "seed": kwargs.get("seed")})
+        return np.zeros(2400, dtype=np.float32), 24000
+
+    async def fake_load(*_a, **_k):
+        return None
+
+    async def fake_voice_prompt(*_a, **_k):
+        return {}
+
+    monkeypatch.setattr("backend.backends.get_tts_backend_for_engine", lambda _e: FakeBackend())
+    monkeypatch.setattr("backend.backends.load_engine_model", fake_load)
+    monkeypatch.setattr("backend.utils.chunked_tts.generate_chunked", fake_generate_chunked)
+    monkeypatch.setattr(
+        "backend.services.profiles.create_voice_prompt_for_profile", fake_voice_prompt
+    )
+    return seen
+
+
+async def _make_generation(db, profile_id, text="He plays a bandeja.", language="en"):
+    from backend.services import history as history_service
+
+    return await history_service.create_generation(
+        profile_id=profile_id,
+        text=text,
+        language=language,
+        audio_path="",
+        duration=0,
+        seed=None,
+        db=db,
+        status="completed",
+        engine="qwen",
+    )
+
+
+async def _regenerate(db, generation, overrides=None):
+    from backend.services.generation import run_generation
+
+    await run_generation(
+        generation_id=generation.id,
+        profile_id=generation.profile_id,
+        text=(overrides or {}).get("text", generation.text),
+        language=(overrides or {}).get("language", generation.language),
+        engine="qwen",
+        model_size="1.7B",
+        seed=(overrides or {}).get("seed"),
+        instruct=(overrides or {}).get("instruct"),
+        mode="regenerate",
+        version_id=str(uuid.uuid4()),
+        version_overrides=overrides or {},
+    )
+
+
+# ── The property the design rests on ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_corrected_text_reaches_the_engine(client, db, profile, mock_tts):
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen, {"text": "He plays a smash."})
+    assert mock_tts[-1]["text"] == "He plays a smash."
+
+
+@pytest.mark.asyncio
+async def test_the_generation_row_keeps_the_original_text(client, db, profile, mock_tts):
+    """Rewriting it would leave earlier takes describing audio they did not
+    produce, and would make the correction unattributable."""
+    gen = await _make_generation(db, profile["id"], text="He plays a bandeja.")
+    await _regenerate(db, gen, {"text": "He plays a smash."})
+
+    db.expire_all()
+    stored = client.get(f"/history/{gen.id}").json()
+    assert stored["text"] == "He plays a bandeja."
+
+
+@pytest.mark.asyncio
+async def test_the_take_records_what_produced_it(client, db, profile, mock_tts):
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen, {"text": "He plays a smash.", "language": "es"})
+
+    versions = client.get(f"/generations/{gen.id}/versions").json()
+    latest = versions[-1]
+    assert latest["text"] == "He plays a smash."
+    assert latest["language"] == "es"
+
+
+@pytest.mark.asyncio
+async def test_an_unoverridden_field_stays_null(client, db, profile, mock_tts):
+    """NULL means "same as the generation". Recording the inherited value would
+    make "unchanged" and "explicitly set to the same thing" indistinguishable,
+    and would need a backfill for every existing row."""
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen, {"text": "Only the text changed."})
+
+    latest = client.get(f"/generations/{gen.id}/versions").json()[-1]
+    assert latest["text"] == "Only the text changed."
+    assert latest["language"] is None
+    assert latest["instruct"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_plain_regenerate_records_nothing(client, db, profile, mock_tts):
+    """Unchanged reruns must keep behaving exactly as before."""
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen)
+
+    latest = client.get(f"/generations/{gen.id}/versions").json()[-1]
+    assert latest["text"] is None
+    assert latest["language"] is None
+
+
+@pytest.mark.asyncio
+async def test_takes_accumulate_rather_than_replace(client, db, profile, mock_tts):
+    """The point of correcting in place: the take with the typo survives, so it
+    stays available to A/B against."""
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen)
+    await _regenerate(db, gen, {"text": "Corrected."})
+
+    versions = client.get(f"/generations/{gen.id}/versions").json()
+    assert len(versions) >= 2
+    assert versions[-1]["text"] == "Corrected."
+
+
+# ── Seed handling ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_plain_regenerate_drops_the_seed(client, db, profile, mock_tts):
+    """Reusing the seed would reproduce the same take, defeating the point."""
+    gen = await _make_generation(db, profile["id"])
+    gen.seed = 1234
+    db.commit()
+    await _regenerate(db, gen)
+    assert mock_tts[-1]["seed"] is None
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_seed_survives(client, db, profile, mock_tts):
+    """An explicitly requested seed is the caller asking for a specific take,
+    usually to reproduce one they liked."""
+    gen = await _make_generation(db, profile["id"])
+    await _regenerate(db, gen, {"seed": 4242})
+    assert mock_tts[-1]["seed"] == 4242
+
+
+# ── API surface ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regenerate_still_accepts_no_body(client, db, profile, mock_tts):
+    """Existing callers post nothing; that must keep working."""
+    gen = await _make_generation(db, profile["id"])
+    r = client.post(f"/generate/{gen.id}/regenerate")
+    assert r.status_code in (200, 400), r.text
+
+
+def test_unknown_generation_404s(client):
+    assert client.post("/generate/no-such-id/regenerate", json={"text": "x"}).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_language_is_rejected(client, db, profile):
+    gen = await _make_generation(db, profile["id"])
+    r = client.post(f"/generate/{gen.id}/regenerate", json={"language": "klingon"})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_an_empty_text_override_is_rejected(client, db, profile):
+    """Omitting text means "reuse it". An empty string is a different request,
+    and not a coherent one."""
+    gen = await _make_generation(db, profile["id"])
+    r = client.post(f"/generate/{gen.id}/regenerate", json={"text": ""})
+    assert r.status_code == 422


### PR DESCRIPTION
Refs #870.

That issue asks to fix a typo in a story segment and re-run it. Today that means building a whole new generation — which loses the timeline placement, fades, speed and track the old one had. A one-character correction costs the arrangement around it.

## Most of this already existed

`POST /generate/{id}/regenerate` already saved its output as a new **version** under the same generation id, and story items can already be pinned to a version. It just couldn't be told to change anything — it re-ran `gen.text` verbatim.

It now takes an optional body:

```bash
curl -X POST localhost:17493/generate/{id}/regenerate \
  -d '{"text": "He plays a bandeja, not a smash."}'
```

`text`, `language`, `instruct`, `seed` — omitted fields reuse the generation's settings, and **no body at all behaves exactly as before**.

## Versions become self-describing

`generation_versions` held only `audio_path` and `effects_chain`, so a corrected take was unattributable: the generation row would describe the newest text while older takes still pointed at audio of the *old* text, with nothing recording which was which.

Four nullable columns fix that. **NULL means "same as the generation"** — so every existing row is already correct and needs no backfill, and only a field the caller actually overrode is written. That keeps "unchanged" and "explicitly set to the same value" distinguishable rather than collapsing them.

**The generation row is never rewritten.** It keeps the text as first written; each take records what produced it. The take with the typo stays playable *and* attributable instead of becoming audio nobody can account for — which is what makes A/B between takes mean anything.

## Seed

A regenerate normally drops the seed so the take varies. An explicitly passed seed now survives, since that's the caller asking for a specific result — usually to reproduce a take they liked.

## Deliberately not included

The timeline half of #870 — rippling the following clips by the duration delta when a correction changes a segment's length — isn't here. It belongs in the story routes, which #1007 is currently rewriting; adding it on top of `main` would conflict for no benefit. It's the natural follow-up once #1007 lands, which is also why this says `Refs` rather than `Closes`.

## Tests

12 in `backend/tests/test_regenerate_overrides.py`: corrected text reaching the engine, the generation row keeping the original, the take recording its own settings, unoverridden fields staying NULL, plain regenerates recording nothing, takes accumulating rather than replacing, both seed rules, and the API surface including no-body compatibility.

The model is mocked — what's under test is which strings go where, and loading 3.5 GB of weights wouldn't make those assertions any truer.

Branched off `main`, independent of my other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regenerate audio with optional text, language, instruction, and seed overrides.
  * Preserve and display generation-specific settings for each audio version.
  * Support explicit seed preservation during regeneration.

* **Bug Fixes**
  * Improved validation for invalid languages, empty text, and missing generations.
  * Maintained compatibility with regenerations that provide no override settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->