### PR TITLE
fix(linux): exit app after window close cleanup

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1566,11 +1566,12 @@ pub fn run() {
                 tauri::async_runtime::spawn(async move {
                     tokio::select! {
                         _ = rx.recv() => {
-                            window_for_close.close().ok();
+                            println!("Frontend cleanup complete, exiting application");
+                            window_for_close.app_handle().exit(0);
                         }
                         _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
-                            eprintln!("Window close timeout, closing anyway");
-                            window_for_close.close().ok();
+                            eprintln!("Window close timeout, exiting application anyway");
+                            window_for_close.app_handle().exit(0);
                         }
                     }
                     window_for_close.unlisten(listener_id);


### PR DESCRIPTION
On Linux, closing the main window with 'Keep server running' disabled could leave the Tauri process alive even after the backend had stopped. The remaining process kept the Rust speak_monitor task running, which retried /events/speak indefinitely every 30 seconds.

This changes the close flow to exit the Tauri application after frontend cleanup completes, instead of only closing the window. The same behavior is used for the 5-second cleanup timeout fallback.

Tested on LMDE 6 / Debian 12 with Voicebox 0.5.0:
- backend terminates correctly
- port 17493 is released
- no voicebox process remains after closing the window
- RunEvent::Exit is reached normally
- CUDA backend operation is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown behavior when closing the window.
  * The app now exits reliably after cleanup completes or after a five-second timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->