### PR TITLE
feat(backend): run Chatterbox multilingual on MLX for Apple Silicon

### DIFF
--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -294,7 +294,8 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
     # Chatterbox multilingual follows the same backend-aware split as Qwen: the MLX
     # backend loads pre-converted weights, so the download must match the backend that
     # will consume it.
-    if get_backend_type() == "mlx":
+    on_mlx = get_backend_type() == "mlx"
+    if on_mlx:
         chatterbox_repo = "mlx-community/chatterbox-multilingual-v3"
         chatterbox_size_mb = 2600
     else:
@@ -317,6 +318,11 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             hf_repo_id=chatterbox_repo,
             size_mb=chatterbox_size_mb,
             needs_trim=True,
+            # Same EOS miss the qwen configs guard against: on mlx-audio the decoder can run past
+            # the end of the sentence and emit silence followed by codec noise, which reaches the
+            # listener as an endless hiss. Retrying the affected text as smaller chunks is the
+            # existing remedy; it just was not wired for this engine.
+            retries_runaway=on_mlx,
             languages=[
                 "zh",
                 "en",

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -290,10 +290,17 @@ def _get_qwen_custom_voice_configs() -> list[ModelConfig]:
 
 
 def _get_non_qwen_tts_configs() -> list[ModelConfig]:
-    """Return model configs for non-Qwen TTS engines.
+    """Return model configs for non-Qwen TTS engines."""
+    # Chatterbox multilingual follows the same backend-aware split as Qwen: the MLX
+    # backend loads pre-converted weights, so the download must match the backend that
+    # will consume it.
+    if get_backend_type() == "mlx":
+        chatterbox_repo = "mlx-community/chatterbox-multilingual-v3"
+        chatterbox_size_mb = 2600
+    else:
+        chatterbox_repo = "ResembleAI/chatterbox"
+        chatterbox_size_mb = 3200
 
-    These are static — no backend-type branching needed.
-    """
     return [
         ModelConfig(
             model_name="luxtts",
@@ -307,8 +314,8 @@ def _get_non_qwen_tts_configs() -> list[ModelConfig]:
             model_name="chatterbox-tts",
             display_name="Chatterbox TTS (Multilingual)",
             engine="chatterbox",
-            hf_repo_id="ResembleAI/chatterbox",
-            size_mb=3200,
+            hf_repo_id=chatterbox_repo,
+            size_mb=chatterbox_size_mb,
             needs_trim=True,
             languages=[
                 "zh",
@@ -704,9 +711,16 @@ def get_tts_backend_for_engine(engine: str) -> TTSBackend:
 
             backend = LuxTTSBackend()
         elif engine == "chatterbox":
-            from .chatterbox_backend import ChatterboxTTSBackend
+            # Same split the qwen engine already makes: on Apple Silicon the MLX/Metal
+            # port renders 7-9x faster than the CPU-pinned PyTorch path.
+            if get_backend_type() == "mlx":
+                from .chatterbox_mlx_backend import ChatterboxMLXTTSBackend
 
-            backend = ChatterboxTTSBackend()
+                backend = ChatterboxMLXTTSBackend()
+            else:
+                from .chatterbox_backend import ChatterboxTTSBackend
+
+                backend = ChatterboxTTSBackend()
         elif engine == "chatterbox_turbo":
             from .chatterbox_turbo_backend import ChatterboxTurboTTSBackend
 

--- a/backend/backends/chatterbox_mlx_backend.py
+++ b/backend/backends/chatterbox_mlx_backend.py
@@ -1,0 +1,179 @@
+"""
+Chatterbox multilingual TTS backend, MLX (Metal) flavour.
+
+Same zero-shot voice cloning and same 23 languages as ``chatterbox_backend``, but running
+on the Apple Silicon GPU through mlx-audio instead of PyTorch on the CPU.
+
+The PyTorch path is pinned to the CPU on macOS (see ``chatterbox_backend``), which costs
+roughly 4x realtime. This backend uses the pre-converted weights published as
+``mlx-community/chatterbox-multilingual-v3`` and renders the same sentences at about 0.5x
+realtime on an M4 Max with a cloned pt-BR profile.
+
+This mirrors the split the qwen engine already makes between ``mlx_backend`` and
+``pytorch_backend``: MLX where it is available, PyTorch everywhere else.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import ClassVar
+
+import numpy as np
+
+from .base import (
+    combine_voice_prompts as _combine_voice_prompts,
+    is_model_cached,
+    model_load_progress,
+)
+
+logger = logging.getLogger(__name__)
+
+CHATTERBOX_MLX_HF_REPO = "mlx-community/chatterbox-multilingual-v3"
+
+# Files that must be present for the MLX multilingual model
+_MLX_WEIGHT_FILES = ["model.safetensors", "config.json", "tokenizer.json"]
+
+
+class ChatterboxMLXTTSBackend:
+    """Chatterbox Multilingual TTS backend for voice cloning, on MLX/Metal."""
+
+    def __init__(self):
+        self.model = None
+        self.model_size = "default"
+        self._model_load_lock = asyncio.Lock()
+
+    def is_loaded(self) -> bool:
+        return self.model is not None
+
+    def _get_model_path(self, model_size: str = "default") -> str:
+        return CHATTERBOX_MLX_HF_REPO
+
+    def _is_model_cached(self, model_size: str = "default") -> bool:
+        return is_model_cached(CHATTERBOX_MLX_HF_REPO, required_files=_MLX_WEIGHT_FILES)
+
+    async def load_model(self, model_size: str = "default") -> None:
+        """Load the Chatterbox multilingual MLX model."""
+        if self.model is not None:
+            return
+        async with self._model_load_lock:
+            if self.model is not None:
+                return
+            await asyncio.to_thread(self._load_model_sync)
+
+    def _load_model_sync(self):
+        """Synchronous model loading."""
+        is_cached = self._is_model_cached()
+
+        with model_load_progress("chatterbox-tts", is_cached):
+            from huggingface_hub import snapshot_download  # lazy: heavy import
+            from mlx_audio.tts.models.chatterbox.chatterbox import Model  # lazy: heavy import
+
+            logger.info("Loading Chatterbox Multilingual TTS on MLX (Metal)...")
+            ckpt_dir = snapshot_download(CHATTERBOX_MLX_HF_REPO)
+            self.model = Model.from_pretrained(ckpt_dir)
+
+        logger.info("Chatterbox Multilingual TTS (MLX) loaded successfully")
+
+    def unload_model(self) -> None:
+        """Unload model to free memory."""
+        if self.model is None:
+            return
+
+        del self.model
+        self.model = None
+        try:
+            import mlx.core as mx  # lazy: heavy import
+
+            mx.clear_cache()
+        except Exception:
+            logger.debug("mlx cache not cleared", exc_info=True)
+        logger.info("Chatterbox (MLX) unloaded")
+
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+    ) -> tuple[dict, bool]:
+        """
+        Create voice prompt from reference audio.
+
+        Chatterbox conditions on the reference audio at generation time, so the prompt
+        just stores the file path.
+        """
+        voice_prompt = {
+            "ref_audio": str(audio_path),
+            "ref_text": reference_text,
+        }
+        return voice_prompt, False
+
+    async def combine_voice_prompts(
+        self,
+        audio_paths: list[str],
+        reference_texts: list[str],
+    ) -> tuple[np.ndarray, str]:
+        return await _combine_voice_prompts(audio_paths, reference_texts)
+
+    # The MLX port carries its own sampling defaults, validated by ear against the PyTorch
+    # output on a cloned profile. The PyTorch tuning (repetition_penalty=2.0) is not
+    # transferable: the two implementations weight it differently.
+    _DEFAULTS: ClassVar[dict] = {
+        "exaggeration": 0.1,
+        "cfg_weight": 0.5,
+        "temperature": 0.8,
+        "repetition_penalty": 1.2,
+    }
+
+    async def generate(
+        self,
+        text: str,
+        voice_prompt: dict,
+        language: str = "en",
+        seed: int | None = None,
+        instruct: str | None = None,
+    ) -> tuple[np.ndarray, int]:
+        """
+        Generate audio using Chatterbox Multilingual TTS on MLX.
+
+        Args:
+            text: Text to synthesize
+            voice_prompt: Dict with ref_audio path
+            language: BCP-47 language code
+            seed: Random seed for reproducibility
+            instruct: Unused (protocol compatibility)
+
+        Returns:
+            Tuple of (audio_array, sample_rate)
+        """
+        await self.load_model()
+
+        ref_audio = voice_prompt.get("ref_audio")
+        if ref_audio and not Path(ref_audio).exists():
+            logger.warning(f"Reference audio not found: {ref_audio}")
+            ref_audio = None
+
+        def _generate_sync():
+            import mlx.core as mx  # lazy: heavy import
+
+            if seed is not None:
+                mx.random.seed(seed)
+
+            logger.info(f"[Chatterbox/MLX] Generating: lang={language}")
+
+            # mlx-audio yields GenerationResult chunks; the whole clip is their concatenation.
+            chunks = [
+                np.asarray(result.audio).squeeze()
+                for result in self.model.generate(
+                    text,
+                    ref_audio=ref_audio,
+                    lang_code=language,
+                    verbose=False,
+                    **self._DEFAULTS,
+                )
+            ]
+            audio = np.concatenate(chunks).astype(np.float32) if chunks else np.zeros(0, dtype=np.float32)
+
+            sample_rate = getattr(self.model, "sr", None) or 24000
+            return audio, int(sample_rate)
+
+        return await asyncio.to_thread(_generate_sync)


### PR DESCRIPTION

## What

Adds `ChatterboxMLXTTSBackend`, an MLX/Metal implementation of the Chatterbox multilingual
engine, and selects it on Apple Silicon. This mirrors the split the qwen engine already makes
in `get_tts_backend_for_engine`: MLX where available, PyTorch everywhere else.

## Why

`chatterbox_backend` calls `get_torch_device(force_cpu_on_mac=True)`, so on macOS the engine
runs on the CPU. That costs roughly 4x realtime, which makes cloned voices impractical for
anything interactive.

Two things worth reporting from investigating it:

1. MPS is not the answer. I ran the PyTorch path with `torch 2.11` on both devices with the same
   cloned profile, and MPS came out about 10% faster than CPU (6.2s vs 6.9s on a short sentence).
   The CPU pinning in the current backend costs very little, so flipping that flag would not have
   been worth the risk it guards against.

2. MLX is. `mlx-audio` already ships a Metal port of Chatterbox with the multilingual tokenizer,
   and pre-converted weights are published as `mlx-community/chatterbox-multilingual-v3`.

## Numbers

M4 Max (36 GB), cloned pt-BR profile, `POST /generate/stream`, model already loaded, measured
through the running server rather than a standalone script:

| | current (PyTorch, CPU) | this PR (MLX, Metal) |
|---|---|---|
| "O Marshall terminou os testes." (1.8s of audio) | 7.4 to 9.2s | 1.2s (1.26 / 1.23 / 1.19) |
| A 5.0s sentence | 23.7 to 27.1s | 3.1s |

That is 6 to 9x, and the longer sentence renders faster than realtime.

## Changes

- `backend/backends/chatterbox_mlx_backend.py`, new, implementing the same backend protocol as
  `chatterbox_backend` (`load_model`, `create_voice_prompt`, `combine_voice_prompts`, `generate`,
  `unload_model`, `is_loaded`).
- `get_tts_backend_for_engine` branches on `get_backend_type()` for the `chatterbox` engine.
- `_get_non_qwen_tts_configs` makes the `chatterbox-tts` model config backend aware, same pattern
  as `_get_qwen_model_configs`, so the download matches the backend that will consume it
  (2.6 GB of MLX weights instead of 3.2 GB of PyTorch ones).

Nothing changes off Apple Silicon. The PyTorch backend is still selected there and its CPU
pinning is untouched.

## Notes

- Sampling defaults follow the MLX port's own values rather than the PyTorch tuning. The
  `repetition_penalty=2.0` used by the PyTorch backend is weighted differently by the two
  implementations and degrades the MLX output.
- Output stayed at 24 kHz mono, and a native speaker compared clips from both paths and could
  not tell the cloned timbre apart.
- `mlx_audio`'s `generate` also accepts `stream=True`, which would let `/generate/stream` become
  an actual stream instead of returning the whole clip at the end. Left out of this PR to keep
  it to one change.

## Testing

- Ran the backend from source on macOS 26.1, Python 3.12, `torch 2.11`, `mlx-audio 0.4.1`.
- Generated in pt with a cloned profile through `POST /generate/stream`, checked the engine
  selection in the logs, and confirmed `GET /models/status` reports the MLX repo as downloaded.
- Verified the PyTorch path still loads when the MLX branch is not taken.
- `ruff check` and `ruff format --check` are clean on the new file. The pre-existing findings in
  `backends/__init__.py` were left alone, per the style guide note about not reformatting files
  in unrelated PRs.

I did not touch `CHANGELOG.md`: the header says it is compiled during the release workflow.
Happy to add an entry if that is not the case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chatterbox multilingual text-to-speech support for MLX/Metal platforms.
  * Added automatic platform-specific model selection and optimized generation settings.
  * Improved model loading with progress reporting, caching, and resource cleanup.
  * Added voice-prompt creation and combination, seeded generation, and streamed audio support.
  * Added multilingual speech generation and graceful handling when reference audio is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->