### PR TITLE
fix(speak): honour the voice profile's language instead of forcing English

### DIFF
--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -104,7 +104,7 @@ def register_tools(mcp: FastMCP) -> None:
                 profile_name=vp.name,
                 text=text,
                 engine=resolved_engine,
-                language=language,
+                language=language or vp.language,
                 personality=use_persona,
                 model_size=model_size,
                 db=db,

--- a/backend/routes/speak.py
+++ b/backend/routes/speak.py
@@ -75,7 +75,7 @@ async def speak(
         models.GenerationRequest(
             profile_id=profile.id,
             text=data.text,
-            language=data.language or "en",
+            language=data.language or profile.language or "en",
             engine=engine,
             personality=bool(personality_flag),
         ),

--- a/backend/tests/test_speak_language.py
+++ b/backend/tests/test_speak_language.py
@@ -1,0 +1,163 @@
+"""Tests for voice-profile language fallback on the two speak surfaces.
+
+Both speak paths built their ``GenerationRequest`` with a hardcoded ``"en"``
+fallback and never consulted the resolved profile, so a profile created with
+``language="fr"`` was still synthesised as English unless every caller passed
+``language=`` explicitly. Agents going through MCP had no way to know the
+profile's language, so they couldn't pass it either.
+
+These tests pin the fix: the fallback chain is now explicit argument →
+resolved profile's language → ``"en"``, matching how ``engine`` and
+``personality`` already consult the resolved binding.
+"""
+
+import pytest
+
+import backend.routes.generations as generations
+import backend.routes.speak as speak_route
+from backend import models
+from backend.mcp_server import tools
+
+
+class _FakeGeneration:
+    """Minimal stand-in for GenerationResponse consumed by the speak paths."""
+
+    id = "gen-test"
+    status = "generating"
+
+    def model_dump(self, mode="json"):
+        return {"id": self.id, "status": self.status}
+
+
+class _FakeProfile:
+    def __init__(self, language):
+        self.id = "p1"
+        self.name = "Siwis"
+        self.language = language
+        self.personality = None
+
+
+class _FakeQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        # No per-client binding — engine/personality fall through to their
+        # own defaults, leaving language as the only variable under test.
+        return None
+
+
+class _FakeDB:
+    def query(self, *args, **kwargs):
+        return _FakeQuery()
+
+    def close(self):
+        pass
+
+
+class _FakeRequest:
+    """Stands in for starlette's Request — only headers are read."""
+
+    def __init__(self, client_id=None):
+        self.headers = {"X-Voicebox-Client-Id": client_id} if client_id else {}
+
+
+@pytest.fixture
+def captured_request(monkeypatch):
+    """Capture the GenerationRequest instead of running a real generation.
+
+    Both speak paths import ``generate_speech`` lazily from
+    ``routes.generations``, so patching the attribute on that module
+    intercepts the call on either surface.
+    """
+    captured = {}
+
+    async def fake_generate_speech(req, db):
+        captured["req"] = req
+        return _FakeGeneration()
+
+    monkeypatch.setattr(generations, "generate_speech", fake_generate_speech)
+    monkeypatch.setattr(speak_route.mcp_events, "publish", lambda *a, **k: None)
+    monkeypatch.setattr(tools.mcp_events, "publish", lambda *a, **k: None)
+    return captured
+
+
+# ─── REST: POST /speak ────────────────────────────────────────────────────
+
+
+async def _call_rest(monkeypatch, profile_language, requested_language=None):
+    monkeypatch.setattr(
+        speak_route,
+        "resolve_profile",
+        lambda profile, client_id, db: _FakeProfile(profile_language),
+    )
+    await speak_route.speak(
+        models.SpeakRequest(text="Bonjour", language=requested_language),
+        _FakeRequest(client_id="claude-code"),
+        _FakeDB(),
+    )
+
+
+async def test_rest_speak_falls_back_to_profile_language(
+    captured_request, monkeypatch
+):
+    await _call_rest(monkeypatch, profile_language="fr")
+    assert captured_request["req"].language == "fr"
+
+
+async def test_rest_speak_explicit_language_wins(captured_request, monkeypatch):
+    # An explicit argument still overrides the profile — a French profile can
+    # be asked to read an English string.
+    await _call_rest(monkeypatch, profile_language="fr", requested_language="en")
+    assert captured_request["req"].language == "en"
+
+
+async def test_rest_speak_defaults_to_en_without_profile_language(
+    captured_request, monkeypatch
+):
+    # Profiles predating the language column resolve to None; the "en"
+    # backstop keeps their behaviour unchanged.
+    await _call_rest(monkeypatch, profile_language=None)
+    assert captured_request["req"].language == "en"
+
+
+# ─── MCP: voicebox.speak ──────────────────────────────────────────────────
+
+
+async def _call_mcp(monkeypatch, profile_language, requested_language=None):
+    from mcp.server.fastmcp import FastMCP
+
+    monkeypatch.setattr(
+        tools,
+        "resolve_profile",
+        lambda profile, client_id, db: _FakeProfile(profile_language),
+    )
+    monkeypatch.setattr(tools, "get_db", lambda: iter([_FakeDB()]))
+
+    mcp = FastMCP("test")
+    tools.register_tools(mcp)
+    args = {"text": "Bonjour"}
+    if requested_language is not None:
+        args["language"] = requested_language
+    await mcp.call_tool("voicebox.speak", args)
+
+
+async def test_mcp_speak_falls_back_to_profile_language(
+    captured_request, monkeypatch
+):
+    # The agent-facing path matters most: an MCP client can't know the
+    # profile's language, so omitting it must not silently mean English.
+    await _call_mcp(monkeypatch, profile_language="fr")
+    assert captured_request["req"].language == "fr"
+
+
+async def test_mcp_speak_explicit_language_wins(captured_request, monkeypatch):
+    await _call_mcp(monkeypatch, profile_language="fr", requested_language="en")
+    assert captured_request["req"].language == "en"
+
+
+async def test_mcp_speak_defaults_to_en_without_profile_language(
+    captured_request, monkeypatch
+):
+    await _call_mcp(monkeypatch, profile_language=None)
+    assert captured_request["req"].language == "en"


### PR DESCRIPTION
## Problem

A voice profile carries a `language` field, but neither speak surface ever reads it. Both build their `GenerationRequest` with a hardcoded English fallback:

```python
# backend/routes/speak.py
language=data.language or "en",

# backend/mcp_server/tools.py
language=language,   # -> _speak(...) -> language or "en"
```

So a profile created with `language="fr"` is still synthesised as English unless every caller passes `language=` explicitly.

This hurts the MCP path most. An agent calling `voicebox.speak` resolves its profile through the per-client binding — it never sees the profile object, so it has no way to know the profile's language and cannot pass the argument either. Every agent-triggered generation on a non-English profile comes out with an English accent.

## Reproduction

Create the Kokoro French preset and bind it to a client:

```bash
curl -X POST localhost:17493/profiles -H 'Content-Type: application/json' \
  -d '{"name":"Siwis","language":"fr","voice_type":"preset",
       "preset_engine":"kokoro","preset_voice_id":"ff_siwis",
       "default_engine":"kokoro"}'

curl -X PUT localhost:17493/mcp/bindings -H 'Content-Type: application/json' \
  -d '{"client_id":"claude-code","profile_id":"<id>","default_engine":"kokoro"}'

curl -X POST localhost:17493/speak -H 'Content-Type: application/json' \
  -H 'X-Voicebox-Client-Id: claude-code' \
  -d '{"text":"Bonjour, je suis la voix française de Voicebox."}'
```

**Before:** `"language": "en"` — French text read with an English accent.
**After:** `"language": "fr"`.

## Fix

The fallback chain becomes explicit argument → resolved profile's language → `"en"`, matching how `engine` and `personality` already consult the resolved binding.

```diff
- language=data.language or "en",
+ language=data.language or profile.language or "en",
```
```diff
- language=language,
+ language=language or vp.language,
```

The `"en"` backstop is kept, so profiles with no language set behave exactly as before.

## Tests

Adds `backend/tests/test_speak_language.py` — 6 tests covering both surfaces (REST `POST /speak` and the `voicebox.speak` MCP tool):

- falls back to the profile's language when the caller omits it
- an explicit `language=` argument still wins over the profile
- still defaults to `"en"` when the profile has no language

Verified the tests fail without the fix: the two fallback tests fail on the unpatched tree, the four precedence/backstop tests pass in both states as intended.

```
$ pytest backend/tests/test_speak_language.py -q
6 passed

$ pytest backend/tests/test_mcp_speak.py backend/tests/test_client_id_middleware.py \
         backend/tests/test_speak_language.py -q
26 passed
```

Manually verified end to end on Linux + CUDA with the Kokoro engine.

## Notes

- No `CHANGELOG.md` entry: the file header says it is compiled automatically during the release workflow and manual edits are overwritten. Happy to add one if maintainers prefer.
- Unrelated, spotted while running the suite: `backend/tests/test_profile_duplicate_names.py` fails at collection on a clean checkout with `ImportError: attempted relative import beyond top-level package`. Not touched here.

## Checklist

- [x] Code follows style guidelines
- [x] Changes tested
- [x] No breaking changes
- [ ] Documentation updated — n/a, no user-facing surface change
- [ ] CHANGELOG.md updated — see note above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speech generation now automatically uses the selected voice profile’s language when no language is specified.
  * Falls back to English when neither an explicit language nor profile language is available.
  * Explicitly selected languages continue to take priority.

* **Tests**
  * Added coverage for language selection across REST and MCP speech interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->