### PR TITLE
fix(backend): break the app<->routes import cycle that aborts the test suite

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -105,26 +105,16 @@ if not os.environ.get("MIOPEN_LOG_LEVEL"):
 import torch
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from urllib.parse import quote
 
 from . import __version__, config, database
 from .services import tts, transcribe, llm
 from .database import get_db
 from .utils.platform_detect import get_backend_type
 from .utils.progress import get_progress_manager
+# Re-exported for backwards compatibility with callers importing it from here.
+from .utils.http import safe_content_disposition as safe_content_disposition
 from .services.task_queue import create_background_task, init_queue
 from .routes import register_routers
-
-
-def safe_content_disposition(disposition_type: str, filename: str) -> str:
-    """Build a Content-Disposition header safe for non-ASCII filenames.
-
-    Uses RFC 5987 ``filename*`` parameter so browsers can decode UTF-8
-    filenames while the ``filename`` fallback stays ASCII-only.
-    """
-    ascii_name = "".join(c for c in filename if c.isascii() and (c.isalnum() or c in " -_.")).strip() or "download"
-    utf8_name = quote(filename, safe="")
-    return f"{disposition_type}; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"
 
 
 def create_app() -> FastAPI:

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from .. import config, models
 from ..services import export_import, history
-from ..app import safe_content_disposition
+from ..utils.http import safe_content_disposition
 from ..database import Generation as DBGeneration, VoiceProfile as DBVoiceProfile, get_db
 
 router = APIRouter()

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from .. import config, models
-from ..app import safe_content_disposition
+from ..utils.http import safe_content_disposition
 from ..database import VoiceProfile as DBVoiceProfile, get_db
 from ..services import channels, export_import, personality, profiles
 from ..services.profiles import _profile_to_response

--- a/backend/routes/stories.py
+++ b/backend/routes/stories.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from .. import database, models
 from ..services import stories
-from ..app import safe_content_disposition
+from ..utils.http import safe_content_disposition
 from ..database import get_db
 
 router = APIRouter()

--- a/backend/tests/test_profile_duplicate_names.py
+++ b/backend/tests/test_profile_duplicate_names.py
@@ -12,13 +12,9 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-# Add parent directory to path to import backend modules
-import sys
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from database import Base, VoiceProfile as DBVoiceProfile
-from models import VoiceProfileCreate
-from profiles import create_profile, update_profile
+from backend.database import Base, VoiceProfile as DBVoiceProfile
+from backend.models import VoiceProfileCreate
+from backend.services.profiles import create_profile, update_profile
 
 
 @pytest.fixture

--- a/backend/utils/http.py
+++ b/backend/utils/http.py
@@ -1,0 +1,19 @@
+"""HTTP header helpers shared by the download routes.
+
+Lives here rather than in ``app`` so route modules can use it without
+importing the application module — ``app`` builds the FastAPI instance at
+import time, which registers those same routers and closes an import cycle.
+"""
+
+from urllib.parse import quote
+
+
+def safe_content_disposition(disposition_type: str, filename: str) -> str:
+    """Build a Content-Disposition header safe for non-ASCII filenames.
+
+    Uses RFC 5987 ``filename*`` parameter so browsers can decode UTF-8
+    filenames while the ``filename`` fallback stays ASCII-only.
+    """
+    ascii_name = "".join(c for c in filename if c.isascii() and (c.isalnum() or c in " -_.")).strip() or "download"
+    utf8_name = quote(filename, safe="")
+    return f"{disposition_type}; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"


### PR DESCRIPTION
## Problem

`pytest backend/tests` fails at collection on a clean checkout, and because pytest aborts on a collection error, **the entire backend suite runs zero tests**:

```
backend/tests/test_profile_duplicate_names.py:19: in <module>
    from database import Base, VoiceProfile as DBVoiceProfile
backend/database/__init__.py:8: in <module>
    from .models import (
backend/database/models.py:9: in <module>
    from ..utils.capture_chords import (
E   ImportError: attempted relative import beyond top-level package
```

Two causes are stacked here.

### 1. A real import cycle in production code

`routes/profiles.py`, `routes/history.py` and `routes/stories.py` each do:

```python
from ..app import safe_content_disposition
```

while `app.py` builds the application at module scope:

```python
app = create_app()   # -> register_routers() -> from .profiles import router
```

So importing any of those three route modules *first* re-enters a partially initialised `app`:

```
E   ImportError: cannot import name 'router' from partially initialized module
    'backend.routes.profiles' (most likely due to a circular import)
```

This is latent today only because `app.py` always happens to be imported first in the running server. Any tool that imports a route module directly — a test, a script, a linter, `python -c "import backend.routes.history"` — hits it:

```bash
$ python -c "import backend.routes.profiles"   # before
ImportError: cannot import name 'router' from partially initialized module ...
$ python -c "import backend.routes.profiles"   # after
(ok)
```

### 2. The test used a sys.path hack and the wrong module

```python
sys.path.insert(0, str(Path(__file__).parent.parent))
from database import Base, VoiceProfile as DBVoiceProfile
from models import VoiceProfileCreate
from profiles import create_profile, update_profile
```

Flat imports make `database/models.py`'s `from ..utils.capture_chords import ...` point outside the package. The rest of the suite uses `from backend.X import ...`; this file is the outlier.

It also aimed at the wrong layer: the tests assert `pytest.raises(ValueError)`, which is what `services/profiles.py` raises — the route handler catches it and re-raises as `HTTPException`.

## Fix

`safe_content_disposition` is a pure helper over `urllib.parse.quote` with no application state, so it moves to `backend/utils/http.py`. `app.py` re-exports it, so anything importing it from the old location keeps working. The three route modules import it from `..utils.http`, and the cycle is gone.

The test switches to `from backend.X import ...` like its neighbours, drops the `sys.path` insert, and points at `backend.services.profiles`.

## Results

| | before | after |
|---|---|---|
| `pytest backend/tests` | **0 collected** — run aborted | 148 passed |
| same, excluding the broken file | 142 passed, 1 failed | 148 passed, 1 failed |

Model-download / e2e tests excluded from both runs (`test_all_models_e2e`, `test_mlx_smoke`, `test_*_download`).

The one remaining failure, `test_progress.py::test_hf_progress_tracker`, is **pre-existing and unrelated** (tqdm patching). It reproduces identically on an unpatched tree.

Also verified the app itself still builds and the helper is unchanged:

```bash
$ python -c "from backend.app import app, safe_content_disposition; \
    print(safe_content_disposition('attachment','héllo wörld.wav'))"
INFO:     MCP: mounted at /mcp
attachment; filename="hllo wrld.wav"; filename*=UTF-8''h%C3%A9llo%20w%C3%B6rld.wav
```

## Follow-ups, not included here

Kept out to stay reviewable — happy to open separate PRs:

- **Three more test files rely on the same `sys.path` hack**: `test_audio_preprocess.py`, `test_offline_guard.py`, `test_progress.py`. They currently pass only as a side effect of collection order — an earlier file's `sys.path.insert` leaks into the shared process. Run `pytest backend/tests/test_progress.py` alone and it dies with `ModuleNotFoundError: No module named 'utils'`. Converting them would surface the tqdm failure above as a genuine red test, which is why it belongs in its own PR.
- **`test_hf_progress_tracker`** needs a real fix or an xfail marker.
- No `CHANGELOG.md` entry: the file header says it is compiled automatically during the release workflow and manual edits are overwritten.

## Checklist

- [x] Code follows style guidelines
- [x] Changes tested
- [x] No breaking changes — old import path re-exported
- [ ] Documentation updated — n/a, internal refactor
- [ ] CHANGELOG.md updated — see note above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of downloaded filenames, including non-ASCII characters, through safer content-disposition headers.
  * Preserved existing export behavior for history, profiles, and story audio downloads.

* **Refactor**
  * Centralized HTTP filename-handling logic for more consistent download responses.

* **Tests**
  * Updated profile tests to use the standard package structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->