### PR TITLE
feat(linux): add CUDA backend build recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -244,6 +244,14 @@ build-server: _ensure-venv
     Write-Host "Copied sidecar: voicebox-mcp-$triple.exe"
 
 # Build CUDA server binary and place in app data dir for local testing
+[linux]
+build-server-cuda: _ensure-venv
+    PATH="{{ venv_bin }}:$PATH" {{ python }} backend/build_binary.py --cuda
+    rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/sh.voicebox.app/backends/cuda"
+    mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}/sh.voicebox.app/backends/cuda"
+    cp -a backend/dist/voicebox-server-cuda/. "${XDG_DATA_HOME:-$HOME/.local/share}/sh.voicebox.app/backends/cuda/"
+    chmod +x "${XDG_DATA_HOME:-$HOME/.local/share}/sh.voicebox.app/backends/cuda/voicebox-server-cuda"
+
 [windows]
 build-server-cuda: _ensure-venv
     $ErrorActionPreference = "Stop"; \


### PR DESCRIPTION
Adds a Linux implementation of the existing build-server-cuda recipe.

The Python builder already supports --cuda cross-platform, but the justfile only exposed the CUDA build/install flow on Windows. This adds the equivalent Linux path and installs the generated backend into the app data directory under XDG_DATA_HOME (falling back to ~/.local/share).

Tested successfully on:
- LMDE 6 / Debian 12, Python 3.11, NVIDIA GTX 1660 SUPER
  - CUDA backend built successfully
  - Voicebox detected and launched the locally built backend
  - Qwen3-TTS 0.6B ran successfully with CUDA
- Linux Mint 22.3 / Ubuntu 24.04 base, Python 3.12, NVIDIA MX110
  - CUDA backend build completed successfully
  - PyTorch CUDA environment was detected correctly
  - Runtime inference was not tested on the MX110 because current PyTorch cu128 does not support its sm_50 compute capability

This keeps the Linux behavior aligned with the existing Windows build-server-cuda recipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linux build command for creating the CUDA-enabled server.
  * Automatically prepares the required backend data and executable permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->