### PR TITLE
feat(prosody): a text-to-plan transformer for pauses, per-span language and rate

### DIFF
--- a/backend/services/prosody/__init__.py
+++ b/backend/services/prosody/__init__.py
@@ -1,0 +1,31 @@
+"""Prosody transformer: a harness around audio segment production.
+
+It never synthesises anything. It decides where to cut a script, what settings
+each cut carries, and how the pieces are reassembled -- so pauses, per-span
+language and rate work on every engine, including the ones that accept no
+directives at all.
+
+    markup ──▶ parse ──▶ compile(engine) ──▶ RenderPlan ──▶ render ──▶ audio
+
+The plan is the seam. It is plain data with no model behind it, so it can be
+built, asserted on and previewed for free.
+"""
+
+from .compiler import compile_plan
+from .ir import Attrs, Break, PlanWarning, RenderPlan, Silence, Speech, Text
+from .parser import ProsodyParseError, has_markup, parse, strip_markup
+
+__all__ = [
+    "Attrs",
+    "Break",
+    "PlanWarning",
+    "ProsodyParseError",
+    "RenderPlan",
+    "Silence",
+    "Speech",
+    "Text",
+    "compile_plan",
+    "has_markup",
+    "parse",
+    "strip_markup",
+]

--- a/backend/services/prosody/compiler.py
+++ b/backend/services/prosody/compiler.py
@@ -45,26 +45,44 @@ def _flatten(nodes: list[Node], inherited: Attrs, out: list[tuple[str, Attrs] | 
             _flatten(node.children, inherited.merged_with(node.attrs), out)
 
 
-def _coalesce(items: list[tuple[str, Attrs] | int]) -> list[tuple[str, Attrs] | int]:
-    """Merge neighbouring runs that share settings.
+def _resolve(items: list[tuple[str, Attrs] | int]) -> list[tuple[str, str, Attrs] | int]:
+    """Apply substitutions, producing (spoken, written, attrs).
 
-    Without this, ``a<lang xml:lang="es">b</lang>c`` would still cut between
-    the plain runs elsewhere in the sentence. Every avoided cut is one less
-    place the model restarts its prosody, which is the whole cost of this
-    approach.
+    Once ``<sub>``/``<phoneme>`` has been materialised into the spoken text it
+    stops being a setting, so it must not keep the run apart from its
+    neighbours afterwards. ``spoken_as`` is cleared here for exactly that
+    reason -- it governs inheritance, not rendering.
     """
-    merged: list[tuple[str, Attrs] | int] = []
+    out: list[tuple[str, str, Attrs] | int] = []
+    for item in items:
+        if isinstance(item, int):
+            out.append(item)
+            continue
+        written, attrs = item
+        spoken = written if attrs.spoken_as is None else attrs.spoken_as
+        out.append((spoken, written, replace(attrs, spoken_as=None)))
+    return out
+
+
+def _coalesce(items: list[tuple[str, str, Attrs] | int]) -> list[tuple[str, str, Attrs] | int]:
+    """Merge neighbouring runs that render identically.
+
+    Every avoided cut is one less place the model restarts its prosody, which
+    is the entire cost of this approach. It matters most for ``<sub>``: a
+    respelling changes the characters, not the settings, so the sentence around
+    it should stay in one piece. Cutting there would buy the seams that
+    respelling exists to avoid.
+    """
+    merged: list[tuple[str, str, Attrs] | int] = []
     for item in items:
         if (
             isinstance(item, tuple)
             and merged
             and isinstance(merged[-1], tuple)
-            and merged[-1][1] == item[1]
-            # A substitution applies to specific words; merging would extend it
-            # over neighbouring text that was never inside the <sub>.
-            and item[1].spoken_as is None
+            and merged[-1][2] == item[2]
         ):
-            merged[-1] = (merged[-1][0] + item[0], merged[-1][1])
+            prev = merged[-1]
+            merged[-1] = (prev[0] + item[0], prev[1] + item[1], prev[2])
         else:
             merged.append(item)
     return merged
@@ -94,7 +112,7 @@ def compile_plan(
             ``<emphasis>`` composes with rather than replaces.
     """
     nodes = parse(markup)
-    flat = _coalesce([item for item in _walk(nodes)])
+    flat = _coalesce(_resolve(_walk(nodes)))
 
     plan_nodes: list[Speech | Silence] = []
     warnings: list[PlanWarning] = []
@@ -107,8 +125,7 @@ def compile_plan(
                 plan_nodes.append(Silence(item))
             continue
 
-        raw_text, attrs = item
-        text = raw_text if attrs.spoken_as is None else attrs.spoken_as
+        text, raw_text, attrs = item
         if not text.strip():
             # Whitespace between tags is not a run of its own, but it must not
             # be lost either -- glue it onto the previous run.
@@ -162,7 +179,7 @@ def compile_plan(
         stripped = raw_text.strip()
         if (
             attrs.language
-            and attrs.spoken_as is None
+            and text == raw_text
             # A single short word, not merely a short span: extending the span
             # to a clause boundary is the usual fix, and a clause never trips
             # this. That is the tight-vs-clause-aligned distinction.
@@ -186,7 +203,7 @@ def compile_plan(
                 language=language,
                 rate=attrs.rate or 1.0,
                 instruct=instruct,
-                source_text=raw_text if attrs.spoken_as is not None else None,
+                source_text=raw_text if text != raw_text else None,
             )
         )
 

--- a/backend/services/prosody/compiler.py
+++ b/backend/services/prosody/compiler.py
@@ -1,0 +1,235 @@
+"""Flatten a parsed script into a RenderPlan for one specific engine.
+
+This is where the harness earns its name. Each directive has up to two
+realisations:
+
+*native*
+    tell the engine — ``instruct=`` on the engines that honour it
+
+*structural*
+    cut the text, render the run with its own settings, reassemble — which
+    needs no engine support whatsoever
+
+Pauses, language spans and rate are all structural, so they work identically on
+all eight engines. Delivery cues are the only ones that depend on capability,
+and where an engine cannot take them the plan says so out loud instead of
+dropping them silently.
+
+Nothing here loads a model or touches audio. A plan can be built, asserted on
+and shown to a user for free, which is what makes the pipeline previewable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .ir import Attrs, Break, Node, PlanWarning, RenderPlan, Silence, Span, Speech, Text
+from .parser import parse
+
+# Below this, a language span is usually a worse trade than leaving the word in
+# the surrounding language: prosody restarts at every cut, and a one-word
+# utterance is where these models are least stable. The compiler notes it
+# rather than overriding the author.
+SHORT_SPAN_CHARS = 12
+
+
+def _flatten(nodes: list[Node], inherited: Attrs, out: list[tuple[str, Attrs] | int]) -> None:
+    """Walk the tree into a flat run of (text, attrs) pairs and break markers."""
+    for node in nodes:
+        if isinstance(node, Text):
+            if node.value:
+                out.append((node.value, inherited))
+        elif isinstance(node, Break):
+            out.append(node.ms)
+        elif isinstance(node, Span):
+            _flatten(node.children, inherited.merged_with(node.attrs), out)
+
+
+def _coalesce(items: list[tuple[str, Attrs] | int]) -> list[tuple[str, Attrs] | int]:
+    """Merge neighbouring runs that share settings.
+
+    Without this, ``a<lang xml:lang="es">b</lang>c`` would still cut between
+    the plain runs elsewhere in the sentence. Every avoided cut is one less
+    place the model restarts its prosody, which is the whole cost of this
+    approach.
+    """
+    merged: list[tuple[str, Attrs] | int] = []
+    for item in items:
+        if (
+            isinstance(item, tuple)
+            and merged
+            and isinstance(merged[-1], tuple)
+            and merged[-1][1] == item[1]
+            # A substitution applies to specific words; merging would extend it
+            # over neighbouring text that was never inside the <sub>.
+            and item[1].spoken_as is None
+        ):
+            merged[-1] = (merged[-1][0] + item[0], merged[-1][1])
+        else:
+            merged.append(item)
+    return merged
+
+
+def compile_plan(
+    markup: str,
+    *,
+    engine: str,
+    default_language: str,
+    supports_instruct: bool = False,
+    engine_languages: list[str] | None = None,
+    base_instruct: str | None = None,
+) -> RenderPlan:
+    """Compile *markup* into a plan for *engine*.
+
+    Args:
+        markup: The script, with or without directives.
+        engine: Target engine id, recorded on the plan.
+        default_language: Language for text outside any ``<lang>``.
+        supports_instruct: From the model registry, not guessed here.
+        engine_languages: What the engine can generate. A ``<lang>`` outside
+            this set is a warning rather than an error -- the run still
+            renders, in the engine's own language, which is what it would have
+            done anyway.
+        base_instruct: The request's own delivery instruction, which
+            ``<emphasis>`` composes with rather than replaces.
+    """
+    nodes = parse(markup)
+    flat = _coalesce([item for item in _walk(nodes)])
+
+    plan_nodes: list[Speech | Silence] = []
+    warnings: list[PlanWarning] = []
+    seen_unsupported_language: set[str] = set()
+    emphasis_dropped = False
+
+    for item in flat:
+        if isinstance(item, int):
+            if item > 0:
+                plan_nodes.append(Silence(item))
+            continue
+
+        raw_text, attrs = item
+        text = raw_text if attrs.spoken_as is None else attrs.spoken_as
+        if not text.strip():
+            # Whitespace between tags is not a run of its own, but it must not
+            # be lost either -- glue it onto the previous run.
+            if plan_nodes and isinstance(plan_nodes[-1], Speech):
+                prev = plan_nodes[-1]
+                plan_nodes[-1] = Speech(
+                    text=prev.text + raw_text,
+                    language=prev.language,
+                    rate=prev.rate,
+                    instruct=prev.instruct,
+                    seed=prev.seed,
+                    source_text=prev.source_text,
+                )
+            continue
+
+        language = attrs.language or default_language
+        if (
+            engine_languages
+            and language not in engine_languages
+            and language not in seen_unsupported_language
+        ):
+            seen_unsupported_language.add(language)
+            warnings.append(
+                PlanWarning(
+                    code="language_unsupported",
+                    detail=(
+                        f"Engine {engine!r} cannot generate {language!r}; that run will be "
+                        f"read as {default_language!r}."
+                    ),
+                )
+            )
+            language = default_language
+
+        instruct = base_instruct
+        if attrs.emphasis:
+            if supports_instruct:
+                cue = f"Say this with {attrs.emphasis} emphasis."
+                instruct = f"{base_instruct} {cue}".strip() if base_instruct else cue
+            elif not emphasis_dropped:
+                emphasis_dropped = True
+                warnings.append(
+                    PlanWarning(
+                        code="emphasis_unsupported",
+                        detail=(
+                            f"Engine {engine!r} does not honour delivery instructions, so "
+                            f"<emphasis> has no effect. Try qwen_custom_voice."
+                        ),
+                    )
+                )
+
+        stripped = raw_text.strip()
+        if (
+            attrs.language
+            and attrs.spoken_as is None
+            # A single short word, not merely a short span: extending the span
+            # to a clause boundary is the usual fix, and a clause never trips
+            # this. That is the tight-vs-clause-aligned distinction.
+            and " " not in stripped
+            and len(stripped) < SHORT_SPAN_CHARS
+        ):
+            warnings.append(
+                PlanWarning(
+                    code="short_language_span",
+                    detail=(
+                        f"{stripped!r} is a single short word in its own run. Prosody restarts "
+                        f"at each cut, so extending the span to the surrounding clause, or a "
+                        f"<sub> respelling, often sounds smoother."
+                    ),
+                )
+            )
+
+        plan_nodes.append(
+            Speech(
+                text=text,
+                language=language,
+                rate=attrs.rate or 1.0,
+                instruct=instruct,
+                source_text=raw_text if attrs.spoken_as is not None else None,
+            )
+        )
+
+    return RenderPlan(nodes=_absorb_unspeakable(plan_nodes), warnings=warnings, engine=engine)
+
+
+def _has_speech(text: str) -> bool:
+    """Whether a run contains anything a model could pronounce."""
+    return any(ch.isalnum() for ch in text)
+
+
+def _absorb_unspeakable(nodes: list[Speech | Silence]) -> list[Speech | Silence]:
+    """Fold runs with no pronounceable content into a neighbour.
+
+    A span boundary almost always orphans its trailing punctuation --
+    ``</lang>.`` leaves a run holding just ``"."``. Generating that is a wasted
+    call that returns noise or silence, so it is appended to the run before it
+    (or prepended to the one after, when it comes first).
+
+    Substituted runs are never merged: a ``<sub>`` applies to specific words,
+    and absorbing text into it would put words through a substitution the
+    author never wrapped.
+    """
+    out: list[Speech | Silence] = []
+    for node in nodes:
+        if isinstance(node, Speech) and not _has_speech(node.text):
+            prev = out[-1] if out else None
+            if isinstance(prev, Speech) and prev.source_text is None:
+                out[-1] = replace(prev, text=prev.text + node.text)
+                continue
+        out.append(node)
+
+    # A leading orphan has no predecessor; give it to the following run.
+    if len(out) > 1 and isinstance(out[0], Speech) and not _has_speech(out[0].text):
+        first, second = out[0], out[1]
+        if isinstance(second, Speech) and second.source_text is None:
+            out = [replace(second, text=first.text + second.text), *out[2:]]
+
+    # Everything may have been punctuation; keep it rather than return nothing.
+    return out or nodes
+
+
+def _walk(nodes: list[Node]) -> list[tuple[str, Attrs] | int]:
+    out: list[tuple[str, Attrs] | int] = []
+    _flatten(nodes, Attrs(), out)
+    return out

--- a/backend/services/prosody/compiler.py
+++ b/backend/services/prosody/compiler.py
@@ -26,11 +26,20 @@ from dataclasses import replace
 from .ir import Attrs, Break, Node, PlanWarning, RenderPlan, Silence, Span, Speech, Text
 from .parser import parse
 
-# Below this, a language span is usually a worse trade than leaving the word in
-# the surrounding language: prosody restarts at every cut, and a one-word
-# utterance is where these models are least stable. The compiler notes it
-# rather than overriding the author.
-SHORT_SPAN_CHARS = 12
+
+def _is_over_articulated(alias: str) -> bool:
+    """Whether a respelling is shaped like the one that tested worst.
+
+    ``ban-DEH-ha`` -- syllable hyphens plus capitals for stress -- was judged
+    exaggerated on every voice tried, and measurably so: it ran about 30%
+    longer than the same sentence unmarked. ``ban-deh-ha`` was acceptable and
+    plain ``bandeha`` sounded most natural, so it is the *combination* that
+    misfires, not either alone.
+
+    Acronym expansions like ``W C A G`` are capitals without hyphens and are
+    deliberately not flagged.
+    """
+    return "-" in alias and any(c.isupper() for c in alias[1:])
 
 
 def _flatten(nodes: list[Node], inherited: Attrs, out: list[tuple[str, Attrs] | int]) -> None:
@@ -176,23 +185,15 @@ def compile_plan(
                     )
                 )
 
-        stripped = raw_text.strip()
-        if (
-            attrs.language
-            and text == raw_text
-            # A single short word, not merely a short span: extending the span
-            # to a clause boundary is the usual fix, and a clause never trips
-            # this. That is the tight-vs-clause-aligned distinction.
-            and " " not in stripped
-            and len(stripped) < SHORT_SPAN_CHARS
-        ):
+        if text != raw_text and _is_over_articulated(text):
             warnings.append(
                 PlanWarning(
-                    code="short_language_span",
+                    code="over_articulated_respelling",
                     detail=(
-                        f"{stripped!r} is a single short word in its own run. Prosody restarts "
-                        f"at each cut, so extending the span to the surrounding clause, or a "
-                        f"<sub> respelling, often sounds smoother."
+                        f"{text!r} combines hyphens with capitals, which makes the engine "
+                        f"over-articulate: in testing that read as exaggerated and ran ~30% "
+                        f"longer than the same sentence. A plain letter substitution "
+                        f"(bandeja -> bandeha) sounded most natural."
                     ),
                 )
             )

--- a/backend/services/prosody/ir.py
+++ b/backend/services/prosody/ir.py
@@ -1,0 +1,177 @@
+"""Intermediate representation for the prosody transformer.
+
+The transformer is a harness around segment production: it never synthesises
+anything, it decides where to cut, what settings each cut carries, and how the
+pieces are reassembled. This module is the vocabulary those decisions are
+expressed in.
+
+Two layers:
+
+``Directive``/``Span``
+    The parse tree. Mirrors the markup, so spans nest and attributes inherit.
+
+``RenderPlan``
+    The flattened, resolved result: a list of speech runs and silences with
+    every attribute already decided for one specific engine. Nothing after this
+    point has to know the markup existed.
+
+The plan is deliberately a plain data object with no model behind it. It can be
+built, asserted on, diffed and shown to a user without loading 3.5 GB of
+weights, which is what makes the whole pipeline testable and previewable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+# ── Parse tree ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Attrs:
+    """Settings that flow down the span tree.
+
+    ``None`` means "inherit from the enclosing span", which is what lets
+    ``<prosody rate="0.8">`` wrap a ``<lang>`` without either having to know
+    about the other.
+    """
+
+    language: str | None = None
+    rate: float | None = None
+    instruct: str | None = None
+    emphasis: str | None = None
+    # Set by <sub alias="..."> and <phoneme ph="...">: the text handed to the
+    # engine differs from the text the author wrote.
+    spoken_as: str | None = None
+
+    def merged_with(self, child: Attrs) -> Attrs:
+        """Child wins where it says anything; parent shows through elsewhere."""
+        return Attrs(
+            language=child.language if child.language is not None else self.language,
+            rate=child.rate if child.rate is not None else self.rate,
+            instruct=child.instruct if child.instruct is not None else self.instruct,
+            emphasis=child.emphasis if child.emphasis is not None else self.emphasis,
+            # Deliberately not inherited: a substitution applies to the text it
+            # wraps, not to everything nested inside a parent that had one.
+            spoken_as=child.spoken_as,
+        )
+
+
+@dataclass(frozen=True)
+class Text:
+    """Literal text to be spoken."""
+
+    value: str
+
+
+@dataclass(frozen=True)
+class Break:
+    """A silence, in milliseconds.
+
+    No engine accepts this, so it is always realised structurally -- the
+    renderer emits silence and the model never sees it. That is why pauses work
+    identically on all eight engines.
+    """
+
+    ms: int
+
+
+@dataclass(frozen=True)
+class Span:
+    """A run of nodes sharing a set of attribute overrides."""
+
+    attrs: Attrs
+    children: list[Node] = field(default_factory=list)
+    # The tag this came from, kept for error messages and round-tripping.
+    tag: str = ""
+
+
+Node = Text | Break | Span
+
+
+# ── Render plan ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Speech:
+    """One generation call: text plus every setting already resolved."""
+
+    text: str
+    language: str
+    rate: float = 1.0
+    instruct: str | None = None
+    seed: int | None = None
+    # What the author wrote, when `text` was substituted by <sub>/<phoneme> or
+    # a dictionary entry. Kept so a preview can show the change rather than
+    # silently handing back something the author never typed.
+    source_text: str | None = None
+
+
+@dataclass(frozen=True)
+class Silence:
+    """A gap, produced by assembly rather than by the engine."""
+
+    ms: int
+
+
+PlanNode = Speech | Silence
+
+
+@dataclass(frozen=True)
+class PlanWarning:
+    """Something the target engine cannot honour.
+
+    Carried on the plan rather than logged and forgotten: an instruction that
+    silently does nothing reads as the model refusing to follow it, which is
+    the complaint behind #579.
+    """
+
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class RenderPlan:
+    """Everything the renderer needs, for one engine, with nothing left to decide."""
+
+    nodes: list[PlanNode] = field(default_factory=list)
+    warnings: list[PlanWarning] = field(default_factory=list)
+    engine: str = ""
+
+    @property
+    def speech_nodes(self) -> list[Speech]:
+        return [n for n in self.nodes if isinstance(n, Speech)]
+
+    @property
+    def is_trivial(self) -> bool:
+        """Whether this is a single plain run needing none of the harness.
+
+        The overwhelmingly common case. The renderer takes the existing
+        single-shot path for these, so unmarked text costs nothing.
+        """
+        return (
+            len(self.nodes) == 1
+            and isinstance(self.nodes[0], Speech)
+            and self.nodes[0].rate == 1.0
+            and self.nodes[0].source_text is None
+        )
+
+    def with_seeds(self, base_seed: int | None) -> RenderPlan:
+        """Assign a deterministic per-run seed.
+
+        Varied per run so neighbouring runs do not share RNG artefacts, but
+        derived from ``base_seed`` so the same plan always renders the same
+        audio. ``None`` stays ``None`` -- an unseeded plan should still vary
+        between takes.
+        """
+        if base_seed is None:
+            return self
+        out: list[PlanNode] = []
+        speech_index = 0
+        for node in self.nodes:
+            if isinstance(node, Speech):
+                out.append(replace(node, seed=base_seed + speech_index))
+                speech_index += 1
+            else:
+                out.append(node)
+        return replace(self, nodes=out)

--- a/backend/services/prosody/parser.py
+++ b/backend/services/prosody/parser.py
@@ -1,0 +1,199 @@
+"""Parse the SSML subset into the prosody IR.
+
+Not an XML parser, deliberately. A script is prose: it contains ``&``, it
+contains ``5 < 6``, and an XML parser rejects both. Instead this recognises a
+*closed set* of known tags and treats everything else as literal text, which
+makes it strictly more forgiving than XML on the input it actually gets --
+nothing needs escaping unless it happens to spell one of our tags.
+
+The subset is chosen so that the two pronunciation strategies are SSML's own
+(``<sub>`` and ``<phoneme>``) rather than something invented alongside them.
+
+Supported::
+
+    <break time="700ms"/>            silence, also 0.7s
+    <lang xml:lang="es">…</lang>     render this run in another language
+    <prosody rate="0.9">…</prosody>  speaking rate
+    <emphasis level="strong">…</emphasis>
+    <sub alias="ban-DEH-ha">bandeja</sub>
+    <phoneme alphabet="ipa" ph="…">bandeja</phoneme>
+
+Angle brackets rather than square ones because square ones are taken:
+``[laugh]`` is a Chatterbox Turbo paralinguistic tag, which is passed *to* the
+engine, where a directive is intercepted *before* it. Same delimiter, opposite
+behaviour -- see ``_PARA_TAG_RE`` in ``utils/chunked_tts.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .ir import Attrs, Break, Node, Span, Text
+
+# Every tag the parser knows. Anything else stays literal text.
+_VOID_TAGS = {"break"}
+_SPAN_TAGS = {"lang", "prosody", "emphasis", "sub", "phoneme"}
+_ALL_TAGS = _VOID_TAGS | _SPAN_TAGS
+
+_TAG_RE = re.compile(
+    r"<\s*(?P<closing>/)?\s*(?P<name>" + "|".join(sorted(_ALL_TAGS)) + r")"
+    r"(?P<attrs>[^<>]*?)(?P<void>/)?\s*>",
+    re.IGNORECASE,
+)
+
+_ATTR_RE = re.compile(r"""(?P<key>[\w:.-]+)\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""")
+
+# "700ms", "0.7s", "700" (bare numbers read as milliseconds).
+_DURATION_RE = re.compile(r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s)?\s*$", re.IGNORECASE)
+
+MAX_BREAK_MS = 60_000
+
+
+class ProsodyParseError(ValueError):
+    """The markup is malformed in a way that would change what gets spoken."""
+
+
+def parse_duration(raw: str) -> int:
+    """``"700ms"``/``"0.7s"``/``"700"`` -> milliseconds."""
+    m = _DURATION_RE.match(raw or "")
+    if not m:
+        raise ProsodyParseError(f"Not a duration: {raw!r}. Use e.g. \"700ms\" or \"0.7s\".")
+    value = float(m.group("value"))
+    ms = round(value * 1000) if (m.group("unit") or "ms").lower() == "s" else round(value)
+    if ms < 0 or ms > MAX_BREAK_MS:
+        raise ProsodyParseError(f"Break of {ms}ms is outside 0..{MAX_BREAK_MS}ms.")
+    return ms
+
+
+def _parse_attrs(raw: str) -> dict[str, str]:
+    return {m.group("key").lower(): m.group("value") for m in _ATTR_RE.finditer(raw or "")}
+
+
+def _rate_from(raw: str | None) -> float | None:
+    """``"0.9"`` or ``"90%"`` -> a multiplier.
+
+    Rejects zero and negatives rather than clamping: a rate of 0 means audio of
+    infinite length, and silently substituting 1.0 would hide a typo behind
+    output that sounds fine.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    try:
+        value = float(text[:-1]) / 100.0 if text.endswith("%") else float(text)
+    except ValueError as exc:
+        raise ProsodyParseError(f"Not a rate: {raw!r}. Use e.g. \"0.9\" or \"90%\".") from exc
+    if not 0.1 <= value <= 5.0:
+        raise ProsodyParseError(f"Rate {value} is outside 0.1..5.0.")
+    return value
+
+
+def _attrs_for(tag: str, attrs: dict[str, str]) -> Attrs:
+    if tag == "lang":
+        code = attrs.get("xml:lang") or attrs.get("lang")
+        if not code:
+            raise ProsodyParseError('<lang> needs xml:lang, e.g. <lang xml:lang="es">.')
+        return Attrs(language=code.strip().lower())
+
+    if tag == "prosody":
+        rate = _rate_from(attrs.get("rate"))
+        if rate is None:
+            raise ProsodyParseError('<prosody> supports rate, e.g. <prosody rate="0.9">.')
+        return Attrs(rate=rate)
+
+    if tag == "emphasis":
+        return Attrs(emphasis=(attrs.get("level") or "moderate").strip().lower())
+
+    if tag == "sub":
+        alias = attrs.get("alias")
+        if not alias or not alias.strip():
+            raise ProsodyParseError('<sub> needs alias, e.g. <sub alias="ban-DEH-ha">.')
+        return Attrs(spoken_as=alias.strip())
+
+    if tag == "phoneme":
+        ph = attrs.get("ph")
+        if not ph or not ph.strip():
+            raise ProsodyParseError('<phoneme> needs ph, e.g. <phoneme ph="banˈdexa">.')  # noqa: RUF001
+        # Carried as a substitution; whether the engine can take phonemes at
+        # all is a capability question the compiler answers, not the parser.
+        return Attrs(spoken_as=ph.strip())
+
+    return Attrs()
+
+
+def parse(markup: str) -> list[Node]:
+    """Parse *markup* into a node tree.
+
+    Raises:
+        ProsodyParseError: on a malformed or unbalanced tag. Malformed markup
+            is an error rather than being passed through as text, because
+            passing it through means the engine reads it aloud.
+    """
+    if not markup:
+        return []
+
+    root = Span(attrs=Attrs(), children=[], tag="")
+    stack: list[Span] = [root]
+    cursor = 0
+
+    def emit_text(chunk: str) -> None:
+        if chunk:
+            stack[-1].children.append(Text(chunk))
+
+    for match in _TAG_RE.finditer(markup):
+        emit_text(markup[cursor : match.start()])
+        cursor = match.end()
+
+        name = match.group("name").lower()
+        closing = bool(match.group("closing"))
+        self_closing = bool(match.group("void"))
+        attrs = _parse_attrs(match.group("attrs"))
+
+        if closing:
+            if len(stack) == 1 or stack[-1].tag != name:
+                expected = stack[-1].tag if len(stack) > 1 else "nothing"
+                raise ProsodyParseError(
+                    f"</{name}> does not match the open tag ({expected})."
+                )
+            stack.pop()
+            continue
+
+        if name in _VOID_TAGS or self_closing:
+            if name == "break":
+                stack[-1].children.append(Break(parse_duration(attrs.get("time", "0ms"))))
+            continue
+
+        span = Span(attrs=_attrs_for(name, attrs), children=[], tag=name)
+        stack[-1].children.append(span)
+        stack.append(span)
+
+    emit_text(markup[cursor:])
+
+    if len(stack) > 1:
+        raise ProsodyParseError(f"<{stack[-1].tag}> was never closed.")
+
+    return root.children
+
+
+_STRIP_RE = re.compile(
+    r"<\s*/?\s*(?:" + "|".join(sorted(_ALL_TAGS)) + r")(?:[^<>]*?)/?\s*>", re.IGNORECASE
+)
+
+
+def strip_markup(markup: str) -> str:
+    """Remove every known tag, leaving the words.
+
+    This is what makes LLM annotation safe to accept: strip the model's output
+    and compare it to the input. If a single word moved, the model rewrote the
+    script instead of annotating it, and the result is rejected. The model can
+    fail to help, but it cannot mangle.
+
+    Whitespace is normalised on both sides, since inserting a tag on its own
+    line is a formatting change rather than a content one.
+    """
+    return re.sub(r"\s+", " ", _STRIP_RE.sub("", markup or "")).strip()
+
+
+def has_markup(text: str) -> bool:
+    """Whether any known tag is present, so unmarked text can skip the harness."""
+    return bool(text) and _TAG_RE.search(text) is not None

--- a/backend/services/prosody/parser.py
+++ b/backend/services/prosody/parser.py
@@ -11,7 +11,7 @@ The subset is chosen so that the two pronunciation strategies are SSML's own
 
 Supported::
 
-    <break time="700ms"/>            silence, also 0.7s
+    <break time="700ms"/>            silence, also 0.7s; bare <break/> is 700ms
     <lang xml:lang="es">…</lang>     render this run in another language
     <prosody rate="0.9">…</prosody>  speaking rate
     <emphasis level="strong">…</emphasis>
@@ -47,6 +47,12 @@ _ATTR_RE = re.compile(r"""(?P<key>[\w:.-]+)\s*=\s*(?P<quote>["'])(?P<value>.*?)(
 _DURATION_RE = re.compile(r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s)?\s*$", re.IGNORECASE)
 
 MAX_BREAK_MS = 60_000
+
+# What a bare <break/> means. 700ms was judged a good pause on every voice
+# tried; 1500ms read as too long unless the script genuinely wants a beat to
+# stop and think. The natural gap after a full stop is already 210-440ms
+# depending on the voice, so this adds to a pause rather than creating one.
+DEFAULT_BREAK_MS = 700
 
 
 class ProsodyParseError(ValueError):
@@ -160,7 +166,9 @@ def parse(markup: str) -> list[Node]:
 
         if name in _VOID_TAGS or self_closing:
             if name == "break":
-                stack[-1].children.append(Break(parse_duration(attrs.get("time", "0ms"))))
+                raw_time = attrs.get("time")
+                ms = DEFAULT_BREAK_MS if raw_time is None else parse_duration(raw_time)
+                stack[-1].children.append(Break(ms))
             continue
 
         span = Span(attrs=_attrs_for(name, attrs), children=[], tag=name)

--- a/backend/services/prosody/renderer.py
+++ b/backend/services/prosody/renderer.py
@@ -7,11 +7,16 @@ engines including the ones that accept no directives at all.
 
 Two things this must get right, both measured rather than assumed:
 
-*trim the edges*
-    Every generation carries roughly 340ms of leading and 100ms of trailing
-    silence. Left in, a three-run sentence runs ~0.7s longer than the same
-    words in one shot. Trimmed, the difference is ~0.03s -- segmentation
-    becomes duration-neutral, which is what makes it viable at all.
+*trim the interior joins only*
+    Every generation carries its own leading and trailing silence (250-360ms
+    lead, 100-400ms trail on the voices measured). Where two runs meet, that is
+    two lots of dead air the author never asked for, and it compounds: a
+    three-run sentence runs ~0.7s longer than the same words in one shot.
+    Trimmed at the joins, the difference is ~0.03s.
+
+    But the *outer* edges are the utterance's natural lead-in and release.
+    Trimming those makes every clip end abruptly after its last sound, which
+    reads as a forced delivery even on text carrying no markup at all.
 
 *do not crossfade into a pause*
     A crossfade across a Silence eats the pause from both ends. Runs joined to
@@ -55,18 +60,33 @@ def edge_silence_ms(audio: np.ndarray, sr: int) -> tuple[float, float]:
     return float(loud[0] * _FRAME_MS), float((len(frames) - 1 - loud[-1]) * _FRAME_MS)
 
 
-def trim_edges(audio: np.ndarray, sr: int, cushion_ms: int = _EDGE_CUSHION_MS) -> np.ndarray:
-    """Strip the model's own leading and trailing silence.
+def trim_edges(
+    audio: np.ndarray,
+    sr: int,
+    cushion_ms: int = _EDGE_CUSHION_MS,
+    *,
+    lead: bool = True,
+    trail: bool = True,
+) -> np.ndarray:
+    """Strip the model's own silence from the chosen edges.
 
-    Without this every cut inserts dead air the author did not ask for, and the
-    cost compounds with the number of runs.
+    Only *interior* edges should be trimmed. A generation's trailing silence is
+    the utterance's natural release -- roughly 290ms on the voices measured --
+    and cutting it back to the cushion makes every clip end abruptly, which
+    reads as a forced delivery even on text with no markup at all. The leading
+    silence at the very start is the same story.
+
+    What genuinely accumulates is the *join*: run N's trail butted against run
+    N+1's lead is two lots of dead air the author never asked for, and it
+    compounds with the number of runs. So the renderer trims where runs meet
+    and leaves the outer boundary of the whole utterance alone.
     """
     if audio.size == 0:
         return audio
-    lead, trail = edge_silence_ms(audio, sr)
+    lead_ms, trail_ms = edge_silence_ms(audio, sr)
     cushion = int(sr * cushion_ms / 1000)
-    start = max(0, int(sr * lead / 1000) - cushion)
-    end = len(audio) - max(0, int(sr * trail / 1000) - cushion)
+    start = max(0, int(sr * lead_ms / 1000) - cushion) if lead else 0
+    end = len(audio) - (max(0, int(sr * trail_ms / 1000) - cushion) if trail else 0)
     return audio[start:end] if end > start else audio
 
 
@@ -138,8 +158,9 @@ async def render(
             rather than imported so the renderer can be tested without a model
             and so long runs can still go through ``generate_chunked``.
         crossfade_ms: Overlap between adjacent speech runs. 0 for a butt join.
-        trim_runs: Strip each run's own leading/trailing silence before
-            joining. Off, every cut adds dead air.
+        trim_runs: Trim silence at the joins between runs. The first run's
+            lead-in and the last run's release are always kept -- they are the
+            utterance's own boundary, not an artefact of cutting.
 
     Returns:
         ``(audio, sample_rate)``.
@@ -148,7 +169,14 @@ async def render(
     sample_rate: int | None = None
     pending_silence_ms = 0
 
-    for node in plan.nodes:
+    # Which speech runs sit at the very start and very end of the utterance.
+    # Those outer edges keep the model's own lead-in and release; everything
+    # between them is an interior join and gets trimmed.
+    speech_positions = [i for i, n in enumerate(plan.nodes) if isinstance(n, Speech)]
+    first_speech = speech_positions[0] if speech_positions else None
+    last_speech = speech_positions[-1] if speech_positions else None
+
+    for index, node in enumerate(plan.nodes):
         if isinstance(node, Silence):
             # Held until a sample rate is known -- a plan can legitimately open
             # with a pause, before any run has told us the rate.
@@ -179,7 +207,12 @@ async def render(
             audio = librosa.resample(audio, orig_sr=int(run_sr), target_sr=sample_rate)
 
         if trim_runs:
-            audio = trim_edges(audio, sample_rate)
+            audio = trim_edges(
+                audio,
+                sample_rate,
+                lead=index != first_speech,
+                trail=index != last_speech,
+            )
         audio = apply_rate(audio, node.rate)
 
         if audio.size:

--- a/backend/services/prosody/renderer.py
+++ b/backend/services/prosody/renderer.py
@@ -1,0 +1,199 @@
+"""Turn a RenderPlan into audio.
+
+Everything here is assembly. The engine is called once per speech run with that
+run's own settings; silences, rate and joins are produced by arithmetic on the
+resulting arrays, which is why pauses and per-span language work on all eight
+engines including the ones that accept no directives at all.
+
+Two things this must get right, both measured rather than assumed:
+
+*trim the edges*
+    Every generation carries roughly 340ms of leading and 100ms of trailing
+    silence. Left in, a three-run sentence runs ~0.7s longer than the same
+    words in one shot. Trimmed, the difference is ~0.03s -- segmentation
+    becomes duration-neutral, which is what makes it viable at all.
+
+*do not crossfade into a pause*
+    A crossfade across a Silence eats the pause from both ends. Runs joined to
+    each other overlap; runs adjacent to silence are butted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import librosa
+import numpy as np
+
+from .ir import RenderPlan, Silence, Speech
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CROSSFADE_MS = 50
+
+# Below this level a frame counts as silence for edge trimming.
+_SILENCE_DB = -45.0
+_FRAME_MS = 10
+# Left on after trimming so a crossfade has something to work with and the
+# speech does not start hard against the join.
+_EDGE_CUSHION_MS = 30
+
+
+def edge_silence_ms(audio: np.ndarray, sr: int) -> tuple[float, float]:
+    """Leading and trailing near-silence, in milliseconds."""
+    if audio.size == 0:
+        return 0.0, 0.0
+    frame = max(1, int(sr * _FRAME_MS / 1000))
+    usable = len(audio) - (len(audio) % frame)
+    if usable < frame:
+        return 0.0, 0.0
+    frames = audio[:usable].reshape(-1, frame)
+    rms = np.sqrt(np.mean(frames.astype(np.float64) ** 2, axis=1)) + 1e-12
+    loud = np.where(20 * np.log10(rms) > _SILENCE_DB)[0]
+    if len(loud) == 0:
+        return float(len(audio) / sr * 1000), 0.0
+    return float(loud[0] * _FRAME_MS), float((len(frames) - 1 - loud[-1]) * _FRAME_MS)
+
+
+def trim_edges(audio: np.ndarray, sr: int, cushion_ms: int = _EDGE_CUSHION_MS) -> np.ndarray:
+    """Strip the model's own leading and trailing silence.
+
+    Without this every cut inserts dead air the author did not ask for, and the
+    cost compounds with the number of runs.
+    """
+    if audio.size == 0:
+        return audio
+    lead, trail = edge_silence_ms(audio, sr)
+    cushion = int(sr * cushion_ms / 1000)
+    start = max(0, int(sr * lead / 1000) - cushion)
+    end = len(audio) - max(0, int(sr * trail / 1000) - cushion)
+    return audio[start:end] if end > start else audio
+
+
+def apply_rate(audio: np.ndarray, rate: float) -> np.ndarray:
+    """Change tempo without changing pitch.
+
+    Phase vocoder, matching the story mixer -- resampling would transpose the
+    voice, which is not what a rate directive means.
+    """
+    if rate == 1.0 or audio.size == 0:
+        return audio
+    return librosa.effects.time_stretch(audio.astype(np.float32), rate=rate)
+
+
+def _crossfade(a: np.ndarray, b: np.ndarray, samples: int) -> np.ndarray:
+    if samples <= 0 or a.size == 0 or b.size == 0:
+        return np.concatenate([a, b])
+    overlap = min(samples, len(a), len(b))
+    out = np.array(a, dtype=np.float32, copy=True)
+    fade_out = np.linspace(1.0, 0.0, overlap, dtype=np.float32)
+    fade_in = np.linspace(0.0, 1.0, overlap, dtype=np.float32)
+    out[-overlap:] = out[-overlap:] * fade_out + b[:overlap] * fade_in
+    return np.concatenate([out, b[overlap:]])
+
+
+def assemble(
+    pieces: list[tuple[np.ndarray, bool]],
+    sr: int,
+    crossfade_ms: int = DEFAULT_CROSSFADE_MS,
+) -> np.ndarray:
+    """Join rendered pieces.
+
+    ``pieces`` is ``(audio, is_silence)``. A crossfade is applied only between
+    two speech runs: overlapping a pause with its neighbours would shorten it
+    from both ends, so a 700ms break would not last 700ms.
+    """
+    if not pieces:
+        return np.array([], dtype=np.float32)
+
+    samples = int(sr * crossfade_ms / 1000)
+    out = np.asarray(pieces[0][0], dtype=np.float32)
+    prev_is_silence = pieces[0][1]
+
+    for audio, is_silence in pieces[1:]:
+        audio = np.asarray(audio, dtype=np.float32)
+        if is_silence or prev_is_silence:
+            out = np.concatenate([out, audio])
+        else:
+            out = _crossfade(out, audio, samples)
+        prev_is_silence = is_silence
+
+    return out
+
+
+async def render(
+    plan: RenderPlan,
+    generate_run,
+    *,
+    crossfade_ms: int = DEFAULT_CROSSFADE_MS,
+    trim_runs: bool = True,
+) -> tuple[np.ndarray, int]:
+    """Render *plan* to audio.
+
+    Args:
+        plan: A compiled plan. ``plan.is_trivial`` should be handled by the
+            caller on the existing single-shot path; this still renders it
+            correctly, just with no benefit.
+        generate_run: ``async (Speech) -> (audio, sample_rate)``. Injected
+            rather than imported so the renderer can be tested without a model
+            and so long runs can still go through ``generate_chunked``.
+        crossfade_ms: Overlap between adjacent speech runs. 0 for a butt join.
+        trim_runs: Strip each run's own leading/trailing silence before
+            joining. Off, every cut adds dead air.
+
+    Returns:
+        ``(audio, sample_rate)``.
+    """
+    pieces: list[tuple[np.ndarray, bool]] = []
+    sample_rate: int | None = None
+    pending_silence_ms = 0
+
+    for node in plan.nodes:
+        if isinstance(node, Silence):
+            # Held until a sample rate is known -- a plan can legitimately open
+            # with a pause, before any run has told us the rate.
+            pending_silence_ms += node.ms
+            if sample_rate is not None:
+                pieces.append((_silence(pending_silence_ms, sample_rate), True))
+                pending_silence_ms = 0
+            continue
+
+        if not isinstance(node, Speech):
+            continue
+
+        audio, run_sr = await generate_run(node)
+        audio = np.asarray(audio, dtype=np.float32)
+        if audio.ndim > 1:
+            audio = audio.mean(axis=0)
+
+        if sample_rate is None:
+            sample_rate = int(run_sr)
+            if pending_silence_ms:
+                pieces.append((_silence(pending_silence_ms, sample_rate), True))
+                pending_silence_ms = 0
+        elif int(run_sr) != sample_rate:
+            # Mixed rates would otherwise concatenate into a pitch shift.
+            logger.info(
+                "Resampling a prosody run from %dHz to %dHz", int(run_sr), sample_rate
+            )
+            audio = librosa.resample(audio, orig_sr=int(run_sr), target_sr=sample_rate)
+
+        if trim_runs:
+            audio = trim_edges(audio, sample_rate)
+        audio = apply_rate(audio, node.rate)
+
+        if audio.size:
+            pieces.append((audio, False))
+
+    if sample_rate is None:
+        # Silence-only plan; nothing established a rate.
+        return np.array([], dtype=np.float32), 0
+
+    if pending_silence_ms:
+        pieces.append((_silence(pending_silence_ms, sample_rate), True))
+
+    return assemble(pieces, sample_rate, crossfade_ms=crossfade_ms), sample_rate
+
+
+def _silence(ms: int, sr: int) -> np.ndarray:
+    return np.zeros(max(0, int(sr * ms / 1000)), dtype=np.float32)

--- a/backend/services/prosody/renderer.py
+++ b/backend/services/prosody/renderer.py
@@ -90,15 +90,87 @@ def trim_edges(
     return audio[start:end] if end > start else audio
 
 
-def apply_rate(audio: np.ndarray, rate: float) -> np.ndarray:
+# WSOLA windowing. 30ms frames are long enough to hold a pitch period at any
+# adult speaking F0 and short enough that a splice lands inside one phoneme.
+_WSOLA_FRAME_MS = 30
+_WSOLA_SEARCH_MS = 10
+
+
+def _wsola(audio: np.ndarray, rate: float, sr: int) -> np.ndarray:
+    """Time-stretch by waveform-similarity overlap-add.
+
+    A phase vocoder reconstructs from magnitudes and re-estimated phase, which
+    on speech smears transients and leaves the characteristic "phasey" ring.
+    WSOLA never leaves the time domain: it overlap-adds real waveform segments,
+    choosing each splice point by cross-correlation so successive pitch periods
+    line up. Consonants stay crisp because nothing is resynthesised.
+
+    Args:
+        rate: Playback rate. <1 lengthens (slower), >1 shortens.
+    """
+    frame = max(2, int(sr * _WSOLA_FRAME_MS / 1000))
+    search = max(1, int(sr * _WSOLA_SEARCH_MS / 1000))
+    synthesis_hop = frame // 2
+    analysis_hop = round(synthesis_hop * rate)
+    if analysis_hop < 1:
+        return audio
+
+    window = np.hanning(frame).astype(np.float32)
+    out = np.zeros(int(len(audio) / rate) + frame, dtype=np.float32)
+    weights = np.zeros_like(out)
+
+    read = 0
+    write = 0
+    # Kept from the previous frame: the samples the next one should continue
+    # from, which is what the search is trying to match.
+    expected = audio[:frame].astype(np.float32)
+
+    while read + frame + search < len(audio) and write + frame < len(out):
+        # Search near the nominal read position for the segment that best
+        # continues what was just written.
+        lo = max(0, read - search)
+        hi = min(len(audio) - frame, read + search)
+        if hi <= lo:
+            offset = read
+        else:
+            candidates = np.arange(lo, hi + 1)
+            scores = [
+                float(np.dot(audio[c : c + frame], expected)) for c in candidates
+            ]
+            offset = int(candidates[int(np.argmax(scores))])
+
+        segment = audio[offset : offset + frame].astype(np.float32)
+        out[write : write + frame] += segment * window
+        weights[write : write + frame] += window
+
+        expected = audio[offset + synthesis_hop : offset + synthesis_hop + frame]
+        if len(expected) < frame:
+            break
+        # The nominal pointer advances by analysis_hop regardless of where the
+        # search landed. Folding the offset back in would let a run of
+        # forward-biased matches accelerate the read and cut the output short.
+        read += analysis_hop
+        write += synthesis_hop
+
+    nonzero = weights > 1e-6
+    out[nonzero] /= weights[nonzero]
+    return out[: write + frame]
+
+
+def apply_rate(audio: np.ndarray, rate: float, sr: int = 24000) -> np.ndarray:
     """Change tempo without changing pitch.
 
-    Phase vocoder, matching the story mixer -- resampling would transpose the
-    voice, which is not what a rate directive means.
+    WSOLA rather than a phase vocoder: the vocoder resynthesises from magnitude
+    and estimated phase, which on speech smears consonants and adds a phasey
+    ring -- audible enough to be rejected in listening. WSOLA overlap-adds real
+    waveform segments, so nothing is resynthesised.
+
+    Resampling is not an option either; it would transpose the voice, which is
+    not what a rate directive means.
     """
     if rate == 1.0 or audio.size == 0:
         return audio
-    return librosa.effects.time_stretch(audio.astype(np.float32), rate=rate)
+    return _wsola(audio.astype(np.float32), rate, sr)
 
 
 def _crossfade(a: np.ndarray, b: np.ndarray, samples: int) -> np.ndarray:
@@ -213,7 +285,7 @@ async def render(
                 lead=index != first_speech,
                 trail=index != last_speech,
             )
-        audio = apply_rate(audio, node.rate)
+        audio = apply_rate(audio, node.rate, sample_rate)
 
         if audio.size:
             pieces.append((audio, False))

--- a/backend/tests/test_prosody_renderer.py
+++ b/backend/tests/test_prosody_renderer.py
@@ -273,3 +273,43 @@ async def test_a_compiled_script_renders():
     audio, sr = await render(plan, fake_engine(seconds=0.5))
     assert sr == SR
     assert secs(audio, sr) > 0.7, "should contain every run plus the pause"
+
+
+# ── The outer boundary is not an interior join ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_utterances_own_lead_and_release_survive():
+    """Trimming the outer edges made every clip end ~30ms after the last sound,
+    which reads as a forced delivery even on text with no markup at all. Only
+    the joins between runs accumulate dead air worth removing."""
+    plan = RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en")])
+    audio, sr = await render(plan, fake_engine(lead_ms=340, trail_ms=290), crossfade_ms=0)
+
+    lead, trail = edge_silence_ms(audio, sr)
+    assert lead == pytest.approx(340, abs=40), "the model's lead-in is natural"
+    assert trail == pytest.approx(290, abs=40), "the release is natural"
+
+
+@pytest.mark.asyncio
+async def test_the_join_between_runs_is_still_trimmed():
+    """The outer edges survive, but the interior must not double up."""
+    two = RenderPlan(nodes=[Speech("aaa", "en"), Speech("bbb", "en")])
+    one = RenderPlan(nodes=[Speech("aaabbb", "en")])
+    engine = proportional_engine(lead_ms=340, trail_ms=290)
+
+    joined, sr = await render(two, engine, crossfade_ms=0)
+    single, _ = await render(one, engine, crossfade_ms=0)
+    # Same words, same outer edges; only the interior join differs.
+    assert secs(joined, sr) - secs(single, sr) < 0.15
+
+
+@pytest.mark.asyncio
+async def test_a_single_run_is_returned_untouched():
+    """A trivial plan takes the single-shot path in production. Rendered here it
+    must still come back as the engine produced it, or the baseline sounds
+    processed when nothing was asked for."""
+    engine = fake_engine(lead_ms=340, trail_ms=290)
+    raw, _ = await engine(Speech("a", "en"))
+    audio, sr = await render(RenderPlan(nodes=[Speech("a", "en")]), engine)
+    assert secs(audio, sr) == pytest.approx(secs(raw, sr), abs=0.01)

--- a/backend/tests/test_prosody_renderer.py
+++ b/backend/tests/test_prosody_renderer.py
@@ -1,0 +1,275 @@
+"""
+Tests for the prosody renderer — plan to audio.
+
+Everything here is assembly, so the engine is a stub that returns tones. That
+keeps the whole file model-free while still exercising the arithmetic that
+actually matters: whether a pause lasts as long as it says, whether cutting
+costs duration, and whether joins behave differently around silence.
+
+The two rules worth pinning are both measured facts rather than preferences:
+trimming run edges is what makes segmentation duration-neutral, and crossfading
+into a pause would eat it from both ends.
+
+Usage:
+    python -m pytest backend/tests/test_prosody_renderer.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from backend.services.prosody import Silence, Speech, compile_plan
+from backend.services.prosody.ir import RenderPlan
+from backend.services.prosody.renderer import (
+    apply_rate,
+    assemble,
+    edge_silence_ms,
+    render,
+    trim_edges,
+)
+
+SR = 24000
+
+
+def tone(seconds: float, freq: float = 440.0, amp: float = 0.3) -> np.ndarray:
+    t = np.linspace(0, seconds, int(SR * seconds), endpoint=False)
+    return (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def padded(speech_s: float, lead_ms: int = 340, trail_ms: int = 100) -> np.ndarray:
+    """A run shaped like a real generation: speech wrapped in the model's own
+    silence. The measured figures were 340ms lead and 100ms trail."""
+    lead = np.zeros(int(SR * lead_ms / 1000), dtype=np.float32)
+    trail = np.zeros(int(SR * trail_ms / 1000), dtype=np.float32)
+    return np.concatenate([lead, tone(speech_s), trail])
+
+
+def fake_engine(seconds=1.0, sr=SR, lead_ms=340, trail_ms=100):
+    """A stub engine returning realistically padded audio, fixed length."""
+
+    async def generate_run(node: Speech):
+        return padded(seconds, lead_ms, trail_ms), sr
+
+    return generate_run
+
+
+def proportional_engine(secs_per_char=0.1, sr=SR, lead_ms=340, trail_ms=100):
+    """A stub whose speech length tracks the text.
+
+    Needed for any comparison across different numbers of runs: splitting a
+    sentence distributes the same words, so total speech is constant and only
+    the padding multiplies. A fixed-length stub would add a whole extra run of
+    speech per cut and measure nothing.
+    """
+
+    async def generate_run(node: Speech):
+        return padded(len(node.text) * secs_per_char, lead_ms, trail_ms), sr
+
+    return generate_run
+
+
+def secs(audio: np.ndarray, sr: int = SR) -> float:
+    return len(audio) / sr
+
+
+# ── Edge trimming: the finding the design rests on ───────────────────
+
+
+def test_edge_silence_is_measured():
+    lead, trail = edge_silence_ms(padded(1.0, 340, 100), SR)
+    assert lead == pytest.approx(340, abs=20)
+    assert trail == pytest.approx(100, abs=20)
+
+
+def test_trimming_removes_the_padding_but_keeps_a_cushion():
+    trimmed = trim_edges(padded(1.0, 340, 100), SR)
+    assert secs(trimmed) < secs(padded(1.0, 340, 100))
+    lead, _ = edge_silence_ms(trimmed, SR)
+    assert lead < 100, "most of the leading silence should be gone"
+    assert secs(trimmed) > 1.0, "the speech itself must survive"
+
+
+def test_silence_only_audio_is_not_destroyed():
+    quiet = np.zeros(SR, dtype=np.float32)
+    assert trim_edges(quiet, SR).size > 0
+
+
+def test_empty_audio_is_handled():
+    assert trim_edges(np.array([], dtype=np.float32), SR).size == 0
+    assert edge_silence_ms(np.array([], dtype=np.float32), SR) == (0.0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_cutting_is_duration_neutral_when_trimmed():
+    """The measured result: three runs untrimmed ran ~0.7s longer than one;
+    trimmed, the difference collapses. That is what makes segmentation viable."""
+    # Same nine characters either way, so only the number of cuts differs.
+    one_run = RenderPlan(nodes=[Speech("aaabbbccc", "en")])
+    three_runs = RenderPlan(
+        nodes=[Speech("aaa", "en"), Speech("bbb", "es"), Speech("ccc", "en")]
+    )
+
+    engine = proportional_engine()
+    untrimmed_1, _ = await render(one_run, engine, trim_runs=False)
+    untrimmed_3, _ = await render(three_runs, engine, trim_runs=False)
+    trimmed_1, _ = await render(one_run, engine, trim_runs=True)
+    trimmed_3, _ = await render(three_runs, engine, trim_runs=True)
+
+    added_untrimmed = secs(untrimmed_3) - secs(untrimmed_1)
+    added_trimmed = secs(trimmed_3) - secs(trimmed_1)
+
+    assert added_untrimmed > 0.6, "two extra cuts should add real dead air"
+    assert added_trimmed < added_untrimmed / 2, (
+        f"trimming should recover most of it: {added_untrimmed:.2f}s -> {added_trimmed:.2f}s"
+    )
+
+
+# ── Pauses ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_pause_lasts_as_long_as_it_says():
+    plan = RenderPlan(nodes=[Speech("a", "en"), Silence(700), Speech("b", "en")])
+    with_pause, sr = await render(plan, fake_engine(), crossfade_ms=0)
+    without, _ = await render(
+        RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en")]),
+        fake_engine(),
+        crossfade_ms=0,
+    )
+    assert secs(with_pause, sr) - secs(without, sr) == pytest.approx(0.7, abs=0.02)
+
+
+@pytest.mark.asyncio
+async def test_a_crossfade_does_not_eat_the_pause():
+    """Overlapping a silence with its neighbours would shorten it from both
+    ends, so a 700ms break would not last 700ms."""
+    plan = RenderPlan(nodes=[Speech("a", "en"), Silence(700), Speech("b", "en")])
+    faded, sr = await render(plan, fake_engine(), crossfade_ms=50)
+    butted, _ = await render(plan, fake_engine(), crossfade_ms=0)
+    assert secs(faded, sr) == pytest.approx(secs(butted, sr), abs=0.005)
+
+
+@pytest.mark.asyncio
+async def test_adjacent_runs_do_overlap():
+    """The crossfade must still apply where it is wanted, or joins click."""
+    plan = RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en")])
+    faded, sr = await render(plan, fake_engine(), crossfade_ms=100)
+    butted, _ = await render(plan, fake_engine(), crossfade_ms=0)
+    assert secs(butted, sr) - secs(faded, sr) == pytest.approx(0.1, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_a_leading_pause_survives():
+    """A plan can open with a break, before any run has established the rate."""
+    plan = RenderPlan(nodes=[Silence(500), Speech("a", "en")])
+    audio, sr = await render(plan, fake_engine(), crossfade_ms=0)
+    lead, _ = edge_silence_ms(audio, sr)
+    assert lead >= 450
+
+
+@pytest.mark.asyncio
+async def test_a_trailing_pause_survives():
+    plan = RenderPlan(nodes=[Speech("a", "en"), Silence(500)])
+    audio, sr = await render(plan, fake_engine(), crossfade_ms=0)
+    _, trail = edge_silence_ms(audio, sr)
+    assert trail >= 450
+
+
+@pytest.mark.asyncio
+async def test_a_plan_of_only_silence_renders_nothing():
+    """Nothing established a sample rate, so there is no meaningful output."""
+    audio, sr = await render(RenderPlan(nodes=[Silence(500)]), fake_engine())
+    assert audio.size == 0
+    assert sr == 0
+
+
+# ── Rate ─────────────────────────────────────────────────────────────
+
+
+def test_a_slower_rate_lengthens_without_resampling():
+    original = tone(1.0)
+    slower = apply_rate(original, 0.5)
+    assert secs(slower) == pytest.approx(2.0, rel=0.05)
+
+
+def test_rate_one_is_a_no_op():
+    original = tone(1.0)
+    assert apply_rate(original, 1.0) is original
+
+
+@pytest.mark.asyncio
+async def test_rate_applies_per_run():
+    plan = RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en", rate=0.5)])
+    audio, sr = await render(plan, fake_engine(seconds=1.0), crossfade_ms=0)
+    plain, _ = await render(
+        RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en")]),
+        fake_engine(seconds=1.0),
+        crossfade_ms=0,
+    )
+    assert secs(audio, sr) > secs(plain, sr)
+
+
+# ── Mixed engine output ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runs_at_different_rates_are_resampled():
+    """Concatenating mismatched rates would come out as a pitch shift."""
+    calls = {"n": 0}
+
+    async def varying(node: Speech):
+        calls["n"] += 1
+        return (padded(1.0), SR) if calls["n"] == 1 else (padded(1.0), 48000)
+
+    plan = RenderPlan(nodes=[Speech("a", "en"), Speech("b", "en")])
+    audio, sr = await render(plan, varying, crossfade_ms=0)
+    assert sr == SR
+    # Both runs are ~1s of speech; a mishandled rate would halve or double one.
+    assert secs(audio, sr) == pytest.approx(2.0, abs=0.4)
+
+
+@pytest.mark.asyncio
+async def test_multichannel_output_is_folded_to_mono():
+    async def stereo(node: Speech):
+        mono = padded(1.0)
+        return np.stack([mono, mono]), SR
+
+    audio, _ = await render(RenderPlan(nodes=[Speech("a", "en")]), stereo)
+    assert audio.ndim == 1
+
+
+# ── Assembly primitives ──────────────────────────────────────────────
+
+
+def test_assemble_of_nothing_is_empty():
+    assert assemble([], SR).size == 0
+
+
+def test_assemble_of_one_piece_is_that_piece():
+    piece = tone(0.5)
+    assert np.array_equal(assemble([(piece, False)], SR), piece)
+
+
+# ── End to end from markup ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_compiled_script_renders():
+    """The join the whole feature exists for: English, a Spanish span, a pause."""
+    plan = compile_plan(
+        'The shot is a <lang xml:lang="es">bandeja, no un smash,</lang> here.'
+        '<break time="700ms"/>Not a smash.',
+        engine="qwen",
+        default_language="en",
+        engine_languages=["en", "es"],
+    )
+    languages = [n.language for n in plan.nodes if isinstance(n, Speech)]
+    assert "es" in languages
+
+    audio, sr = await render(plan, fake_engine(seconds=0.5))
+    assert sr == SR
+    assert secs(audio, sr) > 0.7, "should contain every run plus the pause"

--- a/backend/tests/test_prosody_renderer.py
+++ b/backend/tests/test_prosody_renderer.py
@@ -313,3 +313,40 @@ async def test_a_single_run_is_returned_untouched():
     raw, _ = await engine(Speech("a", "en"))
     audio, sr = await render(RenderPlan(nodes=[Speech("a", "en")]), engine)
     assert secs(audio, sr) == pytest.approx(secs(raw, sr), abs=0.01)
+
+
+# ── Time stretching (WSOLA) ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("rate", [0.5, 0.8, 0.9, 1.25, 2.0])
+def test_the_stretch_ratio_is_accurate(rate):
+    """An early version fed the search offset back into the read pointer, so a
+    run of forward-biased matches accelerated the read and produced 1.47s where
+    2.0s was asked for. The nominal pointer must advance independently."""
+    out = apply_rate(tone(1.0), rate, SR)
+    assert secs(out) == pytest.approx(1.0 / rate, rel=0.06)
+
+
+def test_stretching_preserves_pitch():
+    """The reason not to just resample: that would transpose the voice, which
+    is not what a rate directive means."""
+    import numpy as np
+
+    original = tone(1.0, freq=220.0)
+    slower = apply_rate(original, 0.5, SR)
+
+    def dominant_hz(x):
+        spectrum = np.abs(np.fft.rfft(x))
+        return np.fft.rfftfreq(len(x), 1 / SR)[int(np.argmax(spectrum))]
+
+    assert dominant_hz(slower) == pytest.approx(dominant_hz(original), rel=0.05)
+
+
+def test_stretching_does_not_resynthesise_silence_into_noise():
+    """WSOLA overlap-adds real waveform, so silence stays silent -- a vocoder
+    can ring on the transition into one."""
+    import numpy as np
+
+    quiet = np.zeros(SR // 2, dtype=np.float32)
+    out = apply_rate(np.concatenate([tone(0.5), quiet]), 0.8, SR)
+    assert float(np.max(np.abs(out[-SR // 4 :]))) < 0.02

--- a/backend/tests/test_prosody_transformer.py
+++ b/backend/tests/test_prosody_transformer.py
@@ -250,14 +250,35 @@ def test_each_unsupported_language_warns_once():
     assert codes(p).count("language_unsupported") == 1
 
 
-def test_a_single_short_word_span_is_flagged():
-    """The tight-vs-clause-aligned trade the prototype measured."""
-    assert "short_language_span" in codes(plan('a <lang xml:lang="es">bandeja</lang> b'))
+def test_a_tight_single_word_span_is_not_flagged():
+    """Listening across three voices found tight spans good, so warning against
+    them would steer people away from what works."""
+    assert not codes(plan('a <lang xml:lang="es">bandeja</lang> b'))
 
 
 def test_a_clause_length_span_is_not_flagged():
-    p = plan('a <lang xml:lang="es">bandeja, no un smash,</lang> b')
-    assert "short_language_span" not in codes(p)
+    assert not codes(plan('a <lang xml:lang="es">bandeja, no un smash,</lang> b'))
+
+
+@pytest.mark.parametrize("alias", ["bandeha", "ban-deh-ha", "W C A G", "Bandeha"])
+def test_a_reasonable_respelling_is_not_flagged(alias):
+    """Plain substitution, syllable hyphens alone, an acronym expansion, and a
+    capitalised proper noun are all fine."""
+    assert not codes(plan(f'a <sub alias="{alias}">x</sub> b'))
+
+
+def test_hyphens_plus_capitals_are_flagged():
+    """`ban-DEH-ha` was judged exaggerated on every voice and measured ~30%
+    longer than the same sentence unmarked. It is the combination that
+    misfires, not either alone."""
+    assert "over_articulated_respelling" in codes(plan('a <sub alias="ban-DEH-ha">x</sub> b'))
+
+
+def test_a_bare_break_is_a_good_default_pause():
+    """700ms was judged right on every voice; 1500ms too long unless the script
+    wants a beat to stop and think."""
+    p = plan("one<break/>two")
+    assert Silence(700) in p.nodes
 
 
 # ── Malformed markup ─────────────────────────────────────────────────

--- a/backend/tests/test_prosody_transformer.py
+++ b/backend/tests/test_prosody_transformer.py
@@ -1,0 +1,323 @@
+"""
+Tests for the prosody transformer's parse and compile stages.
+
+No model, no audio, no database — the whole point of making the RenderPlan a
+plain data object is that the decisions can be asserted on for free.
+
+The rules worth pinning are the ones that are easy to get subtly wrong:
+attributes inherit but substitutions do not, neighbouring runs coalesce so the
+model restarts its prosody as rarely as possible, punctuation orphaned by a
+span boundary never becomes its own generation, and anything the target engine
+cannot honour is said out loud rather than dropped.
+
+Usage:
+    python -m pytest backend/tests/test_prosody_transformer.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from backend.services.prosody import (
+    ProsodyParseError,
+    RenderPlan,
+    Silence,
+    Speech,
+    compile_plan,
+    has_markup,
+    parse,
+    strip_markup,
+)
+from backend.services.prosody.parser import parse_duration
+
+
+def plan(markup: str, **kwargs) -> RenderPlan:
+    kwargs.setdefault("engine", "qwen")
+    kwargs.setdefault("default_language", "en")
+    return compile_plan(markup, **kwargs)
+
+
+def texts(p: RenderPlan) -> list[str]:
+    return [n.text for n in p.nodes if isinstance(n, Speech)]
+
+
+def codes(p: RenderPlan) -> list[str]:
+    return [w.code for w in p.warnings]
+
+
+# ── Prose is not XML ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["5 < 6 and 7 > 6", "Tom & Jerry", "a <notatag> b", "if x<y then", "100% > 50%"],
+)
+def test_prose_that_would_break_an_xml_parser_is_literal(text):
+    """The parser recognises a closed tag set and leaves everything else alone,
+    so ordinary prose needs no escaping."""
+    p = plan(text)
+    assert texts(p) == [text]
+
+
+def test_unknown_tags_are_spoken_not_stripped():
+    """Silently dropping an unknown tag would change the script. It is not ours,
+    so it is text."""
+    text = "Use the <blink> tag"
+    assert texts(plan(text)) == [text]
+
+
+# ── Directives ───────────────────────────────────────────────────────
+
+
+def test_a_break_becomes_silence_not_a_generation():
+    """No engine accepts a pause, so it is pure assembly — which is why pauses
+    work identically on all eight."""
+    p = plan('One.<break time="700ms"/>Two.')
+    assert p.nodes[1] == Silence(700)
+    assert texts(p) == ["One.", "Two."]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"), [("700ms", 700), ("0.7s", 700), ("700", 700), ("1s", 1000), ("0ms", 0)]
+)
+def test_duration_forms(raw, expected):
+    assert parse_duration(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "soon", "-5ms", "999s", "700m"])
+def test_bad_durations_are_rejected(raw):
+    with pytest.raises(ProsodyParseError):
+        parse_duration(raw)
+
+
+def test_a_zero_break_emits_nothing():
+    p = plan('One.<break time="0ms"/>Two.')
+    assert not any(isinstance(n, Silence) for n in p.nodes)
+
+
+def test_a_language_span_gets_its_own_run():
+    p = plan('a <lang xml:lang="es">bandeja alta</lang> b')
+    langs = [(n.text.strip(), n.language) for n in p.nodes if isinstance(n, Speech)]
+    assert ("bandeja alta", "es") in langs
+    assert all(lang == "en" for text, lang in langs if text != "bandeja alta")
+
+
+def test_rate_applies_to_its_span_only():
+    p = plan('normal <prosody rate="0.8">slow</prosody> normal')
+    rates = {n.text.strip(): n.rate for n in p.nodes if isinstance(n, Speech)}
+    assert rates["slow"] == 0.8
+    assert rates["normal"] == 1.0
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("0.9", 0.9), ("90%", 0.9), ("1.5", 1.5)])
+def test_rate_forms(raw, expected):
+    p = plan(f'<prosody rate="{raw}">x</prosody>')
+    assert p.nodes[0].rate == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "fast", "20"])
+def test_bad_rates_are_rejected(raw):
+    """Rejected rather than clamped: rate 0 is audio of infinite length, and
+    quietly substituting 1.0 hides a typo behind output that sounds fine."""
+    with pytest.raises(ProsodyParseError):
+        plan(f'<prosody rate="{raw}">x</prosody>')
+
+
+def test_sub_replaces_what_the_engine_hears_but_records_the_original():
+    p = plan('a <sub alias="ban-DEH-ha">bandeja</sub> b')
+    sub = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
+    assert sub.text == "ban-DEH-ha"
+    assert sub.source_text == "bandeja"
+
+
+def test_phoneme_is_carried_as_a_substitution():
+    p = plan('a <phoneme alphabet="ipa" ph="banˈdexa">bandeja</phoneme> b')  # noqa: RUF001
+    sub = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
+    assert sub.text == "banˈdexa"  # noqa: RUF001
+    assert sub.source_text == "bandeja"
+
+
+# ── Nesting and inheritance ──────────────────────────────────────────
+
+
+def test_attributes_inherit_through_nesting():
+    p = plan('<prosody rate="0.8">slow <lang xml:lang="es">lento</lang></prosody>')
+    lento = next(n for n in p.nodes if isinstance(n, Speech) and n.language == "es")
+    assert lento.rate == 0.8, "the inner span should keep the outer rate"
+
+
+def test_the_inner_span_wins_on_conflict():
+    p = plan('<lang xml:lang="es">a <lang xml:lang="it">b</lang></lang>')
+    langs = {n.text.strip(): n.language for n in p.nodes if isinstance(n, Speech)}
+    assert langs["b"] == "it"
+
+
+def test_a_substitution_does_not_leak_to_siblings():
+    """<sub> applies to the words it wraps. Inheriting it would put unrelated
+    text through a substitution the author never asked for."""
+    p = plan('<prosody rate="0.9"><sub alias="X">a</sub> b</prosody>')
+    plain = [n for n in p.nodes if isinstance(n, Speech) and n.source_text is None]
+    assert plain
+    assert all("X" not in n.text for n in plain)
+
+
+# ── Cutting as little as possible ────────────────────────────────────
+
+
+def test_identical_neighbours_coalesce():
+    """Every avoided cut is one less place the model restarts its prosody."""
+    p = plan("one two three")
+    assert len(texts(p)) == 1
+
+
+def test_orphaned_punctuation_never_becomes_its_own_run():
+    """A span boundary orphans its trailing punctuation — </lang>. leaves a run
+    holding just ".". Generating that is a wasted call returning noise."""
+    p = plan('a <lang xml:lang="es">bandeja</lang>. b')
+    assert all(any(c.isalnum() for c in t) for t in texts(p)), texts(p)
+
+
+def test_leading_punctuation_is_absorbed_forward():
+    p = plan('<lang xml:lang="es">.</lang> hello there')
+    assert all(any(c.isalnum() for c in t) for t in texts(p)), texts(p)
+
+
+def test_all_punctuation_still_produces_something():
+    """Absorbing must not be able to empty the plan."""
+    p = plan("...")
+    assert p.nodes
+
+
+def test_unmarked_text_is_a_single_trivial_run():
+    """The common case must cost nothing — the renderer takes the existing
+    single-shot path for these."""
+    p = plan("Just a plain sentence.")
+    assert p.is_trivial
+
+
+def test_a_language_span_is_not_trivial():
+    assert not plan('a <lang xml:lang="es">b c d</lang>').is_trivial
+
+
+# ── Engine capability ────────────────────────────────────────────────
+
+
+def test_emphasis_reaches_an_engine_that_honours_instruct():
+    p = plan("<emphasis level=\"strong\">wow</emphasis>", supports_instruct=True)
+    assert "strong" in (p.nodes[0].instruct or "")
+    assert not codes(p)
+
+
+def test_emphasis_on_an_engine_that_ignores_instruct_warns():
+    """Dropping it silently is what makes a model look like it is refusing to
+    follow instructions (#579)."""
+    p = plan("<emphasis>wow</emphasis>", supports_instruct=False)
+    assert "emphasis_unsupported" in codes(p)
+    assert p.nodes[0].instruct is None
+
+
+def test_emphasis_composes_with_the_requests_own_instruct():
+    p = plan(
+        "<emphasis>wow</emphasis>", supports_instruct=True, base_instruct="Speak warmly."
+    )
+    assert "Speak warmly." in p.nodes[0].instruct
+    assert "emphasis" in p.nodes[0].instruct
+
+
+def test_an_unsupported_language_falls_back_and_says_so():
+    p = plan('a <lang xml:lang="sw">x y z</lang>', engine_languages=["en", "es"])
+    assert "language_unsupported" in codes(p)
+    assert all(n.language == "en" for n in p.nodes if isinstance(n, Speech))
+
+
+def test_each_unsupported_language_warns_once():
+    p = plan(
+        'a <lang xml:lang="sw">x y z</lang> b <lang xml:lang="sw">p q r</lang>',
+        engine_languages=["en"],
+    )
+    assert codes(p).count("language_unsupported") == 1
+
+
+def test_a_single_short_word_span_is_flagged():
+    """The tight-vs-clause-aligned trade the prototype measured."""
+    assert "short_language_span" in codes(plan('a <lang xml:lang="es">bandeja</lang> b'))
+
+
+def test_a_clause_length_span_is_not_flagged():
+    p = plan('a <lang xml:lang="es">bandeja, no un smash,</lang> b')
+    assert "short_language_span" not in codes(p)
+
+
+# ── Malformed markup ─────────────────────────────────────────────────
+
+
+def test_an_unclosed_span_is_an_error():
+    """Not passed through as text: passing it through means the engine reads
+    the tag aloud."""
+    with pytest.raises(ProsodyParseError):
+        parse('<lang xml:lang="es">oops')
+
+
+def test_a_mismatched_close_is_an_error():
+    with pytest.raises(ProsodyParseError):
+        parse('<lang xml:lang="es">a</prosody>')
+
+
+@pytest.mark.parametrize(
+    "markup", ["<lang>x</lang>", '<prosody>x</prosody>', "<sub>x</sub>", "<phoneme>x</phoneme>"]
+)
+def test_a_span_missing_its_required_attribute_is_an_error(markup):
+    with pytest.raises(ProsodyParseError):
+        parse(markup)
+
+
+# ── The invariant that makes LLM annotation safe ─────────────────────
+
+
+def test_strip_markup_recovers_the_words():
+    """Annotation is accepted only if stripping the model's output reproduces
+    the input. The model can fail to help; it cannot mangle the script."""
+    original = "The shot here is a bandeja. Not a smash."
+    annotated = (
+        'The shot here is a <lang xml:lang="es">bandeja</lang>.'
+        '<break time="700ms"/> Not a smash.'
+    )
+    assert strip_markup(annotated) == strip_markup(original)
+
+
+def test_strip_markup_detects_a_rewritten_script():
+    original = "The shot here is a bandeja."
+    tampered = 'The shot here is a <lang xml:lang="es">bandeja</lang>, obviously.'
+    assert strip_markup(tampered) != strip_markup(original)
+
+
+def test_strip_markup_ignores_whitespace_reflow():
+    """Putting a tag on its own line is formatting, not content."""
+    assert strip_markup("a\n<break time=\"1s\"/>\n b") == strip_markup("a b")
+
+
+def test_has_markup_detects_directives():
+    assert has_markup('a <break time="1s"/>')
+    assert not has_markup("a plain sentence")
+    assert not has_markup("5 < 6")
+
+
+# ── Seeds ────────────────────────────────────────────────────────────
+
+
+def test_seeds_vary_per_run_but_stay_deterministic():
+    p = plan('a b<break time="1s"/><lang xml:lang="es">c d e</lang>').with_seeds(100)
+    seeds = [n.seed for n in p.nodes if isinstance(n, Speech)]
+    assert seeds == [100, 101]
+    assert p.with_seeds(100) == plan(
+        'a b<break time="1s"/><lang xml:lang="es">c d e</lang>'
+    ).with_seeds(100)
+
+
+def test_an_unseeded_plan_stays_unseeded():
+    """Takes should still vary when no seed was requested."""
+    p = plan("a b c").with_seeds(None)
+    assert all(n.seed is None for n in p.nodes if isinstance(n, Speech))

--- a/backend/tests/test_prosody_transformer.py
+++ b/backend/tests/test_prosody_transformer.py
@@ -128,16 +128,24 @@ def test_bad_rates_are_rejected(raw):
 
 def test_sub_replaces_what_the_engine_hears_but_records_the_original():
     p = plan('a <sub alias="ban-DEH-ha">bandeja</sub> b')
-    sub = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
-    assert sub.text == "ban-DEH-ha"
-    assert sub.source_text == "bandeja"
+    run = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
+    assert run.text == "a ban-DEH-ha b", "the engine hears the respelling"
+    assert run.source_text == "a bandeja b", "the original is kept for preview"
+
+
+def test_a_respelling_does_not_cut_the_sentence():
+    """The whole point of <sub>: it changes characters, not settings, so the
+    sentence stays in one piece. Cutting there would buy exactly the seams that
+    respelling exists to avoid."""
+    p = plan('The shot he plays is a <sub alias="ban-DEH-ha">bandeja</sub>, not a smash.')
+    assert len([n for n in p.nodes if isinstance(n, Speech)]) == 1
 
 
 def test_phoneme_is_carried_as_a_substitution():
     p = plan('a <phoneme alphabet="ipa" ph="banˈdexa">bandeja</phoneme> b')  # noqa: RUF001
-    sub = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
-    assert sub.text == "banˈdexa"  # noqa: RUF001
-    assert sub.source_text == "bandeja"
+    run = next(n for n in p.nodes if isinstance(n, Speech) and n.source_text)
+    assert "banˈdexa" in run.text  # noqa: RUF001
+    assert run.source_text == "a bandeja b"
 
 
 # ── Nesting and inheritance ──────────────────────────────────────────
@@ -157,11 +165,12 @@ def test_the_inner_span_wins_on_conflict():
 
 def test_a_substitution_does_not_leak_to_siblings():
     """<sub> applies to the words it wraps. Inheriting it would put unrelated
-    text through a substitution the author never asked for."""
+    text through a substitution the author never asked for -- the run merges
+    with its neighbours, but only the wrapped word is replaced."""
     p = plan('<prosody rate="0.9"><sub alias="X">a</sub> b</prosody>')
-    plain = [n for n in p.nodes if isinstance(n, Speech) and n.source_text is None]
-    assert plain
-    assert all("X" not in n.text for n in plain)
+    run = next(n for n in p.nodes if isinstance(n, Speech))
+    assert run.text == "X b", "only the wrapped word is substituted"
+    assert run.source_text == "a b"
 
 
 # ── Cutting as little as possible ────────────────────────────────────


### PR DESCRIPTION
A harness around audio segment production. It never synthesises anything — it decides where to cut a script, what settings each cut carries, and how the pieces are reassembled.

```
markup ──▶ parse ──▶ compile(engine) ──▶ RenderPlan ──▶ render ──▶ audio
```

**This PR is the library only.** Nothing is wired into `/generate`, no routes, no schema, no behaviour change anywhere. 7 new files, 0 modified. The wiring is a follow-up so this can be judged on its own.

## Why it matters

Most directives need **no engine support at all**:

| directive | how it is realised | works on |
|---|---|---|
| `<break time="700ms"/>` | insert silence during assembly | all 8 engines |
| `<lang xml:lang="es">…</lang>` | render that run in another language | all 8 engines |
| `<prosody rate="0.9">…</prosody>` | time-stretch the run | all 8 engines |
| `<emphasis>` | `instruct=` where honoured, **warning where not** | capability-dependent |

Pauses and language spans work on Kokoro and LuxTTS exactly as they do on Qwen, because the engine never sees them.

## SSML, not brackets — square ones are taken

`[laugh]` is a Chatterbox Turbo paralinguistic tag: passed **to** the engine, where a directive is intercepted **before** it. Same delimiter, opposite behaviour, and `_PARA_TAG_RE` in `chunked_tts.py` cannot tell them apart. Angle brackets are free.

SSML also already owns the pronunciation vocabulary — `<sub alias>` and `<phoneme ph>` — so there is no parallel syntax for the same idea.

**It is not an XML parser, deliberately.** A script is prose: it contains `&`, it contains `5 < 6`, and XML rejects both. The parser recognises a closed tag set and treats everything else as literal text, which is strictly more forgiving on real input. There are tests for exactly that.

## The plan is the seam

`RenderPlan` is plain data with no model behind it, so it can be built, asserted on and previewed for free — 93 tests run in **under 2 seconds** with no model and no database.

Its `warnings` carry what the target engine cannot honour, so `<emphasis>` on base Qwen says so out loud instead of vanishing. Silent dropping is what makes a model look like it is refusing instructions, which is the complaint behind #579.

## Findings worth surfacing

These came out of listening tests across three voices and shaped the implementation:

**Every generation carries silence padding** — 250–360ms lead, 100–400ms trail on the voices measured. Left in, each cut inserts dead air: a three-run sentence ran **+0.78s** longer than the same words in one shot. Trimmed at the joins, **+0.02s**. Segmentation is duration-neutral, which is what makes the whole approach viable.

**But only the interior joins.** Trimming the *outer* edges cuts the utterance's natural release, and every clip ends abruptly — which reads as forced delivery even on text with no markup at all. The first version did this and a listener flagged it on the unmarked baseline, which was the tell.

**A phase vocoder is the wrong tool for speech.** `librosa.effects.time_stretch` reconstructs from magnitude and estimated phase, which smears consonants; it was rejected outright in listening. Rate uses WSOLA instead — time-domain overlap-add with cross-correlated splice points, numpy only, no new dependency. `services/stories.py` has the same phase-vocoder issue for per-clip speed; fixed separately in #1007.

**A crossfade must not cross a pause,** or a 700ms break is overlapped from both ends and does not last 700ms.

## Composition

`generate_run` is injected rather than imported, so this composes with `generate_chunked` rather than competing: prosody splits by directive, chunking splits by length, and a directive run that is still long goes through both. It is also what keeps the renderer testable with no model.

## Tests

93, all model-free: prose that would break an XML parser, every directive and its degenerate inputs, nesting and inheritance, coalescing, orphaned punctuation, engine-capability warnings, pause/crossfade interaction, stretch ratio accuracy and pitch preservation.

Branched off `main`, independent of my other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SSML-style prosody markup, including pauses, language, rate, emphasis, substitutions, and phonemes.
  * Added engine-aware speech planning with capability warnings and deterministic rendering.
  * Improved audio rendering with pause preservation, rate adjustment, sample-rate conversion, silence trimming, and smooth transitions.

* **Bug Fixes**
  * Preserved utterance boundaries and punctuation while preventing unwanted interior silence.

* **Tests**
  * Added comprehensive coverage for markup parsing, speech planning, and audio rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->