### PR TITLE
feat(sinks): add Telnyx PSTN sink for outbound call playback

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -22,6 +22,8 @@ from .models import (
     Project,
     Story,
     StoryItem,
+    TelnyxCall,
+    TelnyxSettings,
     VoiceProfile,
 )
 from .session import engine, SessionLocal, _db_path, init_db, get_db
@@ -44,6 +46,8 @@ __all__ = [
     "Project",
     "Story",
     "StoryItem",
+    "TelnyxCall",
+    "TelnyxSettings",
     "VoiceProfile",
     # Session
     "engine",

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -304,6 +304,12 @@ def _migrate_telnyx_settings(engine, inspector, tables: set[str]) -> None:
     webhook) ship their own singleton tables in their own PRs.
     """
     if "telnyx_settings" in tables:
+        # Table predates connection_id (early builds of the sink omitted it
+        # and every dial 422'd). Backfill the column rather than recreate.
+        if "connection_id" not in _get_columns(inspector, "telnyx_settings"):
+            _add_column(
+                engine, "telnyx_settings", "connection_id VARCHAR", "connection_id"
+            )
         return
 
     with engine.begin() as conn:
@@ -313,6 +319,7 @@ def _migrate_telnyx_settings(engine, inspector, tables: set[str]) -> None:
                 id INTEGER PRIMARY KEY DEFAULT 1,
                 enabled BOOLEAN NOT NULL DEFAULT 0,
                 api_key VARCHAR,
+                connection_id VARCHAR,
                 from_number VARCHAR,
                 public_base_url VARCHAR,
                 default_profile_id VARCHAR REFERENCES profiles(id),

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -43,6 +43,8 @@ def run_migrations(engine) -> None:
     _migrate_generation_versions(engine, inspector, tables)
     _migrate_capture_settings(engine, inspector, tables)
     _migrate_mcp_bindings(engine, inspector, tables)
+    _migrate_telnyx_settings(engine, inspector, tables)
+    _migrate_telnyx_calls(engine, inspector, tables)
     _normalize_storage_paths(engine, tables)
 
 
@@ -290,6 +292,68 @@ def _supports_drop_column(engine) -> bool:
     if engine.dialect.name != "sqlite":
         return True
     return tuple(int(p) for p in sqlite3.sqlite_version.split(".")[:3]) >= (3, 35, 0)
+
+
+def _migrate_telnyx_settings(engine, inspector, tables: set[str]) -> None:
+    """Create the ``telnyx_settings`` table for the Telnyx PSTN sink.
+
+    One singleton row (id=1) holding the user's Telnyx API key, default
+    caller ID, public tunnel URL, and a few toggles. The table itself is
+    created here; the singleton row is lazily inserted by the settings
+    service on first read. Future sinks (Apple Notes, Obsidian, generic
+    webhook) ship their own singleton tables in their own PRs.
+    """
+    if "telnyx_settings" in tables:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            """
+            CREATE TABLE telnyx_settings (
+                id INTEGER PRIMARY KEY DEFAULT 1,
+                enabled BOOLEAN NOT NULL DEFAULT 0,
+                api_key VARCHAR,
+                from_number VARCHAR,
+                public_base_url VARCHAR,
+                default_profile_id VARCHAR REFERENCES profiles(id),
+                auto_hangup BOOLEAN NOT NULL DEFAULT 1,
+                updated_at DATETIME
+            )
+            """
+        ))
+    logger.info("Created telnyx_settings table")
+
+
+def _migrate_telnyx_calls(engine, inspector, tables: set[str]) -> None:
+    """Create the ``telnyx_calls`` table that tracks pending outbound calls.
+
+    One row per call. The webhook handler reads this to know which
+    generation to play when Telnyx fires ``call.answered``. The
+    ``webhook_secret`` column is a per-call random token (sent as the
+    ``token`` query param on the webhook URL) so a third party who knows
+    the webhook URL can't trigger playback on someone else's call.
+    """
+    if "telnyx_calls" in tables:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            """
+            CREATE TABLE telnyx_calls (
+                call_control_id VARCHAR PRIMARY KEY,
+                generation_id VARCHAR NOT NULL REFERENCES generations(id),
+                to_number VARCHAR NOT NULL,
+                from_number VARCHAR NOT NULL,
+                webhook_secret VARCHAR,
+                status VARCHAR NOT NULL DEFAULT 'initiating',
+                auto_hangup BOOLEAN NOT NULL DEFAULT 1,
+                error TEXT,
+                started_at DATETIME NOT NULL,
+                completed_at DATETIME
+            )
+            """
+        ))
+    logger.info("Created telnyx_calls table")
 
 
 def _normalize_storage_paths(engine, tables: set[str]) -> None:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -317,6 +317,8 @@ class TelnyxSettings(Base):
     id = Column(Integer, primary_key=True, default=1)
     enabled = Column(Boolean, nullable=False, default=False)
     api_key = Column(String, nullable=True)
+    # Call Control Application ID — required on every outbound dial.
+    connection_id = Column(String, nullable=True)
     from_number = Column(String, nullable=True)  # E.164, used as caller ID
     public_base_url = Column(String, nullable=True)  # ngrok/funnel/etc.
     default_profile_id = Column(String, ForeignKey("profiles.id"), nullable=True)
@@ -336,8 +338,12 @@ class TelnyxCall(Base):
     verification (a follow-up hardening step).
 
     Status progression:
-        initiating → ringing → answered → playing → playback_ended → hangup
-                                                                  ↘ failed
+        initiating → preparing → playing → playback_ended → hangup
+                                                         ↘ failed
+
+    ``preparing`` is the claim state: the ``call.answered`` webhook sets it
+    before doing any slow work, so a retried delivery of the same event finds
+    the call already claimed and doesn't start a second playback.
     """
 
     __tablename__ = "telnyx_calls"

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -301,3 +301,54 @@ class Capture(Base):
     llm_model = Column(String, nullable=True)
     refinement_flags = Column(Text, nullable=True)  # JSON blob
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class TelnyxSettings(Base):
+    """Singleton row holding Telnyx sink credentials and defaults.
+
+    Populated by the "Settings → Sinks → Telnyx" UI. The ``api_key`` is a
+    bearer credential for ``api.telnyx.com`` — stored in the local app
+    database alongside the user's other data, masked in API responses. The
+    ``id`` is always 1; a null ``api_key`` means "not configured".
+    """
+
+    __tablename__ = "telnyx_settings"
+
+    id = Column(Integer, primary_key=True, default=1)
+    enabled = Column(Boolean, nullable=False, default=False)
+    api_key = Column(String, nullable=True)
+    from_number = Column(String, nullable=True)  # E.164, used as caller ID
+    public_base_url = Column(String, nullable=True)  # ngrok/funnel/etc.
+    default_profile_id = Column(String, ForeignKey("profiles.id"), nullable=True)
+    auto_hangup = Column(Boolean, nullable=False, default=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class TelnyxCall(Base):
+    """A pending or in-progress Telnyx call mapped to a Voicebox generation.
+
+    One row per outbound dial. The ``webhook_secret`` is a per-call random
+    token embedded in the ``webhook_url`` we send Telnyx at call-creation
+    time; Telnyx includes it back as the ``token`` query param on webhook
+    POSTs, and the webhook handler rejects any request whose token doesn't
+    match. This stops a third party who knows the webhook URL from
+    triggering playback on a live call without needing full HMAC signature
+    verification (a follow-up hardening step).
+
+    Status progression:
+        initiating → ringing → answered → playing → playback_ended → hangup
+                                                                  ↘ failed
+    """
+
+    __tablename__ = "telnyx_calls"
+
+    call_control_id = Column(String, primary_key=True)
+    generation_id = Column(String, ForeignKey("generations.id"), nullable=False)
+    to_number = Column(String, nullable=False)
+    from_number = Column(String, nullable=False)
+    webhook_secret = Column(String, nullable=True)
+    status = Column(String, nullable=False, default="initiating")
+    auto_hangup = Column(Boolean, nullable=False, default=True)
+    error = Column(Text, nullable=True)
+    started_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    completed_at = Column(DateTime, nullable=True)

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -265,12 +265,10 @@ def register_tools(mcp: FastMCP) -> None:
 
         db = next(get_db())
         try:
-            if not sinks_service.is_configured(db):
-                raise ValueError(
-                    "Telnyx sink not configured. Set api_key, from_number, "
-                    "and public_base_url in Voicebox → Settings → Sinks → "
-                    "Telnyx, then retry."
-                )
+            s = sinks_service.get_settings(db)
+            missing = sinks_service.missing_settings(s)
+            if missing:
+                raise ValueError(sinks_service.setup_hint(missing))
 
             if bool(text) == bool(generation_id):
                 raise ValueError(
@@ -279,28 +277,15 @@ def register_tools(mcp: FastMCP) -> None:
                 )
 
             client_id = current_client_id.get()
-            vp = None
-            if profile:
-                vp = resolve_profile(profile, client_id, db)
-                if vp is None:
-                    raise ValueError(
-                        f"Voice profile '{profile}' not found."
-                    )
-            if vp is None:
-                # Per-client binding next.
-                if client_id:
-                    binding = (
-                        db.query(MCPClientBinding)
-                        .filter(MCPClientBinding.client_id == client_id)
-                        .first()
-                    )
-                    if binding and binding.profile_id:
-                        vp = resolve_profile(binding.profile_id, client_id, db)
-            if vp is None:
-                # Sink default last.
-                s = sinks_service.get_settings(db)
-                if s.default_profile_id:
-                    vp = resolve_profile(s.default_profile_id, client_id, db)
+
+            # One resolve_profile call covers explicit arg → per-client
+            # binding → global capture default, the same chain
+            # voicebox.speak uses. The sink default is the last resort.
+            vp = resolve_profile(profile, client_id, db)
+            if vp is None and profile:
+                raise ValueError(f"Voice profile '{profile}' not found.")
+            if vp is None and s.default_profile_id:
+                vp = resolve_profile(s.default_profile_id, client_id, db)
             if vp is None:
                 raise ValueError(
                     "No voice profile resolved. Pass `profile=`, set a "
@@ -308,32 +293,35 @@ def register_tools(mcp: FastMCP) -> None:
                     "bind a profile to this client in Settings → MCP."
                 )
 
-            resolved_personality = personality
-            if resolved_personality is None and client_id:
+            binding = None
+            if client_id:
                 binding = (
                     db.query(MCPClientBinding)
                     .filter(MCPClientBinding.client_id == client_id)
                     .first()
                 )
-                if binding is not None:
-                    resolved_personality = bool(binding.default_personality)
+
+            resolved_personality = personality
+            if resolved_personality is None and binding is not None:
+                resolved_personality = bool(binding.default_personality)
             use_persona = bool(resolved_personality) and bool(vp.personality)
 
-            try:
-                result = await sinks_service.place_call(
-                    to=to,
-                    text=text,
-                    generation_id=generation_id,
-                    profile_id=vp.id,
-                    profile_name=vp.name,
-                    engine=engine,
-                    language=language,
-                    personality=use_persona,
-                    auto_hangup=auto_hangup,
-                    db=db,
-                )
-            except ValueError as exc:
-                raise ValueError(str(exc)) from exc
+            resolved_engine = engine
+            if resolved_engine is None and binding is not None:
+                resolved_engine = binding.default_engine
+
+            result = await sinks_service.place_call(
+                to=to,
+                text=text,
+                generation_id=generation_id,
+                profile_id=vp.id,
+                profile_name=vp.name,
+                engine=resolved_engine,
+                language=language,
+                personality=use_persona,
+                auto_hangup=auto_hangup,
+                db=db,
+            )
 
             mcp_events.publish(
                 "call-start",

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -224,6 +224,132 @@ def register_tools(mcp: FastMCP) -> None:
         finally:
             db.close()
 
+    @mcp.tool(
+        name="voicebox.call",
+        description=(
+            "Dial a phone number via the Telnyx sink and play a Voicebox "
+            "generation on the call. Returns a `call_control_id` and a "
+            "`generation_id` you can poll at /generate/{id}/status. The "
+            "call dials as soon as Telnyx accepts; playback happens "
+            "asynchronously once the callee picks up. Requires the Telnyx "
+            "sink to be configured in Voicebox → Settings → Sinks."
+        ),
+    )
+    async def voicebox_call(
+        to: str,
+        text: str | None = None,
+        generation_id: str | None = None,
+        profile: str | None = None,
+        engine: str | None = None,
+        personality: bool | None = None,
+        language: str | None = None,
+        auto_hangup: bool | None = None,
+    ) -> dict[str, Any]:
+        """Dial ``to`` (E.164) and play a generation on the call.
+
+        Pass exactly one of ``text`` (generate fresh audio first) or
+        ``generation_id`` (reuse an existing completed generation).
+
+        ``profile`` accepts a voice profile name (e.g. "Morgan") or id, and
+        follows the same resolution chain as ``voicebox.speak``: explicit
+        arg → per-client MCP binding → sink default. If none resolve, the
+        tool raises a helpful error pointing at the Settings UI.
+
+        ``auto_hangup`` overrides the sink's default — when true (the
+        default), the call hangs up after playback ends; when false, the
+        call stays connected after playback so the caller can issue more
+        actions (future: DTMF, recording, etc.).
+        """
+        from ..database.models import MCPClientBinding
+        from ..services import sinks as sinks_service
+
+        db = next(get_db())
+        try:
+            if not sinks_service.is_configured(db):
+                raise ValueError(
+                    "Telnyx sink not configured. Set api_key, from_number, "
+                    "and public_base_url in Voicebox → Settings → Sinks → "
+                    "Telnyx, then retry."
+                )
+
+            if bool(text) == bool(generation_id):
+                raise ValueError(
+                    "Pass exactly one of `text` (generate inline) or "
+                    "`generation_id` (use an existing generation)."
+                )
+
+            client_id = current_client_id.get()
+            vp = None
+            if profile:
+                vp = resolve_profile(profile, client_id, db)
+                if vp is None:
+                    raise ValueError(
+                        f"Voice profile '{profile}' not found."
+                    )
+            if vp is None:
+                # Per-client binding next.
+                if client_id:
+                    binding = (
+                        db.query(MCPClientBinding)
+                        .filter(MCPClientBinding.client_id == client_id)
+                        .first()
+                    )
+                    if binding and binding.profile_id:
+                        vp = resolve_profile(binding.profile_id, client_id, db)
+            if vp is None:
+                # Sink default last.
+                s = sinks_service.get_settings(db)
+                if s.default_profile_id:
+                    vp = resolve_profile(s.default_profile_id, client_id, db)
+            if vp is None:
+                raise ValueError(
+                    "No voice profile resolved. Pass `profile=`, set a "
+                    "default in Voicebox → Settings → Sinks → Telnyx, or "
+                    "bind a profile to this client in Settings → MCP."
+                )
+
+            resolved_personality = personality
+            if resolved_personality is None and client_id:
+                binding = (
+                    db.query(MCPClientBinding)
+                    .filter(MCPClientBinding.client_id == client_id)
+                    .first()
+                )
+                if binding is not None:
+                    resolved_personality = bool(binding.default_personality)
+            use_persona = bool(resolved_personality) and bool(vp.personality)
+
+            try:
+                result = await sinks_service.place_call(
+                    to=to,
+                    text=text,
+                    generation_id=generation_id,
+                    profile_id=vp.id,
+                    profile_name=vp.name,
+                    engine=engine,
+                    language=language,
+                    personality=use_persona,
+                    auto_hangup=auto_hangup,
+                    db=db,
+                )
+            except ValueError as exc:
+                raise ValueError(str(exc)) from exc
+
+            mcp_events.publish(
+                "call-start",
+                {
+                    "call_control_id": result["call_control_id"],
+                    "generation_id": result["generation_id"],
+                    "to": to,
+                    "profile_name": vp.name,
+                    "source": "mcp",
+                    "client_id": client_id,
+                },
+            )
+            return result
+        finally:
+            db.close()
+
 
 # ─── Speak helper ──────────────────────────────────────────────────────────
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -890,10 +890,15 @@ class TelnyxSettingsResponse(BaseModel):
     enabled: bool
     api_key_masked: str
     api_key_set: bool
+    connection_id: Optional[str] = None
     from_number: Optional[str] = None
     public_base_url: Optional[str] = None
     default_profile_id: Optional[str] = None
     auto_hangup: bool = True
+    missing: List[str] = Field(
+        default_factory=list,
+        description="Settings fields still required before the sink can dial.",
+    )
 
 
 class TelnyxSettingsUpdate(BaseModel):
@@ -909,6 +914,13 @@ class TelnyxSettingsUpdate(BaseModel):
     api_key: Optional[str] = Field(
         None,
         description="Set to a non-empty string to update; pass null to leave unchanged.",
+    )
+    connection_id: Optional[str] = Field(
+        None,
+        description=(
+            "Telnyx Call Control Application ID. Required on every outbound "
+            "dial — find it in the Telnyx console under Call Control."
+        ),
     )
     from_number: Optional[str] = Field(
         None,

--- a/backend/models.py
+++ b/backend/models.py
@@ -815,3 +815,109 @@ class CloudStatusResponse(BaseModel):
     key_prefix: Optional[str] = None
     connected_at: Optional[datetime] = None
     dashboard_url: str
+
+
+# ─── Telnyx sink ──────────────────────────────────────────────────────────
+
+
+class CallRequest(BaseModel):
+    """Body for ``POST /call`` — REST surface that mirrors ``voicebox.call``.
+
+    Exactly one of ``text`` or ``generation_id`` must be set: ``text``
+    generates fresh audio via the same path as ``POST /generate``;
+    ``generation_id`` reuses an existing completed generation. ``profile``
+    resolves the same way as ``voicebox.speak`` — explicit name/id, then
+    per-client MCP binding, then the sink's configured default profile.
+    """
+
+    to: str = Field(
+        ...,
+        pattern=r"^\+[1-9]\d{6,14}$",
+        description="E.164 phone number to dial, e.g. '+15551234567'.",
+    )
+    text: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=10000,
+        description="Speak this text on the call. Mutually exclusive with `generation_id`.",
+    )
+    generation_id: Optional[str] = Field(
+        None,
+        description="Play an existing completed generation on the call. Mutually exclusive with `text`.",
+    )
+    profile: Optional[str] = Field(
+        None,
+        description="Voice profile name or id. Falls back to per-client binding, then the sink default.",
+    )
+    engine: Optional[str] = Field(
+        None,
+        pattern=r"^(qwen|qwen_custom_voice|luxtts|chatterbox|chatterbox_turbo|tada|kokoro)$",
+    )
+    personality: Optional[bool] = Field(
+        None,
+        description="When true and the profile has a personality prompt, the input text is rewritten in-character before TTS.",
+    )
+    language: Optional[str] = Field(
+        None,
+        pattern=r"^(zh|en|ja|ko|de|fr|ru|pt|es|it|he|ar|da|el|fi|hi|ms|nl|no|pl|sv|sw|tr)$",
+    )
+    auto_hangup: Optional[bool] = Field(
+        None,
+        description="Override the sink's default. When true, hang up after playback ends.",
+    )
+
+
+class CallResponse(BaseModel):
+    """Response shape for ``POST /call`` and the ``voicebox.call`` MCP tool.
+
+    ``status`` is ``"dialing"`` immediately after Telnyx accepts the call;
+    playback happens asynchronously once Telnyx fires the ``call.answered``
+    webhook. Poll ``generation_id`` at ``poll_url`` to know when the
+    generation itself finished.
+    """
+
+    call_control_id: str
+    status: str
+    generation_id: str
+    profile: str
+    to: str
+    poll_url: str
+
+
+class TelnyxSettingsResponse(BaseModel):
+    """Read-only view of Telnyx sink settings. The API key is masked."""
+
+    enabled: bool
+    api_key_masked: str
+    api_key_set: bool
+    from_number: Optional[str] = None
+    public_base_url: Optional[str] = None
+    default_profile_id: Optional[str] = None
+    auto_hangup: bool = True
+
+
+class TelnyxSettingsUpdate(BaseModel):
+    """Partial update for Telnyx sink settings — every field is optional.
+
+    Passing ``api_key=None`` is a no-op (the route drops it) so the UI can
+    save other fields without clearing the key it never received. To clear
+    the key, set ``api_key=""`` — the route treats an empty string as a
+    clear.
+    """
+
+    enabled: Optional[bool] = None
+    api_key: Optional[str] = Field(
+        None,
+        description="Set to a non-empty string to update; pass null to leave unchanged.",
+    )
+    from_number: Optional[str] = Field(
+        None,
+        pattern=r"^\+[1-9]\d{6,14}$",
+    )
+    public_base_url: Optional[str] = Field(
+        None,
+        max_length=200,
+        description="Public HTTPS URL of this Voicebox server (ngrok, Tailscale Funnel, etc.).",
+    )
+    default_profile_id: Optional[str] = None
+    auto_hangup: Optional[bool] = None

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -25,6 +25,7 @@ def register_routers(app: FastAPI) -> None:
     from .mcp_bindings import router as mcp_bindings_router
     from .events import router as events_router
     from .cloud import router as cloud_router
+    from .sinks import router as sinks_router
 
     app.include_router(health_router)
     app.include_router(profiles_router)
@@ -46,3 +47,4 @@ def register_routers(app: FastAPI) -> None:
     app.include_router(mcp_bindings_router)
     app.include_router(events_router)
     app.include_router(cloud_router)
+    app.include_router(sinks_router)

--- a/backend/routes/sinks.py
+++ b/backend/routes/sinks.py
@@ -1,0 +1,214 @@
+"""REST endpoints for the Telnyx PSTN sink.
+
+Mirrors the pattern from ``routes/speak.py``: a REST surface that wraps the
+same logic as the ``voicebox.call`` MCP tool, plus CRUD for the Telnyx settings
+singleton, plus the webhook receiver Telnyx calls back into when a call is
+answered or playback finishes.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..database import get_db
+from ..mcp_server import events as mcp_events
+from ..mcp_server.context import current_client_id
+from ..mcp_server.resolve import resolve_profile
+from ..services import sinks as sinks_service
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ─── Settings CRUD ─────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/sinks/telnyx",
+    response_model=models.TelnyxSettingsResponse,
+    tags=["sinks"],
+)
+async def get_telnyx_settings(db: Session = Depends(get_db)):
+    """Read the Telnyx sink settings. The API key is masked in the response
+    so the Settings UI can render a "configured" hint without ever shipping
+    the secret to the browser."""
+    row = sinks_service.get_settings(db)
+    return models.TelnyxSettingsResponse(
+        enabled=bool(row.enabled),
+        api_key_masked=sinks_service.mask_key(row.api_key),
+        api_key_set=bool(row.api_key),
+        from_number=row.from_number,
+        public_base_url=row.public_base_url,
+        default_profile_id=row.default_profile_id,
+        auto_hangup=bool(row.auto_hangup),
+    )
+
+
+@router.put(
+    "/sinks/telnyx",
+    response_model=models.TelnyxSettingsResponse,
+    tags=["sinks"],
+)
+async def update_telnyx_settings(
+    patch: models.TelnyxSettingsUpdate,
+    db: Session = Depends(get_db),
+):
+    """Partial update. Passing ``api_key`` overwrites the stored key; passing
+    ``api_key=None`` is a no-op (so the UI can save other fields without
+    clearing the key it never received)."""
+    payload = patch.model_dump(exclude_unset=True)
+    # Don't null the API key if the caller just omitted it.
+    if "api_key" in payload and payload["api_key"] is None:
+        payload.pop("api_key")
+    row = sinks_service.update_settings(db, payload)
+    return models.TelnyxSettingsResponse(
+        enabled=bool(row.enabled),
+        api_key_masked=sinks_service.mask_key(row.api_key),
+        api_key_set=bool(row.api_key),
+        from_number=row.from_number,
+        public_base_url=row.public_base_url,
+        default_profile_id=row.default_profile_id,
+        auto_hangup=bool(row.auto_hangup),
+    )
+
+
+@router.get("/sinks/telnyx/health", tags=["sinks"])
+async def telnyx_health(db: Session = Depends(get_db)):
+    """Verify the API key by listing phone numbers. Returns 200 with
+    ``{ok: true/false}`` — never raises, so the UI can show a green/red dot."""
+    row = sinks_service.get_settings(db)
+    if not row.api_key:
+        return {"ok": False, "reason": "no_api_key"}
+    try:
+        async with sinks_service.TelnyxClient(row.api_key) as client:
+            ok = await client.health()
+        return {"ok": ok}
+    except Exception as exc:
+        return {"ok": False, "reason": str(exc)}
+
+
+# ─── Call endpoint (REST mirror of voicebox.call) ──────────────────────────
+
+
+@router.post("/call", response_model=models.CallResponse, tags=["sinks"])
+async def call_endpoint(
+    data: models.CallRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Dial a number and play a generation on the call. Mirrors the
+    ``voicebox.call`` MCP tool — same profile resolution, same generation
+    path, same webhook-driven playback.
+
+    Returns a ``CallResponse`` with ``status="dialing"`` and a
+    ``call_control_id``. The caller can poll ``GET /generate/{id}/status``
+    to know when the generation finished; the actual playback happens
+    asynchronously once Telnyx fires the ``call.answered`` webhook.
+    """
+    if not sinks_service.is_configured(db):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Telnyx sink not configured. Set api_key, from_number, and "
+                "public_base_url in Voicebox → Settings → Sinks → Telnyx."
+            ),
+        )
+
+    if bool(data.text) == bool(data.generation_id):
+        raise HTTPException(
+            status_code=400,
+            detail="Pass exactly one of `text` or `generation_id`.",
+        )
+
+    client_id = request.headers.get("X-Voicebox-Client-Id")
+
+    # Resolve profile: explicit arg → per-client binding → sink default → fail.
+    profile = None
+    if data.profile:
+        profile = resolve_profile(data.profile, client_id, db)
+        if profile is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Voice profile '{data.profile}' not found.",
+            )
+    if profile is None:
+        # Fall back to the sink's configured default profile.
+        row = sinks_service.get_settings(db)
+        if row.default_profile_id:
+            profile = resolve_profile(row.default_profile_id, client_id, db)
+    if profile is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No voice profile resolved. Pass `profile`, set a default "
+                "in Voicebox → Settings → Sinks → Telnyx, or bind a profile "
+                "to this client in Settings → MCP."
+            ),
+        )
+
+    try:
+        result = await sinks_service.place_call(
+            to=data.to,
+            text=data.text,
+            generation_id=data.generation_id,
+            profile_id=profile.id,
+            profile_name=profile.name,
+            engine=data.engine,
+            language=data.language,
+            personality=bool(data.personality),
+            auto_hangup=data.auto_hangup,
+            db=db,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    mcp_events.publish(
+        "call-start",
+        {
+            "call_control_id": result["call_control_id"],
+            "generation_id": result["generation_id"],
+            "to": data.to,
+            "profile_name": profile.name,
+            "source": "rest",
+            "client_id": client_id,
+        },
+    )
+    return result
+
+
+# ─── Webhook receiver ──────────────────────────────────────────────────────
+
+
+@router.post("/sinks/telnyx/webhook", tags=["sinks"])
+async def telnyx_webhook(
+    request: Request,
+    token: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    """Telnyx call-control webhook receiver. Telnyx POSTs here on
+    ``call.answered`` and ``playback.ended`` (and several other events we
+    ignore). The ``token`` query param is a per-call secret embedded in the
+    ``webhook_url`` we sent Telnyx at call-creation time; verifying it stops
+    a third party who knows the URL from triggering playback on a live call.
+
+    This endpoint is unauthenticated by design — Telnyx can't be asked to
+    authenticate. The per-call token is the only gate. Future hardening:
+    verify the Telnyx webhook signature header against the application's
+    public key.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return {"ok": False, "reason": "invalid_json"}
+
+    return await sinks_service.handle_telnyx_webhook(
+        body=body,
+        token=token,
+        db=db,
+    )

--- a/backend/routes/sinks.py
+++ b/backend/routes/sinks.py
@@ -14,9 +14,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 
 from .. import models
-from ..database import get_db
+from ..database import MCPClientBinding, get_db
 from ..mcp_server import events as mcp_events
-from ..mcp_server.context import current_client_id
 from ..mcp_server.resolve import resolve_profile
 from ..services import sinks as sinks_service
 
@@ -38,16 +37,7 @@ async def get_telnyx_settings(db: Session = Depends(get_db)):
     """Read the Telnyx sink settings. The API key is masked in the response
     so the Settings UI can render a "configured" hint without ever shipping
     the secret to the browser."""
-    row = sinks_service.get_settings(db)
-    return models.TelnyxSettingsResponse(
-        enabled=bool(row.enabled),
-        api_key_masked=sinks_service.mask_key(row.api_key),
-        api_key_set=bool(row.api_key),
-        from_number=row.from_number,
-        public_base_url=row.public_base_url,
-        default_profile_id=row.default_profile_id,
-        auto_hangup=bool(row.auto_hangup),
-    )
+    return _settings_response(sinks_service.get_settings(db))
 
 
 @router.put(
@@ -67,14 +57,25 @@ async def update_telnyx_settings(
     if "api_key" in payload and payload["api_key"] is None:
         payload.pop("api_key")
     row = sinks_service.update_settings(db, payload)
+    return _settings_response(row)
+
+
+def _settings_response(row) -> models.TelnyxSettingsResponse:
+    """Shared serializer so GET and PUT can't drift out of sync.
+
+    ``missing`` is included so the Settings UI can tell the user exactly what
+    is still needed instead of only discovering it when a call fails.
+    """
     return models.TelnyxSettingsResponse(
         enabled=bool(row.enabled),
         api_key_masked=sinks_service.mask_key(row.api_key),
         api_key_set=bool(row.api_key),
+        connection_id=row.connection_id,
         from_number=row.from_number,
         public_base_url=row.public_base_url,
         default_profile_id=row.default_profile_id,
         auto_hangup=bool(row.auto_hangup),
+        missing=sinks_service.missing_settings(row),
     )
 
 
@@ -89,8 +90,11 @@ async def telnyx_health(db: Session = Depends(get_db)):
         async with sinks_service.TelnyxClient(row.api_key) as client:
             ok = await client.health()
         return {"ok": ok}
-    except Exception as exc:
-        return {"ok": False, "reason": str(exc)}
+    except Exception:
+        # Log the detail locally; the response stays generic so a failed probe
+        # can't echo internal state back through the API.
+        logger.exception("Telnyx health check failed")
+        return {"ok": False, "reason": "request_failed"}
 
 
 # ─── Call endpoint (REST mirror of voicebox.call) ──────────────────────────
@@ -111,14 +115,10 @@ async def call_endpoint(
     to know when the generation finished; the actual playback happens
     asynchronously once Telnyx fires the ``call.answered`` webhook.
     """
-    if not sinks_service.is_configured(db):
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Telnyx sink not configured. Set api_key, from_number, and "
-                "public_base_url in Voicebox → Settings → Sinks → Telnyx."
-            ),
-        )
+    row = sinks_service.get_settings(db)
+    missing = sinks_service.missing_settings(row)
+    if missing:
+        raise HTTPException(status_code=400, detail=sinks_service.setup_hint(missing))
 
     if bool(data.text) == bool(data.generation_id):
         raise HTTPException(
@@ -128,20 +128,18 @@ async def call_endpoint(
 
     client_id = request.headers.get("X-Voicebox-Client-Id")
 
-    # Resolve profile: explicit arg → per-client binding → sink default → fail.
-    profile = None
-    if data.profile:
-        profile = resolve_profile(data.profile, client_id, db)
-        if profile is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Voice profile '{data.profile}' not found.",
-            )
-    if profile is None:
-        # Fall back to the sink's configured default profile.
-        row = sinks_service.get_settings(db)
-        if row.default_profile_id:
-            profile = resolve_profile(row.default_profile_id, client_id, db)
+    # Resolve profile the same way POST /speak does: one resolve_profile call
+    # handles explicit arg → per-client binding → global capture default. Only
+    # if all of those miss do we fall back to the sink's own default, so a
+    # caller with an MCP binding gets the same voice on /call as on /speak.
+    profile = resolve_profile(data.profile, client_id, db)
+    if profile is None and data.profile:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Voice profile '{data.profile}' not found.",
+        )
+    if profile is None and row.default_profile_id:
+        profile = resolve_profile(row.default_profile_id, client_id, db)
     if profile is None:
         raise HTTPException(
             status_code=400,
@@ -152,6 +150,23 @@ async def call_endpoint(
             ),
         )
 
+    # Per-client defaults for personality/engine, matching POST /speak.
+    binding = None
+    if client_id:
+        binding = (
+            db.query(MCPClientBinding)
+            .filter(MCPClientBinding.client_id == client_id)
+            .first()
+        )
+
+    personality_flag = data.personality
+    if personality_flag is None and binding is not None:
+        personality_flag = bool(binding.default_personality)
+
+    engine = data.engine
+    if engine is None and binding is not None:
+        engine = binding.default_engine
+
     try:
         result = await sinks_service.place_call(
             to=data.to,
@@ -159,9 +174,9 @@ async def call_endpoint(
             generation_id=data.generation_id,
             profile_id=profile.id,
             profile_name=profile.name,
-            engine=data.engine,
+            engine=engine,
             language=data.language,
-            personality=bool(data.personality),
+            personality=bool(personality_flag),
             auto_hangup=data.auto_hangup,
             db=db,
         )

--- a/backend/services/sinks.py
+++ b/backend/services/sinks.py
@@ -1,28 +1,35 @@
 """Telnyx PSTN sink — dial a number and play a Voicebox generation on the call.
 
-Thin HTTP-only client against ``api.telnyx.com/v2``. No SDK dependency, no
-new requirements (httpx is already in ``requirements.txt``). Generation stays
-local; only the PSTN leg touches Telnyx.
+Thin HTTP-only client against ``api.telnyx.com/v2``. No SDK dependency; the
+only network library is ``httpx``, which the cloud service already imports at
+module scope. Generation stays local; only the PSTN leg touches Telnyx.
 
 Flow:
     1. Caller hits ``POST /call`` (REST) or ``voicebox.call`` (MCP).
     2. We resolve a voice profile and either reuse an existing generation_id
        or run ``generate_speech`` to produce one (status="generating").
-    3. We POST to Telnyx ``/v2/calls`` with ``webhook_url`` pointing back at
-       this Voicebox server, scoped to the call via a per-call ``webhook_secret``.
+    3. We POST to Telnyx ``/v2/calls`` with ``connection_id`` (the Call Control
+       Application) plus a ``webhook_url`` pointing back at this Voicebox
+       server, scoped to the call via a per-call ``webhook_secret``.
     4. Telnyx returns ``call_control_id`` immediately; we persist a
        ``TelnyxCall`` row mapping it to the generation and return to the caller.
     5. Telnyx fires ``call.answered`` asynchronously → ``POST /sinks/telnyx/webhook``.
-       The webhook handler waits for the generation to finish (if it hasn't yet),
-       then issues ``POST /calls/{id}/actions/playback_start`` with a media
-       URL pointing at the existing ``GET /audio/{generation_id}`` route.
+       The webhook acks immediately and finishes the work in a background task:
+       wait for the generation, then ``POST /calls/{id}/actions/playback_start``
+       with an ``audio_url`` pointing at ``GET /audio/{generation_id}``.
     6. If ``auto_hangup`` is set, ``playback.ended`` triggers a hangup.
 
 The user must expose their Voicebox server publicly (ngrok, Tailscale Funnel,
 Cloudflare Tunnel, etc.) and set ``public_base_url`` in Telnyx settings so
-both the outbound webhook_url and the playback media_url are reachable from
+both the outbound webhook_url and the playback audio_url are reachable from
 Telnyx. ``GET /audio/{generation_id}`` already exists and serves the file
 with the right Content-Type; we just hand Telnyx its public URL.
+
+Security note: that tunnel exposes *every* Voicebox route, not just the two
+Telnyx needs. Voicebox binds to 127.0.0.1 and has no request auth, so a naive
+``ngrok http 17493`` publishes the profile, generation, and settings APIs to
+the internet. The docs tell users to put a reverse proxy in front that only
+allows ``/sinks/telnyx/webhook`` and ``/audio/``.
 """
 
 from __future__ import annotations
@@ -30,7 +37,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
-import uuid
+import time
 from datetime import datetime, timezone
 from typing import Any
 
@@ -52,11 +59,24 @@ TELNYX_API_BASE = "https://api.telnyx.com/v2"
 # Wait this long for a generation to finish before giving up on the call.
 # TTS for short clips finishes in 1-3s; the cap protects against a wedged
 # worker leaving the line open in silence after the callee picks up.
+# This runs in a background task, not inside the webhook request, so it does
+# not hold Telnyx's webhook connection open.
 PLAYBACK_WAIT_SECS = 30
 POLL_INTERVAL_SECS = 0.5
 
+# Statuses that mean "call.answered has already been handled (or is being
+# handled right now)". Telnyx retries webhooks it considers failed, so the
+# answered handler claims the row before doing any slow work.
+_ANSWERED_CLAIMED = ("preparing", "playing", "playback_ended", "hangup", "failed")
+
+# Settings fields that must be present before we can dial.
+_REQUIRED_SETTINGS = ("api_key", "connection_id", "from_number", "public_base_url")
+
 
 SINGLETON_ID = 1
+
+# Strong refs to detached webhook tasks so the loop can't collect them midway.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
 # ─── Settings singleton ────────────────────────────────────────────────────
@@ -91,12 +111,27 @@ def update_settings(db: Session, patch: dict[str, Any]) -> DBTelnyxSettings:
     return row
 
 
-def is_configured(db: Session) -> bool:
-    """True if the Telnyx sink has enough to dial: api_key + from_number +
-    public_base_url. Used by the route and MCP tool to gate the "Call"
-    action behind a friendly setup hint instead of a 500."""
-    s = _get_or_create_settings_row(db)
-    return bool(s.enabled and s.api_key and s.from_number and s.public_base_url)
+def missing_settings(row: DBTelnyxSettings) -> list[str]:
+    """Names of the settings fields still needed before the sink can dial.
+
+    Single source of truth for "is this thing set up?" — both the request-time
+    gate and ``dial_and_play`` call it, so the two can't drift apart and let a
+    request past one check only to fail the other deeper in.
+    """
+    missing = [f for f in _REQUIRED_SETTINGS if not getattr(row, f, None)]
+    if not row.enabled:
+        # Explicit toggle: creds can be filled in while the sink stays off.
+        missing.append("enabled")
+    return missing
+
+
+def setup_hint(missing: list[str]) -> str:
+    """Error text naming exactly which fields are missing."""
+    return (
+        "Telnyx sink not configured (missing: "
+        + ", ".join(missing)
+        + "). Set these in Voicebox → Settings → Sinks → Telnyx."
+    )
 
 
 def mask_key(key: str | None) -> str:
@@ -109,6 +144,39 @@ def mask_key(key: str | None) -> str:
 
 
 # ─── Thin HTTP client ──────────────────────────────────────────────────────
+
+
+def _raise_for_telnyx_status(resp: httpx.Response, action: str) -> None:
+    """Turn a Telnyx error response into a ``ValueError`` carrying its detail.
+
+    Misconfiguration is the common failure here (wrong connection_id, number
+    not on the account, unreachable webhook URL), and Telnyx explains each one
+    in its JSON error body. ``raise_for_status`` would throw that away and the
+    caller would surface a bare 500, so unpack ``errors[].detail`` instead and
+    let the route map it to a 400 the user can act on.
+    """
+    if resp.status_code < 400:
+        return
+
+    detail = ""
+    try:
+        errors = resp.json().get("errors") or []
+        detail = "; ".join(
+            " ".join(
+                part
+                for part in (e.get("title"), e.get("detail"))
+                if part
+            )
+            for e in errors
+            if isinstance(e, dict)
+        )
+    except Exception:  # noqa: BLE001 - non-JSON error body
+        detail = (resp.text or "").strip()[:300]
+
+    raise ValueError(
+        f"Telnyx {action} failed ({resp.status_code})"
+        + (f": {detail}" if detail else "")
+    )
 
 
 class TelnyxClient:
@@ -140,34 +208,50 @@ class TelnyxClient:
         *,
         to: str,
         from_: str,
+        connection_id: str,
         webhook_url: str,
     ) -> dict[str, Any]:
-        """POST /calls — returns Telnyx's ``data`` payload."""
+        """POST /calls — returns Telnyx's ``data`` payload.
+
+        ``connection_id`` (the Call Control Application ID) is required by the
+        API alongside ``to`` and ``from``; omitting it fails the request.
+        """
         resp = await self._client.post(
             "/calls",
             json={
                 "to": to,
                 "from": from_,
+                "connection_id": connection_id,
                 "webhook_url": webhook_url,
             },
         )
-        resp.raise_for_status()
-        return resp.json()["data"]
+        _raise_for_telnyx_status(resp, "dial")
+        payload = resp.json()
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, dict):
+            raise ValueError(f"Unexpected Telnyx dial response: {payload!r}")
+        return data
 
-    async def playback_start(self, call_control_id: str, media_url: str) -> None:
+    async def playback_start(self, call_control_id: str, audio_url: str) -> None:
+        """Play a file on the call.
+
+        The API field is ``audio_url`` — there is no ``media_url`` on this
+        action (``media_name`` refers to previously uploaded media instead).
+        """
         resp = await self._client.post(
             f"/calls/{call_control_id}/actions/playback_start",
-            json={"media_url": media_url, "overlay": False},
+            json={"audio_url": audio_url},
         )
-        resp.raise_for_status()
+        _raise_for_telnyx_status(resp, "playback_start")
 
     async def hangup(self, call_control_id: str) -> None:
         resp = await self._client.post(
             f"/calls/{call_control_id}/actions/hangup",
         )
-        # 404 means the call already ended — not an error from our POV.
-        if resp.status_code not in (200, 404):
-            resp.raise_for_status()
+        # 404/422 mean the call already ended — not an error from our POV.
+        if resp.status_code in (404, 422):
+            return
+        _raise_for_telnyx_status(resp, "hangup")
 
     async def health(self) -> bool:
         """Verify the API key by listing phone numbers. Returns True on 200."""
@@ -185,6 +269,7 @@ async def dial_and_play(
     *,
     to: str,
     generation_id: str,
+    auto_hangup: bool | None,
     db: Session,
 ) -> DBTelnyxCall:
     """Dial ``to`` and arrange for ``generation_id`` to play once the call
@@ -193,11 +278,9 @@ async def dial_and_play(
     poll for generation completion (the webhook handler does that).
     """
     s = _get_or_create_settings_row(db)
-    if not (s.api_key and s.from_number and s.public_base_url):
-        raise ValueError(
-            "Telnyx sink not configured. Set api_key, from_number, and "
-            "public_base_url in Voicebox → Settings → Sinks → Telnyx."
-        )
+    missing = missing_settings(s)
+    if missing:
+        raise ValueError(setup_hint(missing))
 
     base = s.public_base_url.rstrip("/")
     webhook_secret = secrets.token_urlsafe(24)
@@ -207,10 +290,14 @@ async def dial_and_play(
         data = await client.create_call(
             to=to,
             from_=s.from_number,
+            connection_id=s.connection_id,
             webhook_url=webhook_url,
         )
 
-    call_control_id = data.get("call_control_id") or data.get("call_session_id")
+    # Only call_control_id addresses call-control actions. call_session_id is
+    # a different identifier and every playback/hangup against it would 404,
+    # so fail loudly here rather than dial a call we can never control.
+    call_control_id = data.get("call_control_id")
     if not call_control_id:
         raise ValueError(f"Telnyx returned no call_control_id: {data}")
 
@@ -222,7 +309,7 @@ async def dial_and_play(
         webhook_secret=webhook_secret,
         status="initiating",
         started_at=datetime.now(timezone.utc),
-        auto_hangup=bool(s.auto_hangup),
+        auto_hangup=bool(s.auto_hangup if auto_hangup is None else auto_hangup),
     )
     db.add(row)
     db.commit()
@@ -261,91 +348,149 @@ async def handle_telnyx_webhook(
         # or someone probing the webhook. Either way, nothing to do.
         return {"ok": True, "reason": "unknown_call"}
 
-    # Per-call webhook_secret is in the query string; we don't expose the
-    # webhook endpoint publicly without it. If the row has no secret stored
-    # (older rows), accept anyway — they were created before this gate.
-    if row.webhook_secret and row.webhook_secret != token:
+    # Per-call webhook_secret is in the query string. Compared in constant
+    # time, and a row with no stored secret fails closed — every row this
+    # code path creates has one, so a missing secret means something is wrong
+    # rather than "legacy row worth trusting".
+    if not row.webhook_secret or not secrets.compare_digest(
+        str(row.webhook_secret), str(token or "")
+    ):
         return {"ok": False, "reason": "bad_token"}
 
     if event_type == "call.answered":
-        await _on_call_answered(row, db)
+        # Claim the row before returning so a Telnyx retry (it re-POSTs when a
+        # webhook is slow or errors) can't start a second playback on the same
+        # call. The claim commits synchronously; the slow work runs detached.
+        if _claim_for_playback(row, db):
+            _spawn(_run_call_answered(row.call_control_id))
     elif event_type == "playback.ended":
-        await _on_playback_ended(row, db)
+        _spawn(_run_playback_ended(row.call_control_id))
     # Other events (call.initiated, call.hangup, call.bridge, etc.) are
     # ignored for now — we don't need them to fulfill the basic dial+play.
 
     return {"ok": True, "event": event_type, "call_control_id": call_control_id}
 
 
-async def _on_call_answered(row: DBTelnyxCall, db: Session) -> None:
-    """Call was picked up. Wait for the generation to finish, then issue
-    playback_start with the public audio URL."""
-    if row.status in ("playing", "playback_ended", "hangup", "failed"):
-        return  # already advanced past this state
+def _spawn(coro) -> None:
+    """Run a coroutine detached from the webhook request.
 
-    s = _get_or_create_settings_row(db)
-    if not (s.api_key and s.public_base_url):
-        row.status = "failed"
-        row.error = "Telnyx settings missing on webhook"
-        db.commit()
-        return
+    Telnyx expects a prompt ack and retries webhooks it thinks failed. Waiting
+    for a generation can take tens of seconds, so the handler must not do that
+    work inline. The task holds a reference until done so it isn't garbage
+    collected mid-flight.
+    """
+    task = asyncio.create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
 
-    # Wait for generation to complete. The /call endpoint returns immediately
-    # after Telnyx accepts the dial, so by the time the callee picks up the
-    # generation is usually already done. Polling here covers the edge case.
-    ok = await _wait_for_generation(row.generation_id, db)
-    if not ok:
-        row.status = "failed"
-        row.error = "Generation did not complete in time"
-        db.commit()
-        return
 
-    media_url = (
-        f"{s.public_base_url.rstrip('/')}/audio/{row.generation_id}"
-    )
+def _claim_for_playback(row: DBTelnyxCall, db: Session) -> bool:
+    """Transition the row into ``preparing`` exactly once.
+
+    Returns True for the caller that won the claim, False if another webhook
+    delivery already took it. Guards against Telnyx's at-least-once delivery
+    turning into two ``playback_start`` calls and doubled audio.
+    """
+    if row.status in _ANSWERED_CLAIMED:
+        return False
+    row.status = "preparing"
+    db.commit()
+    return True
+
+
+async def _run_call_answered(call_control_id: str) -> None:
+    """Background half of ``call.answered``: wait for audio, then play it.
+
+    Opens its own session — the webhook request's session is closed by the
+    time this runs.
+    """
+    db = next(get_db())
     try:
-        async with TelnyxClient(s.api_key) as client:
-            await client.playback_start(row.call_control_id, media_url)
-    except Exception as exc:
-        row.status = "failed"
-        row.error = f"playback_start failed: {exc}"
-        logger.exception("Telnyx playback_start failed for call %s", row.call_control_id)
+        row = (
+            db.query(DBTelnyxCall)
+            .filter(DBTelnyxCall.call_control_id == call_control_id)
+            .first()
+        )
+        if row is None:
+            return
+
+        s = _get_or_create_settings_row(db)
+        if not (s.api_key and s.public_base_url):
+            row.status = "failed"
+            row.error = "Telnyx settings missing on webhook"
+            db.commit()
+            return
+
+        # Wait for generation to complete. The /call endpoint returns
+        # immediately after Telnyx accepts the dial, so by the time the callee
+        # picks up the generation is usually already done. Polling here covers
+        # the edge case.
+        if not await _wait_for_generation(row.generation_id):
+            row.status = "failed"
+            row.error = "Generation did not complete in time"
+            db.commit()
+            return
+
+        audio_url = f"{s.public_base_url.rstrip('/')}/audio/{row.generation_id}"
+        try:
+            async with TelnyxClient(s.api_key) as client:
+                await client.playback_start(row.call_control_id, audio_url)
+        except Exception as exc:  # noqa: BLE001 - recorded on the row
+            row.status = "failed"
+            row.error = f"playback_start failed: {exc}"
+            logger.exception(
+                "Telnyx playback_start failed for call %s", row.call_control_id
+            )
+            db.commit()
+            return
+
+        row.status = "playing"
         db.commit()
-        return
-
-    row.status = "playing"
-    db.commit()
+    finally:
+        db.close()
 
 
-async def _on_playback_ended(row: DBTelnyxCall, db: Session) -> None:
-    """Playback finished. If auto_hangup is on, hang up the call."""
-    row.status = "playback_ended"
-    db.commit()
-
-    if not row.auto_hangup:
-        return
-
-    s = _get_or_create_settings_row(db)
-    if not s.api_key:
-        return
-
+async def _run_playback_ended(call_control_id: str) -> None:
+    """Background half of ``playback.ended``: hang up when configured to."""
+    db = next(get_db())
     try:
-        async with TelnyxClient(s.api_key) as client:
-            await client.hangup(row.call_control_id)
-        row.status = "hangup"
-        row.completed_at = datetime.now(timezone.utc)
-    except Exception as exc:
-        row.error = f"hangup failed: {exc}"
-        logger.exception("Telnyx hangup failed for call %s", row.call_control_id)
-    db.commit()
+        row = (
+            db.query(DBTelnyxCall)
+            .filter(DBTelnyxCall.call_control_id == call_control_id)
+            .first()
+        )
+        if row is None or row.status in ("playback_ended", "hangup"):
+            return
+
+        row.status = "playback_ended"
+        db.commit()
+
+        if not row.auto_hangup:
+            return
+
+        s = _get_or_create_settings_row(db)
+        if not s.api_key:
+            return
+
+        try:
+            async with TelnyxClient(s.api_key) as client:
+                await client.hangup(row.call_control_id)
+            row.status = "hangup"
+            row.completed_at = datetime.now(timezone.utc)
+        except Exception as exc:  # noqa: BLE001 - recorded on the row
+            row.error = f"hangup failed: {exc}"
+            logger.exception("Telnyx hangup failed for call %s", row.call_control_id)
+        db.commit()
+    finally:
+        db.close()
 
 
-async def _wait_for_generation(generation_id: str, db: Session) -> bool:
+async def _wait_for_generation(generation_id: str) -> bool:
     """Poll the Generation row until it leaves the "generating" state, or
     PLAYBACK_WAIT_SECS elapses. Uses a fresh session each poll to avoid stale
     ORM cache across the long sleep window."""
-    deadline = asyncio.get_event_loop().time() + PLAYBACK_WAIT_SECS
-    while asyncio.get_event_loop().time() < deadline:
+    deadline = time.monotonic() + PLAYBACK_WAIT_SECS
+    while time.monotonic() < deadline:
         # New session per check so we don't read cached state.
         fresh = next(get_db())
         try:
@@ -413,16 +558,14 @@ async def place_call(
         )
         used_generation_id = generation.id
 
+    # auto_hangup goes in at row creation — patching it afterwards left a
+    # window where an early playback.ended could read the sink default.
     call_row = await dial_and_play(
         to=to,
         generation_id=used_generation_id,
+        auto_hangup=auto_hangup,
         db=db,
     )
-
-    # Override the sink's default auto_hangup if the caller asked.
-    if auto_hangup is not None and auto_hangup != call_row.auto_hangup:
-        call_row.auto_hangup = bool(auto_hangup)
-        db.commit()
 
     return {
         "call_control_id": call_row.call_control_id,

--- a/backend/services/sinks.py
+++ b/backend/services/sinks.py
@@ -1,0 +1,434 @@
+"""Telnyx PSTN sink — dial a number and play a Voicebox generation on the call.
+
+Thin HTTP-only client against ``api.telnyx.com/v2``. No SDK dependency, no
+new requirements (httpx is already in ``requirements.txt``). Generation stays
+local; only the PSTN leg touches Telnyx.
+
+Flow:
+    1. Caller hits ``POST /call`` (REST) or ``voicebox.call`` (MCP).
+    2. We resolve a voice profile and either reuse an existing generation_id
+       or run ``generate_speech`` to produce one (status="generating").
+    3. We POST to Telnyx ``/v2/calls`` with ``webhook_url`` pointing back at
+       this Voicebox server, scoped to the call via a per-call ``webhook_secret``.
+    4. Telnyx returns ``call_control_id`` immediately; we persist a
+       ``TelnyxCall`` row mapping it to the generation and return to the caller.
+    5. Telnyx fires ``call.answered`` asynchronously → ``POST /sinks/telnyx/webhook``.
+       The webhook handler waits for the generation to finish (if it hasn't yet),
+       then issues ``POST /calls/{id}/actions/playback_start`` with a media
+       URL pointing at the existing ``GET /audio/{generation_id}`` route.
+    6. If ``auto_hangup`` is set, ``playback.ended`` triggers a hangup.
+
+The user must expose their Voicebox server publicly (ngrok, Tailscale Funnel,
+Cloudflare Tunnel, etc.) and set ``public_base_url`` in Telnyx settings so
+both the outbound webhook_url and the playback media_url are reachable from
+Telnyx. ``GET /audio/{generation_id}`` already exists and serves the file
+with the right Content-Type; we just hand Telnyx its public URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy.orm import Session
+
+from ..database import (
+    Generation as DBGeneration,
+    TelnyxCall as DBTelnyxCall,
+    TelnyxSettings as DBTelnyxSettings,
+    get_db,
+)
+from .. import models
+
+logger = logging.getLogger(__name__)
+
+
+TELNYX_API_BASE = "https://api.telnyx.com/v2"
+# Wait this long for a generation to finish before giving up on the call.
+# TTS for short clips finishes in 1-3s; the cap protects against a wedged
+# worker leaving the line open in silence after the callee picks up.
+PLAYBACK_WAIT_SECS = 30
+POLL_INTERVAL_SECS = 0.5
+
+
+SINGLETON_ID = 1
+
+
+# ─── Settings singleton ────────────────────────────────────────────────────
+
+
+def _get_or_create_settings_row(db: Session) -> DBTelnyxSettings:
+    row = db.query(DBTelnyxSettings).filter(DBTelnyxSettings.id == SINGLETON_ID).first()
+    if row is None:
+        row = DBTelnyxSettings(id=SINGLETON_ID)
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+    return row
+
+
+def get_settings(db: Session) -> DBTelnyxSettings:
+    return _get_or_create_settings_row(db)
+
+
+def update_settings(db: Session, patch: dict[str, Any]) -> DBTelnyxSettings:
+    row = _get_or_create_settings_row(db)
+    columns = type(row).__table__.columns
+    for key, value in patch.items():
+        col = columns.get(key)
+        if col is None:
+            continue
+        if value is None and not col.nullable:
+            continue
+        setattr(row, key, value)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def is_configured(db: Session) -> bool:
+    """True if the Telnyx sink has enough to dial: api_key + from_number +
+    public_base_url. Used by the route and MCP tool to gate the "Call"
+    action behind a friendly setup hint instead of a 500."""
+    s = _get_or_create_settings_row(db)
+    return bool(s.enabled and s.api_key and s.from_number and s.public_base_url)
+
+
+def mask_key(key: str | None) -> str:
+    """Mask all but the last 4 chars — same shape as the cloud settings UI."""
+    if not key:
+        return ""
+    if len(key) <= 4:
+        return "*" * len(key)
+    return "*" * (len(key) - 4) + key[-4:]
+
+
+# ─── Thin HTTP client ──────────────────────────────────────────────────────
+
+
+class TelnyxClient:
+    """Three endpoints, no SDK. Constructed per-call to avoid holding a
+    connection across the long-lived webhook wait."""
+
+    def __init__(self, api_key: str, *, timeout: float = 10.0):
+        self._client = httpx.AsyncClient(
+            base_url=TELNYX_API_BASE,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            timeout=timeout,
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "TelnyxClient":
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        await self._client.aclose()
+
+    async def create_call(
+        self,
+        *,
+        to: str,
+        from_: str,
+        webhook_url: str,
+    ) -> dict[str, Any]:
+        """POST /calls — returns Telnyx's ``data`` payload."""
+        resp = await self._client.post(
+            "/calls",
+            json={
+                "to": to,
+                "from": from_,
+                "webhook_url": webhook_url,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["data"]
+
+    async def playback_start(self, call_control_id: str, media_url: str) -> None:
+        resp = await self._client.post(
+            f"/calls/{call_control_id}/actions/playback_start",
+            json={"media_url": media_url, "overlay": False},
+        )
+        resp.raise_for_status()
+
+    async def hangup(self, call_control_id: str) -> None:
+        resp = await self._client.post(
+            f"/calls/{call_control_id}/actions/hangup",
+        )
+        # 404 means the call already ended — not an error from our POV.
+        if resp.status_code not in (200, 404):
+            resp.raise_for_status()
+
+    async def health(self) -> bool:
+        """Verify the API key by listing phone numbers. Returns True on 200."""
+        try:
+            resp = await self._client.get("/phone_numbers", params={"page[size]": 1})
+            return resp.status_code == 200
+        except httpx.HTTPError:
+            return False
+
+
+# ─── Dial-and-play orchestration ───────────────────────────────────────────
+
+
+async def dial_and_play(
+    *,
+    to: str,
+    generation_id: str,
+    db: Session,
+) -> DBTelnyxCall:
+    """Dial ``to`` and arrange for ``generation_id`` to play once the call
+    answers. Persists the pending call row and returns it. Caller is
+    responsible for ensuring the generation exists; this function does not
+    poll for generation completion (the webhook handler does that).
+    """
+    s = _get_or_create_settings_row(db)
+    if not (s.api_key and s.from_number and s.public_base_url):
+        raise ValueError(
+            "Telnyx sink not configured. Set api_key, from_number, and "
+            "public_base_url in Voicebox → Settings → Sinks → Telnyx."
+        )
+
+    base = s.public_base_url.rstrip("/")
+    webhook_secret = secrets.token_urlsafe(24)
+    webhook_url = f"{base}/sinks/telnyx/webhook?token={webhook_secret}"
+
+    async with TelnyxClient(s.api_key) as client:
+        data = await client.create_call(
+            to=to,
+            from_=s.from_number,
+            webhook_url=webhook_url,
+        )
+
+    call_control_id = data.get("call_control_id") or data.get("call_session_id")
+    if not call_control_id:
+        raise ValueError(f"Telnyx returned no call_control_id: {data}")
+
+    row = DBTelnyxCall(
+        call_control_id=call_control_id,
+        generation_id=generation_id,
+        to_number=to,
+        from_number=s.from_number,
+        webhook_secret=webhook_secret,
+        status="initiating",
+        started_at=datetime.now(timezone.utc),
+        auto_hangup=bool(s.auto_hangup),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ─── Webhook handler ──────────────────────────────────────────────────────
+
+
+async def handle_telnyx_webhook(
+    *,
+    body: dict[str, Any],
+    token: str | None,
+    db: Session,
+) -> dict[str, Any]:
+    """Dispatch a Telnyx webhook event. Returns a small ack dict for the
+    route to JSON back to Telnyx. Idempotent on ``call_control_id`` — replaying
+    an event won't re-fire playback on a call that's already past that state.
+    """
+    data = body.get("data") or {}
+    event_type = data.get("event_type") or ""
+    payload = data.get("payload") or {}
+    call_control_id = payload.get("call_control_id")
+
+    if not call_control_id:
+        return {"ok": True, "reason": "no_call_control_id"}
+
+    row = (
+        db.query(DBTelnyxCall)
+        .filter(DBTelnyxCall.call_control_id == call_control_id)
+        .first()
+    )
+    if row is None:
+        # Unknown call — could be a stray from before sink tracking existed,
+        # or someone probing the webhook. Either way, nothing to do.
+        return {"ok": True, "reason": "unknown_call"}
+
+    # Per-call webhook_secret is in the query string; we don't expose the
+    # webhook endpoint publicly without it. If the row has no secret stored
+    # (older rows), accept anyway — they were created before this gate.
+    if row.webhook_secret and row.webhook_secret != token:
+        return {"ok": False, "reason": "bad_token"}
+
+    if event_type == "call.answered":
+        await _on_call_answered(row, db)
+    elif event_type == "playback.ended":
+        await _on_playback_ended(row, db)
+    # Other events (call.initiated, call.hangup, call.bridge, etc.) are
+    # ignored for now — we don't need them to fulfill the basic dial+play.
+
+    return {"ok": True, "event": event_type, "call_control_id": call_control_id}
+
+
+async def _on_call_answered(row: DBTelnyxCall, db: Session) -> None:
+    """Call was picked up. Wait for the generation to finish, then issue
+    playback_start with the public audio URL."""
+    if row.status in ("playing", "playback_ended", "hangup", "failed"):
+        return  # already advanced past this state
+
+    s = _get_or_create_settings_row(db)
+    if not (s.api_key and s.public_base_url):
+        row.status = "failed"
+        row.error = "Telnyx settings missing on webhook"
+        db.commit()
+        return
+
+    # Wait for generation to complete. The /call endpoint returns immediately
+    # after Telnyx accepts the dial, so by the time the callee picks up the
+    # generation is usually already done. Polling here covers the edge case.
+    ok = await _wait_for_generation(row.generation_id, db)
+    if not ok:
+        row.status = "failed"
+        row.error = "Generation did not complete in time"
+        db.commit()
+        return
+
+    media_url = (
+        f"{s.public_base_url.rstrip('/')}/audio/{row.generation_id}"
+    )
+    try:
+        async with TelnyxClient(s.api_key) as client:
+            await client.playback_start(row.call_control_id, media_url)
+    except Exception as exc:
+        row.status = "failed"
+        row.error = f"playback_start failed: {exc}"
+        logger.exception("Telnyx playback_start failed for call %s", row.call_control_id)
+        db.commit()
+        return
+
+    row.status = "playing"
+    db.commit()
+
+
+async def _on_playback_ended(row: DBTelnyxCall, db: Session) -> None:
+    """Playback finished. If auto_hangup is on, hang up the call."""
+    row.status = "playback_ended"
+    db.commit()
+
+    if not row.auto_hangup:
+        return
+
+    s = _get_or_create_settings_row(db)
+    if not s.api_key:
+        return
+
+    try:
+        async with TelnyxClient(s.api_key) as client:
+            await client.hangup(row.call_control_id)
+        row.status = "hangup"
+        row.completed_at = datetime.now(timezone.utc)
+    except Exception as exc:
+        row.error = f"hangup failed: {exc}"
+        logger.exception("Telnyx hangup failed for call %s", row.call_control_id)
+    db.commit()
+
+
+async def _wait_for_generation(generation_id: str, db: Session) -> bool:
+    """Poll the Generation row until it leaves the "generating" state, or
+    PLAYBACK_WAIT_SECS elapses. Uses a fresh session each poll to avoid stale
+    ORM cache across the long sleep window."""
+    deadline = asyncio.get_event_loop().time() + PLAYBACK_WAIT_SECS
+    while asyncio.get_event_loop().time() < deadline:
+        # New session per check so we don't read cached state.
+        fresh = next(get_db())
+        try:
+            gen = fresh.query(DBGeneration).filter_by(id=generation_id).first()
+            if gen is None:
+                return False
+            status = gen.status or "completed"
+            if status == "completed":
+                return True
+            if status == "failed":
+                return False
+        finally:
+            fresh.close()
+        await asyncio.sleep(POLL_INTERVAL_SECS)
+    return False
+
+
+# ─── Top-level call entry (used by REST + MCP) ──────────────────────────────
+
+
+async def place_call(
+    *,
+    to: str,
+    text: str | None,
+    generation_id: str | None,
+    profile_id: str,
+    profile_name: str,
+    engine: str | None,
+    language: str | None,
+    personality: bool,
+    auto_hangup: bool | None,
+    db: Session,
+) -> dict[str, Any]:
+    """Resolve the generation (existing or fresh), dial the call, return the
+    shape both ``POST /call`` and ``voicebox.call`` return."""
+    from ..routes.generations import generate_speech
+
+    if bool(text) == bool(generation_id):
+        raise ValueError(
+            "Pass exactly one of `text` (generate inline) or `generation_id` "
+            "(use an existing generation)."
+        )
+
+    if generation_id is not None:
+        gen = db.query(DBGeneration).filter_by(id=generation_id).first()
+        if gen is None:
+            raise ValueError(f"Generation '{generation_id}' not found.")
+        if (gen.status or "completed") != "completed":
+            raise ValueError(
+                f"Generation '{generation_id}' is not completed (status: "
+                f"{gen.status}). Wait for it to finish before dialing."
+            )
+        used_generation_id = generation_id
+    else:
+        # Generate inline using the same path POST /generate takes.
+        generation = await generate_speech(
+            models.GenerationRequest(
+                profile_id=profile_id,
+                text=text or "",
+                language=language or "en",
+                engine=engine,
+                personality=personality,
+            ),
+            db,
+        )
+        used_generation_id = generation.id
+
+    call_row = await dial_and_play(
+        to=to,
+        generation_id=used_generation_id,
+        db=db,
+    )
+
+    # Override the sink's default auto_hangup if the caller asked.
+    if auto_hangup is not None and auto_hangup != call_row.auto_hangup:
+        call_row.auto_hangup = bool(auto_hangup)
+        db.commit()
+
+    return {
+        "call_control_id": call_row.call_control_id,
+        "status": call_row.status,
+        "generation_id": used_generation_id,
+        "profile": profile_name,
+        "to": to,
+        "poll_url": f"/generate/{used_generation_id}/status",
+    }

--- a/backend/services/sinks.py
+++ b/backend/services/sinks.py
@@ -374,10 +374,11 @@ async def handle_telnyx_webhook(
 def _spawn(coro) -> None:
     """Run a coroutine detached from the webhook request.
 
-    Telnyx expects a prompt ack and retries webhooks it thinks failed. Waiting
-    for a generation can take tens of seconds, so the handler must not do that
-    work inline. The task holds a reference until done so it isn't garbage
-    collected mid-flight.
+    Telnyx wants a 2xx within 2000 ms and retries the delivery otherwise, so
+    the handler acknowledges first and does the slow part here. Waiting for a
+    generation can take tens of seconds; doing that inline guaranteed a
+    timeout, a retry, and a second playback on the same call. The task holds a
+    reference until done so it isn't garbage collected mid-flight.
     """
     task = asyncio.create_task(coro)
     _BACKGROUND_TASKS.add(task)

--- a/backend/tests/test_telnyx_sink.py
+++ b/backend/tests/test_telnyx_sink.py
@@ -1,0 +1,236 @@
+"""Tests for the Telnyx PSTN sink's wire contract and webhook handling.
+
+The two bugs these pin first are the ones that made the sink a no-op against
+the live API: ``POST /v2/calls`` requires ``connection_id`` alongside ``to``
+and ``from``, and the playback action's field is ``audio_url`` (there is no
+``media_url`` on ``playback_start``). Both failed with a 422 that the old
+code surfaced as an opaque 500, so the request bodies are asserted directly.
+
+The rest cover the webhook gate: a per-call token compared in constant time,
+and single-fire playback under Telnyx's at-least-once webhook delivery.
+"""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from backend.services import sinks  # noqa: E402
+
+
+class _Row:
+    """Minimal stand-in for the TelnyxSettings/TelnyxCall ORM rows."""
+
+    def __init__(self, **kw):
+        for key, value in kw.items():
+            setattr(self, key, value)
+
+
+class _FakeDB:
+    """Records commits so claim-ordering can be asserted without SQLite."""
+
+    def __init__(self):
+        self.commits = 0
+
+    def commit(self):
+        self.commits += 1
+
+
+def _client_with(capture, *, status=200, json_body=None):
+    """Build a TelnyxClient whose transport records the outgoing request."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        capture["url"] = str(request.url)
+        capture["body"] = request.read().decode() or ""
+        return httpx.Response(status, json=json_body if json_body is not None else {})
+
+    client = sinks.TelnyxClient("test-key")
+    client._client = httpx.AsyncClient(
+        base_url=sinks.TELNYX_API_BASE,
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer test-key"},
+    )
+    return client
+
+
+# ─── Wire contract ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_call_sends_connection_id():
+    """connection_id is required by the Dial API; omitting it 422s every call."""
+    capture = {}
+    body = {"data": {"call_control_id": "ccid-1"}}
+    async with _client_with(capture, json_body=body) as client:
+        data = await client.create_call(
+            to="+15551234567",
+            from_="+15557654321",
+            connection_id="conn-abc",
+            webhook_url="https://example.test/sinks/telnyx/webhook?token=t",
+        )
+
+    import json
+
+    sent = json.loads(capture["body"])
+    assert sent["connection_id"] == "conn-abc"
+    assert sent["to"] == "+15551234567"
+    assert sent["from"] == "+15557654321"
+    assert data["call_control_id"] == "ccid-1"
+
+
+@pytest.mark.asyncio
+async def test_playback_uses_audio_url_not_media_url():
+    """The playback_start action takes `audio_url`; `media_url` is not a field."""
+    capture = {}
+    async with _client_with(capture) as client:
+        await client.playback_start("ccid-1", "https://example.test/audio/gen-1")
+
+    import json
+
+    sent = json.loads(capture["body"])
+    assert sent["audio_url"] == "https://example.test/audio/gen-1"
+    assert "media_url" not in sent
+
+
+@pytest.mark.asyncio
+async def test_telnyx_error_detail_is_surfaced():
+    """A 422 should carry Telnyx's explanation, not collapse into a bare 500."""
+    capture = {}
+    errors = {"errors": [{"title": "Invalid connection", "detail": "not found"}]}
+    async with _client_with(capture, status=422, json_body=errors) as client:
+        with pytest.raises(ValueError) as exc:
+            await client.playback_start("ccid-1", "https://example.test/audio/g")
+
+    assert "Invalid connection" in str(exc.value)
+    assert "not found" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_hangup_tolerates_already_ended_call():
+    """404/422 on hangup means the call is already gone — not an error."""
+    capture = {}
+    async with _client_with(capture, status=404) as client:
+        await client.hangup("ccid-1")  # must not raise
+
+
+# ─── Configuration gate ────────────────────────────────────────────────────
+
+
+def test_missing_settings_names_each_gap():
+    row = _Row(
+        enabled=True,
+        api_key="k",
+        connection_id=None,
+        from_number=None,
+        public_base_url="https://x.test",
+    )
+    assert sinks.missing_settings(row) == ["connection_id", "from_number"]
+
+
+def test_missing_settings_reports_disabled_sink():
+    """Fully credentialed but toggled off still can't dial — say so."""
+    row = _Row(
+        enabled=False,
+        api_key="k",
+        connection_id="c",
+        from_number="+15551234567",
+        public_base_url="https://x.test",
+    )
+    assert sinks.missing_settings(row) == ["enabled"]
+
+
+def test_fully_configured_sink_has_no_gaps():
+    row = _Row(
+        enabled=True,
+        api_key="k",
+        connection_id="c",
+        from_number="+15551234567",
+        public_base_url="https://x.test",
+    )
+    assert sinks.missing_settings(row) == []
+
+
+def test_mask_key_keeps_only_last_four():
+    assert sinks.mask_key("abcdefghij") == "******ghij"
+    assert sinks.mask_key(None) == ""
+
+
+# ─── Webhook gate ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_wrong_token():
+    row = _Row(call_control_id="ccid-1", webhook_secret="right", status="initiating")
+    db = _FakeDB()
+    db.query = lambda *a, **k: _Query(row)
+
+    result = await sinks.handle_telnyx_webhook(
+        body={"data": {"event_type": "call.answered",
+                       "payload": {"call_control_id": "ccid-1"}}},
+        token="wrong",
+        db=db,
+    )
+    assert result == {"ok": False, "reason": "bad_token"}
+    assert row.status == "initiating"  # never claimed
+
+
+@pytest.mark.asyncio
+async def test_webhook_fails_closed_when_row_has_no_secret():
+    """A row without a stored secret must not be treated as trusted."""
+    row = _Row(call_control_id="ccid-1", webhook_secret=None, status="initiating")
+    db = _FakeDB()
+    db.query = lambda *a, **k: _Query(row)
+
+    result = await sinks.handle_telnyx_webhook(
+        body={"data": {"event_type": "call.answered",
+                       "payload": {"call_control_id": "ccid-1"}}},
+        token=None,
+        db=db,
+    )
+    assert result == {"ok": False, "reason": "bad_token"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_call_is_acked_without_work():
+    db = _FakeDB()
+    db.query = lambda *a, **k: _Query(None)
+
+    result = await sinks.handle_telnyx_webhook(
+        body={"data": {"event_type": "call.answered",
+                       "payload": {"call_control_id": "nope"}}},
+        token="whatever",
+        db=db,
+    )
+    assert result == {"ok": True, "reason": "unknown_call"}
+
+
+def test_playback_claim_fires_once():
+    """Telnyx retries webhooks; only the first delivery may start playback."""
+    row = _Row(status="initiating")
+    db = _FakeDB()
+
+    assert sinks._claim_for_playback(row, db) is True
+    assert row.status == "preparing"
+    # A retry arriving while the first is still preparing must not double-fire.
+    assert sinks._claim_for_playback(row, db) is False
+
+
+@pytest.mark.parametrize("status", ["preparing", "playing", "playback_ended", "hangup", "failed"])
+def test_playback_claim_refused_once_advanced(status):
+    assert sinks._claim_for_playback(_Row(status=status), _FakeDB()) is False
+
+
+class _Query:
+    """Chainable query stub returning a fixed row."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._row

--- a/docs/content/docs/overview/meta.json
+++ b/docs/content/docs/overview/meta.json
@@ -13,6 +13,7 @@
     "preset-voices",
     "voice-personalities",
     "mcp-server",
+    "sinks",
     "stories-editor",
     "recording-transcription",
     "generation-history",

--- a/docs/content/docs/overview/sinks.mdx
+++ b/docs/content/docs/overview/sinks.mdx
@@ -184,19 +184,22 @@ whatever proxy or tunnel sits in front of Voicebox. It is scoped to one call
 and useless once that call ends, but it is not a long-lived secret and
 shouldn't be treated as one.
 
-For full webhook signature verification against Telnyx's Ed25519 signature
-header, see the
-[Telnyx webhook docs](https://developers.telnyx.com/docs/api/v2/webhooks).
-That is the stronger gate and remains a follow-up.
+The stronger gate is Telnyx's own signature. Every event carries
+`telnyx-signature-ed25519` and `telnyx-timestamp`, signed over
+`{timestamp}|{raw body}` and verifiable against your account's public key
+(Mission Control Portal → Keys & Credentials → Public Key). Verifying that,
+and rejecting timestamps older than five minutes, authenticates the sender
+rather than just scoping the URL. It needs an Ed25519 dependency and a public
+key setting, so it remains a follow-up.
 
 ## Webhook delivery and retries
 
-Telnyx delivers webhooks at least once and retries anything it considers
-failed, so the receiver acknowledges immediately and finishes the work in the
-background. On `call.answered` it claims the call row before returning; a
-retried delivery sees the claim and exits instead of starting a second
-`playback_start`, which would otherwise play the audio twice on the same
-call.
+Telnyx expects a 2xx within 2000 ms and retries the delivery otherwise, so the
+receiver acknowledges immediately and finishes the work in the background. On
+`call.answered` it claims the call row before returning; a retried delivery
+sees the claim and exits instead of starting a second `playback_start`.
+Without the claim, consecutive play commands queue on the Telnyx side and the
+callee hears the same clip repeated.
 
 Waiting for a still-running generation (up to 30s) happens in that background
 task, never inside the webhook request.

--- a/docs/content/docs/overview/sinks.mdx
+++ b/docs/content/docs/overview/sinks.mdx
@@ -33,9 +33,9 @@ Generation stays local. Only the PSTN leg touches Telnyx.
 
 1. Sign up at [telnyx.com](https://telnyx.com) and grab an API key.
 2. Buy a phone number (~$1/mo) — you'll use this as the caller ID.
-3. Make sure your account has a **Call Control Application** set up. The
-   Telnyx console walks you through this; the API key from that application
-   is the one Voicebox needs.
+3. Create a **Call Control Application** in the Telnyx console and copy its
+   ID. This is the `connection_id`, and the Dial API rejects any call that
+   doesn't carry it. Assign the number you bought to this application.
 
 ### 2. Expose your Voicebox server publicly
 
@@ -50,6 +50,22 @@ The public URL is the `public_base_url` setting in Voicebox — Telnyx will
 POST call-control events to `{public_base_url}/sinks/telnyx/webhook` and
 fetch playback audio from `{public_base_url}/audio/{generation_id}`.
 
+<Callout type="warn">
+  **A bare tunnel publishes your whole Voicebox install.** Voicebox binds to
+  127.0.0.1 and has no request authentication, because it assumes only your
+  machine can reach it. Pointing a tunnel at port 17493 breaks that
+  assumption: every route goes public, including the profile, generation,
+  and settings APIs, and anyone with the URL can read or delete your voice
+  data.
+
+  Telnyx only needs two paths. Put a reverse proxy in front of the tunnel
+  that allows `POST /sinks/telnyx/webhook` and `GET /audio/` and rejects
+  everything else. If your tunnel supports IP allowlisting, restrict it to
+  [Telnyx's published IP ranges](https://developers.telnyx.com/docs/voice/programmable-voice/webhooks)
+  as well. Treat a wide-open tunnel as a temporary debugging step, not a
+  setup you leave running.
+</Callout>
+
 ### 3. Configure Voicebox
 
 Open **Voicebox → Settings → Sinks → Telnyx** and fill in:
@@ -57,22 +73,28 @@ Open **Voicebox → Settings → Sinks → Telnyx** and fill in:
 | Field | Value |
 | --- | --- |
 | `api_key` | Your Telnyx API key |
+| `connection_id` | The Call Control Application ID from step 1 |
 | `from_number` | The number you bought, in E.164 (`+1...`) |
 | `public_base_url` | The tunnel URL from step 2 |
 | `default_profile` | The voice profile to use when a caller doesn't specify one |
 | `auto_hangup` | Whether to hang up the call after playback ends (default: on) |
+| `enabled` | Master switch — the sink refuses to dial until this is on |
 
 Hit **Test connection** — Voicebox will ping Telnyx and tell you if the key
 is valid.
+
+`GET /sinks/telnyx` returns a `missing` array listing any of these that are
+still unset, so you can see what's outstanding before placing a call.
 
 ## Using the sink
 
 ### From the UI
 
-When the Telnyx sink is configured, a **Call** button appears on each
-generation card next to Play and Speak. Click it, enter a destination
-number, and dial. The generation plays on the call once the callee picks
-up.
+<Callout type="info">
+  Not shipped yet. The **Call** action on the generation card is a follow-up;
+  this release adds the backend surface only. Use the MCP tool or the REST
+  endpoint below in the meantime.
+</Callout>
 
 ### From any MCP-aware agent
 
@@ -152,12 +174,32 @@ asynchronously via the webhook.
 Each call carries a random `webhook_secret` token embedded in the
 `webhook_url`. Telnyx includes it back as the `token` query param when it
 calls the webhook; Voicebox rejects any webhook whose token doesn't match
-the row for that `call_control_id`. This stops a third party who knows the
-webhook URL from triggering playback on a live call.
+the row for that `call_control_id`. The comparison is constant-time, and a
+call row without a stored secret is rejected rather than trusted. This stops
+a third party who knows the webhook URL from triggering playback on a live
+call.
 
-For full webhook signature verification against Telnyx's HMAC header, see
-the [Telnyx webhook docs](https://developers.telnyx.com/docs/api/v2/webhooks).
-This is a follow-up hardening step tracked in the sink's TODO.
+The token travels in the query string, so it lands in the access logs of
+whatever proxy or tunnel sits in front of Voicebox. It is scoped to one call
+and useless once that call ends, but it is not a long-lived secret and
+shouldn't be treated as one.
+
+For full webhook signature verification against Telnyx's Ed25519 signature
+header, see the
+[Telnyx webhook docs](https://developers.telnyx.com/docs/api/v2/webhooks).
+That is the stronger gate and remains a follow-up.
+
+## Webhook delivery and retries
+
+Telnyx delivers webhooks at least once and retries anything it considers
+failed, so the receiver acknowledges immediately and finishes the work in the
+background. On `call.answered` it claims the call row before returning; a
+retried delivery sees the claim and exits instead of starting a second
+`playback_start`, which would otherwise play the audio twice on the same
+call.
+
+Waiting for a still-running generation (up to 30s) happens in that background
+task, never inside the webhook request.
 
 ## What this does not do
 
@@ -192,8 +234,16 @@ This is a follow-up hardening step tracked in the sink's TODO.
 - Look for the call in the Telnyx console's Call Control logs — it shows
   the webhook URL Telnyx actually attempted to reach and the response code.
 
-### "Telnyx sink not configured"
+### "Telnyx sink not configured (missing: ...)"
 
-The Settings UI prevents this, but the API will return a 400 with this
-message if you hit `POST /call` before configuring `api_key`,
-`from_number`, and `public_base_url`. Set all three and try again.
+`POST /call` returns a 400 naming the fields that are still unset. The most
+common one is `enabled` — credentials saved but the master switch left off —
+followed by `connection_id`. Fill in what the message lists and retry.
+
+### The call never dials, and the error mentions the connection
+
+Telnyx rejects a dial whose `connection_id` doesn't exist, isn't a Call
+Control Application, or doesn't own the `from_number`. Confirm in the console
+that the application ID matches the one in Voicebox and that your number is
+assigned to that application. Voicebox passes Telnyx's own error text through,
+so the 400 detail tells you which of the three it is.

--- a/docs/content/docs/overview/sinks.mdx
+++ b/docs/content/docs/overview/sinks.mdx
@@ -1,0 +1,199 @@
+---
+title: "Sinks"
+description: "Take a Voicebox generation and play it on a real phone call via Telnyx."
+---
+
+## Overview
+
+Voicebox today runs the full voice I/O loop locally — clone, generate,
+dictate, agent speech — but stops at the speaker. **Sinks** are the bridge
+from a local generation to an external destination. The first sink ships in
+this release: **Telnyx**, which dials a real phone number and plays the
+generation on the call.
+
+Generation stays local. Only the PSTN leg touches Telnyx.
+
+<Callout type="info">
+  Sinks are new and currently opt-in. The Telnyx sink is the reference
+  implementation of the `Sink` pattern. Future sinks (Apple Notes, Obsidian,
+  generic webhook) will follow the same shape.
+</Callout>
+
+## Why Telnyx
+
+- Carrier-grade PSTN, sub-second call setup, global reach.
+- Pay-per-minute, no monthly minimums — fits a hobbyist OSS install.
+- The API is REST + webhooks, no SIP stack required on the client side.
+- A user with a Telnyx account and a $1/mo number can dial out from
+  Voicebox in under five minutes.
+
+## Setup
+
+### 1. Get Telnyx credentials
+
+1. Sign up at [telnyx.com](https://telnyx.com) and grab an API key.
+2. Buy a phone number (~$1/mo) — you'll use this as the caller ID.
+3. Make sure your account has a **Call Control Application** set up. The
+   Telnyx console walks you through this; the API key from that application
+   is the one Voicebox needs.
+
+### 2. Expose your Voicebox server publicly
+
+Telnyx needs to reach your local Voicebox server to fire call-control
+webhooks. Pick any tunnel you like:
+
+- **ngrok**: `ngrok http 17493` → copy the `https://*.ngrok.app` URL.
+- **Tailscale Funnel**: `tailscale funnel 17493` → copy the funnel URL.
+- **Cloudflare Tunnel**: `cloudflared tunnel --url http://localhost:17493`.
+
+The public URL is the `public_base_url` setting in Voicebox — Telnyx will
+POST call-control events to `{public_base_url}/sinks/telnyx/webhook` and
+fetch playback audio from `{public_base_url}/audio/{generation_id}`.
+
+### 3. Configure Voicebox
+
+Open **Voicebox → Settings → Sinks → Telnyx** and fill in:
+
+| Field | Value |
+| --- | --- |
+| `api_key` | Your Telnyx API key |
+| `from_number` | The number you bought, in E.164 (`+1...`) |
+| `public_base_url` | The tunnel URL from step 2 |
+| `default_profile` | The voice profile to use when a caller doesn't specify one |
+| `auto_hangup` | Whether to hang up the call after playback ends (default: on) |
+
+Hit **Test connection** — Voicebox will ping Telnyx and tell you if the key
+is valid.
+
+## Using the sink
+
+### From the UI
+
+When the Telnyx sink is configured, a **Call** button appears on each
+generation card next to Play and Speak. Click it, enter a destination
+number, and dial. The generation plays on the call once the callee picks
+up.
+
+### From any MCP-aware agent
+
+```
+await voicebox.call({
+  to: "+15551234567",
+  profile: "Morgan",
+  text: "Deploy complete."
+});
+```
+
+Or play an existing generation:
+
+```
+await voicebox.call({
+  to: "+15551234567",
+  generation_id: "abc-123..."
+});
+```
+
+### From a shell script or any non-MCP client
+
+```bash
+curl -X POST http://127.0.0.1:17493/call \
+  -H "Content-Type: application/json" \
+  -H "X-Voicebox-Client-Id: my-script" \
+  -d '{
+    "to": "+15551234567",
+    "profile": "Morgan",
+    "text": "Deploy complete."
+  }'
+```
+
+Returns:
+
+```json
+{
+  "call_control_id": "abc...",
+  "status": "dialing",
+  "generation_id": "xyz...",
+  "profile": "Morgan",
+  "to": "+15551234567",
+  "poll_url": "/generate/xyz.../status"
+}
+```
+
+## How it works
+
+```
+Caller → POST /call (or voicebox.call)
+  ↓
+Voicebox resolves profile + generation (existing or fresh)
+  ↓
+Voicebox POST /v2/calls to Telnyx with webhook_url
+  ↓
+Telnyx returns call_control_id immediately
+  ↓
+Voicebox persists TelnyxCall row, returns to caller
+  ↓ (async)
+Callee picks up → Telnyx POST /sinks/telnyx/webhook (call.answered)
+  ↓
+Voicebox waits for generation to finish if needed
+  ↓
+Voicebox POST /v2/calls/{id}/actions/playback_start with media_url
+  ↓
+Telnyx fetches {public_base_url}/audio/{generation_id} and plays it
+  ↓
+If auto_hangup: Telnyx POST /sinks/telnyx/webhook (playback.ended) → hangup
+```
+
+The caller does not wait for the callee to pick up. The MCP/REST call
+returns as soon as Telnyx accepts the dial; playback happens
+asynchronously via the webhook.
+
+## Per-call webhook secret
+
+Each call carries a random `webhook_secret` token embedded in the
+`webhook_url`. Telnyx includes it back as the `token` query param when it
+calls the webhook; Voicebox rejects any webhook whose token doesn't match
+the row for that `call_control_id`. This stops a third party who knows the
+webhook URL from triggering playback on a live call.
+
+For full webhook signature verification against Telnyx's HMAC header, see
+the [Telnyx webhook docs](https://developers.telnyx.com/docs/api/v2/webhooks).
+This is a follow-up hardening step tracked in the sink's TODO.
+
+## What this does not do
+
+- **No inbound calls.** The sink dials out only. Inbound call handling
+  (use Voicebox as the agent voice on an incoming call) is on the roadmap
+  as a separate sink.
+- **No streaming audio over the call.** Playback uses Telnyx's
+  `playback_start` action with a media URL — Telnyx fetches the WAV file
+  over HTTPS. No SIPREC, no bidirectional audio.
+- **No Telnyx SDK.** Three HTTP endpoints via `httpx`, which is already in
+  `requirements.txt`. No new dependencies, no PyInstaller bundling changes.
+- **No cloud TTS.** Generation stays local. Only the PSTN leg touches
+  Telnyx.
+
+## Troubleshooting
+
+### Call connects but no audio plays
+
+- Check that `public_base_url` is reachable from the public internet. Telnyx
+  needs to fetch `{public_base_url}/audio/{generation_id}`.
+- Open `{public_base_url}/audio/{generation_id}` in a browser — if it
+  404s, the tunnel isn't pointing at Voicebox or the generation_id is wrong.
+- Check Voicebox logs for `playback_start failed` — Telnyx returns a 4xx
+  if the call is no longer in the `answered` state by the time we issue it.
+
+### Webhook never fires
+
+- Telnyx won't POST to `http://` URLs, only `https://`. Make sure your
+  tunnel gives you a TLS endpoint.
+- Check that `public_base_url` has no trailing slash. Voicebox appends
+  `/sinks/telnyx/webhook?token=...` to it.
+- Look for the call in the Telnyx console's Call Control logs — it shows
+  the webhook URL Telnyx actually attempted to reach and the response code.
+
+### "Telnyx sink not configured"
+
+The Settings UI prevents this, but the API will return a 400 with this
+message if you hit `POST /call` before configuring `api_key`,
+`from_number`, and `public_base_url`. Set all three and try again.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ soundfile
 librosa
 python-multipart
 huggingface_hub
+httpx


### PR DESCRIPTION
# Add Telnyx PSTN sink: call any phone and play generations on the line

## What this adds

Voicebox today runs the full voice I/O loop locally (clone, generate, dictate,
agent speech) but stops at the speaker. There's no way to take a generation and
play it on a real phone call. The roadmap lists "Pipeline routing … webhook +
MCP sinks" and "Platform sinks: Apple Notes, Obsidian, and other opt-in
integrations."

This PR ships the first reference sink, Telnyx, and the convention future sinks
follow. Generation stays local; only the PSTN leg touches the carrier.

## What's in the box

- **`voicebox.call` MCP tool**: dial a number and play a generation on the call.
  Mirrors `voicebox.speak`'s shape (profile resolution, personality rewrite,
  engine override).
- **`POST /call`**: REST wrapper, same pattern as `POST /speak`.
- **`POST /sinks/telnyx/webhook`**: receives Telnyx `call.answered` and
  `playback.ended`. Per-call webhook secret stops third-party triggering.
- **`GET/PUT /sinks/telnyx`**: settings CRUD (api_key masked in responses,
  plus a `missing` array naming any unset required field).
- **`GET /sinks/telnyx/health`**: verify the API key against Telnyx.
- **`TelnyxSettings` and `TelnyxCalls` SQLite tables**: created idempotently on
  first boot via the existing migration pattern.
- **Docs**: new `sinks.mdx` page in the overview.
- **Tests**: `backend/tests/test_telnyx_sink.py`, 17 cases.

## Flow

```
Caller → POST /call (or voicebox.call)
  → Voicebox resolves profile + generation (existing or fresh via /generate)
  → Voicebox POST /v2/calls to Telnyx with connection_id + webhook_url + per-call secret
  → Telnyx returns call_control_id immediately
  → Voicebox persists TelnyxCall row, returns to caller (status="dialing")

Callee picks up → Telnyx POST /sinks/telnyx/webhook (call.answered)
  → Voicebox verifies webhook_secret, claims the row, acks immediately
  → background task waits for the generation to finish (if still "generating")
  → POST /v2/calls/{id}/actions/playback_start with audio_url
  → Telnyx fetches {public_base_url}/audio/{generation_id} and plays it

If auto_hangup → Telnyx POST /sinks/telnyx/webhook (playback.ended)
  → Voicebox POST /v2/calls/{id}/actions/hangup
```

The caller does not block on the callee picking up. The MCP/REST call returns as
soon as Telnyx accepts the dial; playback happens asynchronously via the webhook.

Telnyx wants a 2xx within 2000 ms and retries otherwise, and it queues
consecutive play commands, so the webhook acknowledges before doing any slow
work and claims the call row so a retried delivery can't start a second
playback on the same call.

## HTTP-only, no SDK

Uses `httpx` against `api.telnyx.com/v2`. Three endpoints: `POST /calls`,
`POST /calls/{id}/actions/playback_start`, `POST /calls/{id}/actions/hangup`.
No `telnyx` package, no PyInstaller bundling changes.

`httpx` was already imported at module scope by `services/cloud.py` but was
never declared, so this PR adds it to `requirements.txt`.

## Config

- Settings → Sinks → Telnyx: API key, Call Control Application ID
  (`connection_id`), from-number, `public_base_url` (ngrok/Funnel URL), default
  voice profile, auto-hangup toggle, and an `enabled` master switch.
- Per-sink config, not global env, matching the pattern Apple Notes / Obsidian
  sinks will need.

## Security note on `public_base_url`

Telnyx has to reach this server, but Voicebox binds to 127.0.0.1 and has no
request authentication. A bare `ngrok http 17493` therefore publishes every
route, including the profile, generation, and settings APIs. The docs call this
out and tell users to front the tunnel with a proxy that allows only
`POST /sinks/telnyx/webhook` and `GET /audio/`.

Worth a maintainer opinion: if sinks become a common pattern, Voicebox may want
a first-class "expose these paths only" mode rather than leaving each user to
build it.

## What this PR does NOT do

- No inbound calls (separate sink, separate PR).
- No streaming audio over the call. Uses `playback_start` with an audio URL.
  No SIPREC, no bidirectional audio.
- No Telnyx SDK.
- No move of TTS to the cloud. Generation stays local.
- No frontend UI changes. The backend surface (REST + MCP) is complete; the
  "Call" button on the generation card is a small follow-up PR, and the docs
  say so rather than describing a button that isn't there.
- No Telnyx webhook signature verification yet. See open question 1.

## Files

- `backend/database/models.py`: `TelnyxSettings` + `TelnyxCall` ORM
- `backend/database/__init__.py`: re-exports
- `backend/database/migrations.py`: `_migrate_telnyx_settings`,
  `_migrate_telnyx_calls` (idempotent CREATE TABLE, plus a `connection_id`
  backfill for anyone who ran an earlier build of this branch)
- `backend/models.py`: `CallRequest`, `CallResponse`, `TelnyxSettingsResponse`,
  `TelnyxSettingsUpdate` Pydantic models
- `backend/services/sinks.py`: `TelnyxClient` (thin httpx wrapper) +
  `dial_and_play`, `handle_telnyx_webhook`, `place_call` orchestration
- `backend/routes/sinks.py`: `POST /call`, settings CRUD, webhook receiver
- `backend/routes/__init__.py`: register the new router
- `backend/mcp_server/tools.py`: `voicebox.call` tool, next to `voicebox.speak`
- `backend/tests/test_telnyx_sink.py`: wire contract, config gate, webhook gate
- `requirements.txt`: declare `httpx`
- `docs/content/docs/overview/sinks.mdx`: setup + usage guide
- `docs/content/docs/overview/meta.json`: add the new page

## Why Telnyx

- Carrier-grade PSTN, sub-second call setup, global reach.
- Pay-per-minute, no monthly minimums, fits a hobbyist OSS install.
- REST + webhooks, no SIP stack required on the client.
- A user with a Telnyx account and a $1 number can dial out in a few minutes.

## Setup

1. Sign up at telnyx.com, grab an API key, buy a number (~$1/mo), create a Call
   Control Application, and assign the number to it. Copy the application ID.
2. Expose Voicebox via ngrok, Tailscale Funnel, or Cloudflare Tunnel, ideally
   behind a proxy restricted to the two paths above. Copy the HTTPS URL.
3. Voicebox → Settings → Sinks → Telnyx: paste the key, the application ID, the
   from-number, the public URL, pick a default voice profile, turn on `enabled`.
4. Hit "Test connection".
5. Test via MCP:
   ```python
   await voicebox.call({
     "to": "+15551234567",
     "profile": "Morgan",
     "text": "Deploy complete."
   })
   ```
   Or via curl:
   ```bash
   curl -X POST http://127.0.0.1:17493/call \
     -H "Content-Type: application/json" \
     -d '{"to":"+15551234567","profile":"Morgan","text":"Deploy complete."}'
   ```

## Verification

- `backend/tests/test_telnyx_sink.py` passes (17 cases). Covers the request
  bodies sent to Telnyx, the config gate, constant-time token comparison, and
  single-fire playback under retried webhook delivery.
- Unconfigured sink: `POST /call` returns 400 naming the missing fields; the
  MCP tool raises with the same message.
- Existing routes unaffected; the new router is additive.
- Live PSTN verification against a real number is pending on this revision.
  An earlier revision of this branch sent no `connection_id` and used a
  `media_url` field that doesn't exist on `playback_start`, so both the dial
  and the playback would have been rejected by the API. That's fixed here and
  covered by tests, but I want to re-run it end to end on hardware before
  anyone treats the call path as confirmed working.

## Open questions for maintainers

1. **Webhook signature verification.** This PR gates the webhook on a per-call
   `webhook_secret` query param, compared in constant time, failing closed when
   absent. Telnyx also signs every event with `telnyx-signature-ed25519` and
   `telnyx-timestamp` over `{timestamp}|{raw body}`, verifiable against the
   account public key. That authenticates the sender rather than just scoping
   the URL, and it's the better gate for an internet-exposed endpoint, but it
   needs an Ed25519 dependency and a public-key setting. Want it in this PR, or
   as a follow-up?
2. **Sink vs. pipeline-routing roadmap.** This ships a single sink with its own
   settings table, additive, not blocking on the broader pipeline-routing
   refactor. When that lands, the Telnyx sink can be reframed as a sink node
   and the HTTP + webhook logic carries over. Merge the additive version now
   and migrate later, or hold until the sink interface is settled?
3. **Frontend "Call" button.** Backend surface is complete; the React UI is
   left for a follow-up so this PR stays reviewable, and the docs mark it as
   not yet shipped. Acceptable, or should the UI ship here?

## License

MIT, no CLA friction. The contributor is a Telnyx employee but is contributing
as an individual user of the project. No Telnyx affiliation claim beyond the
choice of carrier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Telnyx phone calling with generated voice playback.
  * Added REST and MCP controls for text or existing generations.
  * Added configuration, health checks, call tracking, webhooks, status updates, and automatic hangup support.
  * Added voice profile, language, personality, caller, and masked credential settings.
  * Added validation and retry-safe call event handling.

* **Documentation**
  * Added setup, configuration, usage, security, limitations, and troubleshooting guidance for Telnyx calling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->