### PR TITLE
fix(backend): prevent unbounded memory accumulation over consecutive TTS generations (#923)

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -171,17 +171,23 @@ def check_cuda_compatibility() -> tuple[bool, str | None]:
 
 def empty_device_cache(device: str) -> None:
     """
-    Free cached memory on the given device (CUDA or XPU).
+    Free cached memory and unreferenced tensors on the given device (CUDA, XPU, MPS, CPU).
 
-    Backends should call this after unloading models so VRAM is returned
-    to the OS.
+    Backends call this after model unloading and post-generation cleanup to return
+    memory to the OS and prevent process heap accumulation.
     """
+    import gc
     import torch
+
+    gc.collect()
 
     if device == "cuda" and torch.cuda.is_available():
         torch.cuda.empty_cache()
     elif device == "xpu" and hasattr(torch, "xpu"):
         torch.xpu.empty_cache()
+    elif device == "mps" and hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        if hasattr(torch.mps, "empty_cache"):
+            torch.mps.empty_cache()
 
 
 def manual_seed(seed: int, device: str) -> None:

--- a/backend/backends/chatterbox_backend.py
+++ b/backend/backends/chatterbox_backend.py
@@ -203,21 +203,22 @@ class ChatterboxTTSBackend:
 
             logger.info(f"[Chatterbox] Generating: lang={language}")
 
-            wav = self.model.generate(
-                text,
-                language_id=language,
-                audio_prompt_path=ref_audio,
-                exaggeration=lang_defaults["exaggeration"],
-                cfg_weight=lang_defaults["cfg_weight"],
-                temperature=lang_defaults["temperature"],
-                repetition_penalty=lang_defaults["repetition_penalty"],
-            )
+            with torch.inference_mode():
+                wav = self.model.generate(
+                    text,
+                    language_id=language,
+                    audio_prompt_path=ref_audio,
+                    exaggeration=lang_defaults["exaggeration"],
+                    cfg_weight=lang_defaults["cfg_weight"],
+                    temperature=lang_defaults["temperature"],
+                    repetition_penalty=lang_defaults["repetition_penalty"],
+                )
 
-            # Convert tensor -> numpy
-            if isinstance(wav, torch.Tensor):
-                audio = wav.squeeze().cpu().numpy().astype(np.float32)
-            else:
-                audio = np.asarray(wav, dtype=np.float32)
+                # Convert tensor -> numpy
+                if isinstance(wav, torch.Tensor):
+                    audio = wav.squeeze().cpu().numpy().astype(np.float32)
+                else:
+                    audio = np.asarray(wav, dtype=np.float32)
 
             sample_rate = getattr(self.model, "sr", None) or getattr(self.model, "sample_rate", 24000)
 

--- a/backend/backends/chatterbox_turbo_backend.py
+++ b/backend/backends/chatterbox_turbo_backend.py
@@ -184,20 +184,21 @@ class ChatterboxTurboTTSBackend:
 
             logger.info("[Chatterbox Turbo] Generating (English)")
 
-            wav = self.model.generate(
-                text,
-                audio_prompt_path=ref_audio,
-                temperature=0.8,
-                top_k=1000,
-                top_p=0.95,
-                repetition_penalty=1.2,
-            )
+            with torch.inference_mode():
+                wav = self.model.generate(
+                    text,
+                    audio_prompt_path=ref_audio,
+                    temperature=0.8,
+                    top_k=1000,
+                    top_p=0.95,
+                    repetition_penalty=1.2,
+                )
 
-            # Convert tensor -> numpy
-            if isinstance(wav, torch.Tensor):
-                audio = wav.squeeze().cpu().numpy().astype(np.float32)
-            else:
-                audio = np.asarray(wav, dtype=np.float32)
+                # Convert tensor -> numpy
+                if isinstance(wav, torch.Tensor):
+                    audio = wav.squeeze().cpu().numpy().astype(np.float32)
+                else:
+                    audio = np.asarray(wav, dtype=np.float32)
 
             sample_rate = getattr(self.model, "sr", None) or getattr(self.model, "sample_rate", 24000)
 

--- a/backend/backends/kokoro_backend.py
+++ b/backend/backends/kokoro_backend.py
@@ -276,12 +276,13 @@ class KokoroTTSBackend:
 
             # Generate all chunks and concatenate
             audio_chunks = []
-            for result in pipeline(text, voice=voice_name, speed=1.0):
-                if result.audio is not None:
-                    chunk = result.audio
-                    if isinstance(chunk, torch.Tensor):
-                        chunk = chunk.detach().cpu().numpy()
-                    audio_chunks.append(chunk.squeeze())
+            with torch.inference_mode():
+                for result in pipeline(text, voice=voice_name, speed=1.0):
+                    if result.audio is not None:
+                        chunk = result.audio
+                        if isinstance(chunk, torch.Tensor):
+                            chunk = chunk.detach().cpu().numpy()
+                        audio_chunks.append(chunk.squeeze())
 
             if not audio_chunks:
                 # Return 1 second of silence as fallback

--- a/backend/backends/luxtts_backend.py
+++ b/backend/backends/luxtts_backend.py
@@ -167,18 +167,21 @@ class LuxTTSBackend:
             if seed is not None:
                 manual_seed(seed, self.device)
 
-            wav = self.model.generate_speech(
-                text=text,
-                encode_dict=voice_prompt,
-                num_steps=4,
-                guidance_scale=3.0,
-                t_shift=0.5,
-                speed=1.0,
-                return_smooth=False,  # 48kHz output
-            )
+            import torch
 
-            # LuxTTS returns a tensor (may be on GPU/MPS), move to CPU first
-            audio = wav.detach().cpu().numpy().squeeze()
+            with torch.inference_mode():
+                wav = self.model.generate_speech(
+                    text=text,
+                    encode_dict=voice_prompt,
+                    num_steps=4,
+                    guidance_scale=3.0,
+                    t_shift=0.5,
+                    speed=1.0,
+                    return_smooth=False,  # 48kHz output
+                )
+
+                # LuxTTS returns a tensor (may be on GPU/MPS), move to CPU first
+                audio = wav.detach().cpu().numpy().squeeze()
             return audio, 48000
 
         return await asyncio.to_thread(_generate_sync)

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -231,12 +231,13 @@ class PyTorchTTSBackend:
 
             # See _create_prompt_sync comment — inference runs with the
             # process's default HF_HUB_OFFLINE state (issue #462).
-            wavs, sample_rate = self.model.generate_voice_clone(
-                text=text,
-                voice_clone_prompt=voice_prompt,
-                language=LANGUAGE_CODE_TO_NAME.get(language, "auto"),
-                instruct=instruct,
-            )
+            with torch.inference_mode():
+                wavs, sample_rate = self.model.generate_voice_clone(
+                    text=text,
+                    voice_clone_prompt=voice_prompt,
+                    language=LANGUAGE_CODE_TO_NAME.get(language, "auto"),
+                    instruct=instruct,
+                )
             return wavs[0], sample_rate
 
         # Run blocking inference in thread pool to avoid blocking event loop

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -207,7 +207,8 @@ class QwenCustomVoiceBackend:
             # state. Forcing offline here (issue #462) regressed online
             # users whose libraries issue legitimate metadata lookups
             # during generation.
-            wavs, sample_rate = self.model.generate_custom_voice(**kwargs)
+            with torch.inference_mode():
+                wavs, sample_rate = self.model.generate_custom_voice(**kwargs)
             return wavs[0], sample_rate
 
         audio, sample_rate = await asyncio.to_thread(_generate_sync)

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -156,6 +156,12 @@ async def run_generation(
     finally:
         task_manager.complete_generation(generation_id)
         bg_db.close()
+        try:
+            from ..backends.base import empty_device_cache
+            device = getattr(tts_model, "device", "cpu") if "tts_model" in locals() else "cpu"
+            empty_device_cache(device)
+        except Exception:
+            pass
 
 
 def _notify_speak_end(generation_id: str, *, status: str) -> None:
@@ -313,14 +319,22 @@ async def generate_audio_sync(
     if crossfade_ms is not None:
         gen_kwargs["crossfade_ms"] = crossfade_ms
 
-    audio, sample_rate = await generate_chunked(
-        tts_model, text, voice_prompt, **gen_kwargs
-    )
+    try:
+        audio, sample_rate = await generate_chunked(
+            tts_model, text, voice_prompt, **gen_kwargs
+        )
 
-    if normalize:
-        audio = normalize_audio(audio)
+        if normalize:
+            audio = normalize_audio(audio)
 
-    return tts.audio_to_wav_bytes(audio, sample_rate)
+        return tts.audio_to_wav_bytes(audio, sample_rate)
+    finally:
+        try:
+            from ..backends.base import empty_device_cache
+            device = getattr(tts_model, "device", "cpu") if "tts_model" in locals() else "cpu"
+            empty_device_cache(device)
+        except Exception:
+            pass
 
 
 def _save_regenerate(


### PR DESCRIPTION
## Summary & Context

Fixes [#923](https://github.com/jamiepine/voicebox/issues/923) where `voicebox-server` memory accumulated continuously over consecutive speech synthesis runs on CPU (as well as GPU/MPS) backends. On long texts or consecutive generation requests, memory would grow step-wise (+120 MB to +250 MB per run), eventually causing RAM inflation and stalling subsequent queue items in `generating` state.

---

## Root Cause Analysis

1. **Autograd Activation Graph Retention**: Model forward inference was invoked without `torch.inference_mode()` or `torch.no_grad()` contexts across TTS engine backends. PyTorch retained computation graphs and intermediate activation tensors in RAM across consecutive synthesis passes.
2. **Missing Post-Generation Cleanup**: Unreferenced audio arrays and spectrogram buffers were not collected after individual synthesis jobs completed; cache clearing was only performed during full model unloads.
3. **Incomplete Allocator Flushing**: `empty_device_cache()` lacked explicit Python garbage collection (`gc.collect()`) for CPU memory reclamation and did not flush Apple Silicon MPS pools.

---

## Proposed Changes

### 1. PyTorch Inference Mode Guards
Wrapped all forward synthesis calls in `with torch.inference_mode():` across engine drivers:
- [`backend/backends/kokoro_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/kokoro_backend.py)
- [`backend/backends/qwen_custom_voice_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/qwen_custom_voice_backend.py)
- [`backend/backends/pytorch_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/pytorch_backend.py)
- [`backend/backends/luxtts_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/luxtts_backend.py)
- [`backend/backends/chatterbox_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/chatterbox_backend.py)
- [`backend/backends/chatterbox_turbo_backend.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/chatterbox_turbo_backend.py)

### 2. Mandatory Post-Generation Reclaim Hooks
Added `empty_device_cache(device)` invocations in the `finally` blocks of `run_generation()` and `generate_audio_sync()` within [`backend/services/generation.py`](file:///d:/Work/gitexperi/voicebox/backend/services/generation.py).

### 3. Comprehensive Device & Host Cache Clearing
Updated `empty_device_cache(device)` in [`backend/backends/base.py`](file:///d:/Work/gitexperi/voicebox/backend/backends/base.py) to trigger `gc.collect()` across all platforms and added `torch.mps.empty_cache()` support for Apple Silicon.

---

## Empirical Benchmark & Verification Results

### Test Environment & Cross-Platform Roadmap
- **Tested Environment**: Windows 11 Home (64-bit), CPU mode (`CUDA_VISIBLE_DEVICES="-1"`), Kokoro 82M engine (`Heart` female preset voice).
- **Upcoming Verification**: Testing will further continue on Linux environments.
- **Community Testing**: Simultaneous verification testing by macOS / Apple Silicon (MPS) device owners is highly welcomed and encouraged!

---

### Benchmark 1: 10-Run Baseline Test (97 Words / 685 Characters)

| Run | Status | Time | Worker RAM | Delta | Total Growth |
|---|---|---|---|---|---|
| **Run 1** | Completed | 24.6s | 1962.20 MB | +1176.63 MB (Model Load) | Baseline |
| **Run 2** | Completed | 14.3s | 1958.38 MB | -3.82 MB | -3.82 MB |
| **Run 3** | Completed | 14.3s | 1988.52 MB | +30.14 MB | +26.32 MB |
| **Run 4** | Completed | 15.3s | 1964.56 MB | -23.96 MB | +2.36 MB |
| **Run 5** | Completed | 15.3s | 1962.56 MB | -2.00 MB | +0.36 MB |
| **Run 6** | Completed | 15.3s | 1959.17 MB | -3.39 MB | -3.03 MB |
| **Run 7** | Completed | 15.3s | 1984.88 MB | +25.71 MB | +22.68 MB |
| **Run 8** | Completed | 14.3s | 1983.71 MB | -1.17 MB | +21.51 MB |
| **Run 9** | Completed | 16.3s | 1952.79 MB | -30.92 MB | -9.41 MB |
| **Run 10** | Completed | 16.3s | 1954.48 MB | +1.69 MB | **-7.72 MB** |

---

### Benchmark 2: Exhaustive 7-Run Stress Test (195 Words / 1,533 Characters Passage)

| Run | Status | Time | Worker RAM | Run-to-Run Delta | Net Fluctuation |
|---|---|---|---|---|---|
| **Run 1** | Completed | 42.9s | 1970.29 MB | Baseline (Inference Alloc) | — |
| **Run 2** | Completed | 33.7s | 2026.25 MB | +55.96 MB | Warm-up peak |
| **Run 3** | Completed | 37.8s | 2003.23 MB | **-23.02 MB** | Reclaimed |
| **Run 4** | Completed | 37.8s | 2004.92 MB | **+1.69 MB** | Stable |
| **Run 5** | Completed | 34.8s | 1992.73 MB | **-12.19 MB** | Reclaimed |
| **Run 6** | Completed | 33.6s | 2017.71 MB | **+24.98 MB** | Stable |
| **Run 7** | Completed | 33.6s | 2011.77 MB | **-5.94 MB** | **-14.48 MB vs Run 2** |

### Key Observations:
1. **Unbounded Accumulation Resolved**: Before the fix, memory increased monotonically by +120 MB to +250 MB per run. With the fix, memory remains strictly bounded within a narrow **1992 MB – 2026 MB** window across 7 consecutive large-text passes.
2. **Active Garbage Collection**: Negative deltas on Runs 3, 5, and 7 confirm that unreferenced arrays and tensors are actively reclaimed between passes.
3. **Zero Queue Degradation**: All generations completed cleanly without latency degradation or stall conditions.

---

## PowerShell Reproduction & Testing Snippet

I used the following PowerShell script to verify this fix against a running dev server (`http://localhost:17493`):

```powershell
$prof = (Invoke-RestMethod -Uri "http://localhost:17493/profiles") | Where-Object { $_.default_engine -eq "kokoro" -or $_.name -like "*Kokoro*" } | Select-Object -First 1
if (-not $prof) { $prof = (Invoke-RestMethod -Uri "http://localhost:17493/profiles")[0] }

$hugeText = @"
Voicebox is a modern, open-source desktop speech synthesis application and local voice cloning system engineered with Tauri, React, and Python FastAPI. It empowers creators, developers, and voice enthusiasts to generate natural-sounding speech locally on their own hardware without relying on cloud APIs or subscription services. Voicebox features modular support for cutting-edge text-to-speech architectures including Qwen3-TTS, Kokoro 82M, LuxTTS, Chatterbox, and HumeAI TADA.

When performing consecutive speech synthesis tasks on CPU architectures, resource management becomes paramount. Neural network backends process tokenized text inputs through multi-head self-attention mechanisms and recurrent decoder blocks to generate high-resolution audio spectrograms and raw audio waveforms. Without strict control over PyTorch autograd computation graphs, intermediate activation tensors, and device memory pools, consecutive generation passes can retain unreferenced allocation blocks in the process heap. This accumulation leads to progressive memory inflation and queue stall conditions.

By wrapping neural inference inside strict PyTorch inference mode context managers and invoking explicit host and accelerator cache clearing routines upon every task completion, Voicebox ensures that intermediate memory blocks are reclaimed immediately after synthesis. This guarantees that process memory remains flat, predictable, and bounded across dozens of consecutive generation requests regardless of input length or audio duration.
"@

$mainPid = (Get-NetTCPConnection -LocalPort 17493 -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1).OwningProcess
$initialMem = $null

1..7 | ForEach-Object {
    $loopNum = $_
    $allPy = Get-CimInstance Win32_Process | Where-Object { $_.Name -like '*python*' }
    $workerBefore = $allPy | Where-Object { $_.ParentProcessId -eq $mainPid -or $_.ProcessId -eq $mainPid } | Sort-Object WorkingSetSize -Descending | Select-Object -First 1
    $memBefore = [math]::Round($workerBefore.WorkingSetSize / 1MB, 2)
    if ($null -eq $initialMem) { $initialMem = $memBefore }

    $sw = [System.Diagnostics.Stopwatch]::StartNew()
    $body = @{
        profile_id = $prof.id
        engine = if ($prof.default_engine) { $prof.default_engine } else { "kokoro" }
        text = $hugeText
    } | ConvertTo-Json

    $res = Invoke-RestMethod -Uri "http://localhost:17493/generate" -Method Post -ContentType "application/json" -Body $body
    
    do {
        Start-Sleep -Seconds 1
        $st = (Invoke-RestMethod -Uri "http://localhost:17493/history/$($res.id)").status
    } while ($st -eq "generating" -or $st -eq "queued" -or $st -eq "loading_model")
    $sw.Stop()

    $allPy = Get-CimInstance Win32_Process | Where-Object { $_.Name -like '*python*' }
    $workerAfter = $allPy | Where-Object { $_.ParentProcessId -eq $mainPid -or $_.ProcessId -eq $mainPid } | Sort-Object WorkingSetSize -Descending | Select-Object -First 1
    $memAfter = [math]::Round($workerAfter.WorkingSetSize / 1MB, 2)
    $delta = [math]::Round($memAfter - $memBefore, 2)
    $totalGrowth = [math]::Round($memAfter - $initialMem, 2)
    $elapsedSec = $sw.Elapsed.TotalSeconds.ToString("F1")

    Write-Host "Run $loopNum | Time: ${elapsedSec}s | After: ${memAfter} MB (Delta: +${delta} MB | Total Growth: +${totalGrowth} MB)"
}






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved audio generation efficiency and memory usage across supported speech synthesis engines.
  * Added automatic cleanup after audio generation to help release unused device memory.

* **Bug Fixes**
  * Improved memory cleanup for CPU, CUDA, XPU, and MPS devices.
  * Reduced the risk of retained memory after unloading models or completing generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->