### PR TITLE
fix(mcp): voicebox.speak inherits the voice profile language instead of forcing English

### DIFF
--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -105,6 +105,7 @@ def register_tools(mcp: FastMCP) -> None:
                 text=text,
                 engine=resolved_engine,
                 language=language,
+                profile_language=vp.language,
                 personality=use_persona,
                 model_size=model_size,
                 db=db,
@@ -236,6 +237,7 @@ async def _speak(
     engine: str | None,
     language: str | None,
     personality: bool,
+    profile_language: str | None = None,
     model_size: str | None = None,
     db,
 ) -> dict[str, Any]:
@@ -246,10 +248,14 @@ async def _speak(
     # model_size=None is intentional: generate_speech normalizes it to the
     # engine default (see routes/generations.py), so an omitted size behaves
     # exactly like the REST /generate endpoint with no model_size in the body.
+    #
+    # language precedence: explicit tool arg → the resolved profile's own
+    # language → "en". Without the profile fallback, a non-English voice
+    # profile with no explicit language is phonemized as English.
     req = models.GenerationRequest(
         profile_id=profile_id,
         text=text,
-        language=language or "en",
+        language=language or profile_language or "en",
         engine=engine,
         personality=personality,
         model_size=model_size,


### PR DESCRIPTION
## What

`voicebox.speak` now inherits the resolved voice profile's `language` when the caller doesn't pass an explicit one, instead of hardcoding a fallback to `"en"`.

Precedence becomes: **explicit `language` arg → resolved profile's `language` → `"en"`**.

## Why

When speaking through a non-English profile (e.g. a Spanish `kokoro` preset) without an explicit `language`, the text was phonemized with English g2p rules — Spanish words came out with an English accent. The profile is resolved correctly, but its `language` was discarded and the request defaulted to `"en"`.

This mirrors the precedence already documented in `mcp_server/README.md` for profile resolution, and it's the same class of fix as #884 (the tool not inheriting `model_size`).

Fixes #1049

## Change

`backend/mcp_server/tools.py`:
- `_speak` gains a `profile_language: str | None = None` keyword arg.
- `voicebox_speak` passes the resolved `vp.language` into `_speak`.
- The `GenerationRequest.language` value becomes `language or profile_language or "en"`.

+7 / -1, no behavior change for callers that already pass `language`.

## Testing

- Root cause confirmed empirically: without the fix, generations from a Spanish profile with no `language` arg are recorded as `language="en"`; passing `es` explicitly corrects pronunciation.
- `ruff check` / `ruff format --check` on the touched file surface only **pre-existing** import/format findings in unrelated code, which per `STYLE_GUIDE.md` shouldn't be reformatted in an unrelated PR. The change itself introduces no new lint/format errors.
- I did not spin up the full backend for an end-to-end run. Happy to add a `pytest` case under `backend/tests/` for the language-precedence behavior if you'd like.

## Notes

- `CHANGELOG.md` intentionally left untouched — the file header states it's compiled automatically and shouldn't be edited by hand.

## PR checklist

- [x] Code follows style guidelines
- [x] Documentation updated (n/a — behavior aligns with existing `mcp_server/README.md` precedence)
- [x] Changes tested (empirically; see Testing)
- [x] No breaking changes
- [ ] CHANGELOG.md updated (intentionally skipped — see Notes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice synthesis language selection.
  * Voice output now uses the requested language when provided, otherwise the selected voice profile’s language, with English as the fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->