### PR TITLE
feat: build designed voices from a written description

### DIFF
--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -27,6 +27,8 @@ export interface VoiceProfileResponse {
   preset_engine?: string;
   preset_voice_id?: string;
   design_prompt?: string;
+  /** Voice id issued by the design provider, present once the voice is built. */
+  designed_voice_id?: string;
   default_engine?: string;
   personality?: string | null;
   generation_count: number;

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -155,6 +155,8 @@ def _migrate_profiles(engine, inspector, tables: set[str]) -> None:
         _add_column(engine, "profiles", "preset_voice_id VARCHAR", "preset_voice_id")
     if "design_prompt" not in columns:
         _add_column(engine, "profiles", "design_prompt TEXT", "design_prompt")
+    if "designed_voice_id" not in columns:
+        _add_column(engine, "profiles", "designed_voice_id VARCHAR", "designed_voice_id")
     if "default_engine" not in columns:
         _add_column(engine, "profiles", "default_engine VARCHAR", "default_engine")
     if "personality" not in columns:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -37,6 +37,9 @@ class VoiceProfile(Base):
     preset_engine = Column(String, nullable=True)   # e.g. "kokoro" — only for preset
     preset_voice_id = Column(String, nullable=True)  # e.g. "am_adam" — only for preset
     design_prompt = Column(Text, nullable=True)      # text description — only for designed
+    # Voice id issued by the design provider for design_prompt, referenced by
+    # later synthesis. Only for designed, and set once the voice is built.
+    designed_voice_id = Column(String, nullable=True)
     default_engine = Column(String, nullable=True)   # auto-selected engine, locked for preset
     # Free-form character prompt used by the compose button and the
     # personality-rewrite path on /generate. Describes *what* this voice

--- a/backend/models.py
+++ b/backend/models.py
@@ -41,6 +41,7 @@ class VoiceProfileResponse(BaseModel):
     preset_engine: Optional[str] = None
     preset_voice_id: Optional[str] = None
     design_prompt: Optional[str] = None
+    designed_voice_id: Optional[str] = None
     default_engine: Optional[str] = None
     personality: Optional[str] = None
     generation_count: int = 0
@@ -50,6 +51,17 @@ class VoiceProfileResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class VoiceDesignRequest(BaseModel):
+    """Request model for building the voice of a designed profile.
+
+    The voice id is minted server-side, so callers only choose what the preview
+    says and which region serves the request.
+    """
+
+    preview_text: Optional[str] = Field(None, max_length=500)
+    region: Optional[str] = Field(None, max_length=50)
 
 
 class ProfileSampleCreate(BaseModel):

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -150,6 +150,31 @@ SAMPLE_MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 SAMPLE_UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 
+@router.post("/profiles/{profile_id}/design", response_model=models.VoiceProfileResponse)
+async def design_profile_voice(
+    profile_id: str,
+    data: models.VoiceDesignRequest | None = None,
+    db: Session = Depends(get_db),
+):
+    """Build the voice of a designed profile from its written description."""
+    payload = data or models.VoiceDesignRequest()
+    try:
+        return await profiles.design_profile_voice(
+            profile_id,
+            db,
+            preview_text=payload.preview_text,
+            region=payload.region,
+        )
+    except ValueError as e:
+        detail = str(e)
+        if detail.startswith("Profile not found"):
+            raise HTTPException(status_code=404, detail=detail) from e
+        raise HTTPException(status_code=400, detail=detail) from e
+    except RuntimeError as e:
+        # Missing credentials or an upstream failure — neither is the caller's fault.
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+
 @router.post("/profiles/{profile_id}/samples", response_model=models.ProfileSampleResponse)
 async def add_profile_sample(
     profile_id: str,

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -21,6 +21,7 @@ from ..models import (
 from ..utils.audio import save_audio, validate_and_load_reference_audio
 from ..utils.cache import _get_cache_dir, clear_profile_cache
 from ..utils.images import process_avatar, validate_image
+from . import voice_design
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,7 @@ def _profile_to_response(
         preset_engine=getattr(profile, "preset_engine", None),
         preset_voice_id=getattr(profile, "preset_voice_id", None),
         design_prompt=getattr(profile, "design_prompt", None),
+        designed_voice_id=getattr(profile, "designed_voice_id", None),
         default_engine=getattr(profile, "default_engine", None),
         personality=getattr(profile, "personality", None),
         generation_count=generation_count,
@@ -513,6 +515,56 @@ async def update_profile_sample(
     return ProfileSampleResponse.model_validate(sample)
 
 
+async def design_profile_voice(
+    profile_id: str,
+    db: Session,
+    preview_text: str | None = None,
+    region: str | None = None,
+) -> VoiceProfileResponse:
+    """Build the voice for a designed profile and persist the returned voice id.
+
+    Designed profiles carry a written description instead of audio samples. This
+    sends that description to the voice design endpoint, which answers with the
+    voice id later synthesis references, and stores it on the profile so the
+    voice survives restarts and is reused instead of re-designed.
+
+    Args:
+        profile_id: Profile ID of a profile whose voice_type is "designed".
+        db: Database session
+        preview_text: Text spoken in the provider's preview sample
+        region: API region override
+
+    Returns:
+        The updated profile.
+
+    Raises:
+        ValueError: if the profile is missing, is not designed, or has no prompt.
+    """
+    profile = db.query(DBVoiceProfile).filter_by(id=profile_id).first()
+    if not profile:
+        raise ValueError(f"Profile not found: {profile_id}")
+
+    voice_type = getattr(profile, "voice_type", None) or "cloned"
+    if voice_type != "designed":
+        raise ValueError(f"Profile {profile_id} is not a designed profile")
+    if not profile.design_prompt or not profile.design_prompt.strip():
+        raise ValueError(f"Designed profile {profile_id} is missing design_prompt")
+
+    designed_voice_id = await voice_design.design_voice(
+        profile.design_prompt,
+        preview_text=preview_text,
+        region=region,
+    )
+
+    profile.designed_voice_id = designed_voice_id
+    profile.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(profile)
+    logger.info("Stored designed voice %s on profile %s", designed_voice_id, profile_id)
+
+    return _profile_to_response(profile)
+
+
 async def create_voice_prompt_for_profile(
     profile_id: str,
     db: Session,
@@ -524,7 +576,7 @@ async def create_voice_prompt_for_profile(
 
     For cloned profiles: combines all audio samples into a voice prompt.
     For preset profiles: returns the engine-specific preset voice reference.
-    For designed profiles: returns the text design prompt (future).
+    For designed profiles: returns the design prompt and the designed voice id.
 
     Args:
         profile_id: Profile ID
@@ -558,14 +610,20 @@ async def create_voice_prompt_for_profile(
             "preset_voice_id": profile.preset_voice_id,
         }
 
-    # ── Designed profiles: return text description (future) ──
+    # ── Designed profiles: return the text description plus the built voice ──
     if voice_type == "designed":
         if not profile.design_prompt or not profile.design_prompt.strip():
             raise ValueError(f"Designed profile {profile_id} is missing design_prompt")
-        return {
+        voice_prompt = {
             "voice_type": "designed",
             "design_prompt": profile.design_prompt,
         }
+        # Present once the voice has been designed; engines that render designed
+        # voices remotely reference this id instead of the raw description.
+        designed_voice_id = getattr(profile, "designed_voice_id", None)
+        if designed_voice_id:
+            voice_prompt["voice_id"] = designed_voice_id
+        return voice_prompt
 
     if engine not in CLONING_ENGINES:
         raise ValueError(f"Engine '{engine}' does not support cloned voice profiles")

--- a/backend/services/voice_design.py
+++ b/backend/services/voice_design.py
@@ -1,0 +1,201 @@
+"""MiniMax voice design — turn a written description into a reusable voice.
+
+The provider exposes one JSON endpoint that takes a natural-language voice
+description and returns a voice id usable for later speech synthesis:
+
+    POST /v1/voice_design
+    {"prompt": "...", "voice_id": "...", "preview_text": "..."}
+    -> {"voice_id": "...", "trial_audio": "...", "base_resp": {"status_code": 0}}
+
+Two regional hosts serve the same API; select one with ``MINIMAX_API_REGION``.
+The ``voice_id`` is supplied by us rather than discovered afterwards, so the
+profile row and the remote voice stay in sync without a second lookup — see
+``services.profiles.design_profile_voice``, which persists the returned id.
+
+Failures arrive inside the body: the HTTP status stays 200 and ``base_resp``
+carries a non-zero ``status_code`` plus a human-readable ``status_msg``.
+
+Requirements:
+  - ``MINIMAX_API_KEY`` environment variable
+  - httpx (already in requirements.txt)
+
+Reference: https://platform.minimax.io/docs/api-reference/voice-design-design
+"""
+
+import logging
+import os
+import re
+import secrets
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Regional hosts for the voice-design endpoint. Both speak the same API.
+MINIMAX_VOICE_DESIGN_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/voice_design",
+    "cn_zh": "https://api.minimaxi.com/v1/voice_design",
+}
+
+MINIMAX_DEFAULT_REGION = "global_en"
+
+API_KEY_ENV_VAR = "MINIMAX_API_KEY"
+API_REGION_ENV_VAR = "MINIMAX_API_REGION"
+
+# Mirrors VoiceProfileCreate.design_prompt so the HTTP call and the DB agree.
+DESIGN_PROMPT_MAX_CHARS = 2000
+
+# The provider renders a short preview of every new voice and caps its length.
+PREVIEW_TEXT_MAX_CHARS = 500
+DEFAULT_PREVIEW_TEXT = "This is a preview of the voice you just designed."
+
+# Voice ids we mint carry a prefix so designed voices stay recognisable in the
+# provider's account-wide voice list.
+VOICE_ID_PREFIX = "voicebox_design_"
+VOICE_ID_MIN_CHARS = 8
+VOICE_ID_MAX_CHARS = 100
+_VOICE_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+REQUEST_TIMEOUT_SECONDS = 60.0
+
+
+def resolve_region(region: str | None = None) -> str:
+    """Resolve the API region, honouring ``MINIMAX_API_REGION``.
+
+    Raises:
+        ValueError: if the region is not one this endpoint is served from.
+    """
+    candidate = (region or os.environ.get(API_REGION_ENV_VAR) or MINIMAX_DEFAULT_REGION).strip()
+    if candidate not in MINIMAX_VOICE_DESIGN_ENDPOINTS:
+        supported = ", ".join(sorted(MINIMAX_VOICE_DESIGN_ENDPOINTS))
+        raise ValueError(f"Unknown MiniMax API region '{candidate}'. Supported regions: {supported}")
+    return candidate
+
+
+def get_voice_design_endpoint(region: str | None = None) -> str:
+    """Return the voice-design endpoint URL for the resolved region."""
+    return MINIMAX_VOICE_DESIGN_ENDPOINTS[resolve_region(region)]
+
+
+def load_api_key() -> str | None:
+    """Load ``MINIMAX_API_KEY`` from the environment."""
+    return os.environ.get(API_KEY_ENV_VAR, "").strip() or None
+
+
+def generate_voice_id() -> str:
+    """Mint a fresh voice id for a designed voice."""
+    return f"{VOICE_ID_PREFIX}{secrets.token_hex(8)}"
+
+
+def validate_voice_id(voice_id: str | None) -> str:
+    """Return ``voice_id`` unchanged, or raise ``ValueError`` if unusable."""
+    candidate = (voice_id or "").strip()
+    if not candidate:
+        raise ValueError("voice_id is required to design a voice")
+    if len(candidate) < VOICE_ID_MIN_CHARS:
+        raise ValueError(f"voice_id must be at least {VOICE_ID_MIN_CHARS} characters")
+    if len(candidate) > VOICE_ID_MAX_CHARS:
+        raise ValueError(f"voice_id must be at most {VOICE_ID_MAX_CHARS} characters")
+    if not _VOICE_ID_RE.match(candidate):
+        raise ValueError("voice_id must start with a letter and use only letters, digits, hyphens or underscores")
+    return candidate
+
+
+def build_request_payload(
+    design_prompt: str | None,
+    voice_id: str,
+    preview_text: str | None = None,
+) -> dict:
+    """Validate the design inputs and build the JSON request body."""
+    prompt = (design_prompt or "").strip()
+    if not prompt:
+        raise ValueError("design_prompt is required to design a voice")
+    if len(prompt) > DESIGN_PROMPT_MAX_CHARS:
+        raise ValueError(f"design_prompt must be at most {DESIGN_PROMPT_MAX_CHARS} characters")
+
+    preview = (preview_text or DEFAULT_PREVIEW_TEXT).strip()
+    if not preview:
+        raise ValueError("preview_text cannot be blank")
+    if len(preview) > PREVIEW_TEXT_MAX_CHARS:
+        raise ValueError(f"preview_text must be at most {PREVIEW_TEXT_MAX_CHARS} characters")
+
+    return {
+        "prompt": prompt,
+        "voice_id": validate_voice_id(voice_id),
+        "preview_text": preview,
+    }
+
+
+def extract_voice_id(body: dict, requested_voice_id: str) -> str:
+    """Pull the designed voice id out of a response body.
+
+    Raises:
+        RuntimeError: if the body reports a provider-side failure or omits the id.
+    """
+    base_resp = body.get("base_resp") or {}
+    status_code = base_resp.get("status_code") or 0
+    if status_code:
+        status_msg = base_resp.get("status_msg") or "Unknown error"
+        raise RuntimeError(f"Voice design failed (status {status_code}): {status_msg}")
+
+    voice_id = (body.get("voice_id") or "").strip()
+    if not voice_id:
+        raise RuntimeError("Voice design response did not contain a voice_id")
+    if voice_id != requested_voice_id:
+        logger.warning("Voice design returned voice_id %s instead of the requested %s", voice_id, requested_voice_id)
+    return voice_id
+
+
+async def post_voice_design(url: str, api_key: str, payload: dict) -> dict:
+    """POST a design request and return the decoded JSON body.
+
+    A module-level seam so tests can stand in for the network call.
+    """
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+        try:
+            response = await client.post(url, headers=headers, json=payload)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Could not reach the voice design endpoint: {e}") from e
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Voice design request failed with HTTP {response.status_code}")
+
+    try:
+        body = response.json()
+    except ValueError as e:
+        raise RuntimeError("Voice design response was not valid JSON") from e
+    if not isinstance(body, dict):
+        raise RuntimeError("Voice design response was not a JSON object")
+    return body
+
+
+async def design_voice(
+    design_prompt: str | None,
+    voice_id: str | None = None,
+    preview_text: str | None = None,
+    region: str | None = None,
+) -> str:
+    """Design a voice from a written description and return its voice id.
+
+    Args:
+        design_prompt: Natural-language description of how the voice should sound.
+        voice_id: Voice id to claim; a fresh one is minted when omitted.
+        preview_text: Text spoken in the provider's preview sample.
+        region: API region override, otherwise ``MINIMAX_API_REGION``.
+
+    Returns:
+        The voice id to persist and reference from later synthesis.
+    """
+    api_key = load_api_key()
+    if not api_key:
+        raise RuntimeError(f"{API_KEY_ENV_VAR} is not configured. Set it in your environment.")
+
+    resolved_region = resolve_region(region)
+    requested_voice_id = voice_id or generate_voice_id()
+    payload = build_request_payload(design_prompt, requested_voice_id, preview_text)
+
+    body = await post_voice_design(get_voice_design_endpoint(resolved_region), api_key, payload)
+    designed_voice_id = extract_voice_id(body, requested_voice_id)
+    logger.info("Designed voice %s in region %s", designed_voice_id, resolved_region)
+    return designed_voice_id

--- a/backend/tests/test_minimax_voice_design.py
+++ b/backend/tests/test_minimax_voice_design.py
@@ -1,0 +1,290 @@
+"""Tests for MiniMax voice design — designed profiles get a real, persisted voice.
+
+The ``designed`` voice_type has existed in the profiles schema since v0.3.x, but
+nothing ever built the voice: ``create_voice_prompt_for_profile`` handed engines
+a bare text description, so a designed profile silently rendered in whatever
+default voice the engine happened to use. These tests pin the wiring — the
+written description plus a freshly minted ``voice_id`` go to the regional
+voice-design endpoint, the voice id that comes back is persisted on the profile,
+and later synthesis references it instead of re-designing the voice.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base, VoiceProfile as DBVoiceProfile
+from backend.services import profiles, voice_design
+
+DESIGN_PROMPT = "A warm, low-pitched narrator with a steady pace."
+A_VOICE_ID = "voicebox_design_abc12345"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Keep ambient credentials and region settings out of the assertions."""
+    monkeypatch.delenv(voice_design.API_KEY_ENV_VAR, raising=False)
+    monkeypatch.delenv(voice_design.API_REGION_ENV_VAR, raising=False)
+
+
+@pytest.fixture
+def test_db():
+    """Temporary SQLite database carrying the real profiles schema."""
+    temp_dir = tempfile.mkdtemp()
+    engine = create_engine(f"sqlite:///{Path(temp_dir) / 'test.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+    yield session
+
+    session.close()
+    shutil.rmtree(temp_dir)
+
+
+def _add_designed_profile(db) -> DBVoiceProfile:
+    profile = DBVoiceProfile(
+        id="profile-designed",
+        name="Designed narrator",
+        language="en",
+        voice_type="designed",
+        design_prompt=DESIGN_PROMPT,
+    )
+    db.add(profile)
+    db.commit()
+    return profile
+
+
+# ── Region and endpoint resolution ───────────────────────────────────
+
+
+def test_default_region_is_used_when_unset():
+    assert voice_design.resolve_region() == voice_design.MINIMAX_DEFAULT_REGION
+
+
+def test_region_comes_from_the_environment(monkeypatch):
+    monkeypatch.setenv(voice_design.API_REGION_ENV_VAR, "cn_zh")
+    assert voice_design.resolve_region() == "cn_zh"
+
+
+def test_explicit_region_beats_the_environment(monkeypatch):
+    monkeypatch.setenv(voice_design.API_REGION_ENV_VAR, "cn_zh")
+    assert voice_design.resolve_region("global_en") == "global_en"
+
+
+def test_each_region_has_its_own_voice_design_endpoint():
+    endpoints = voice_design.MINIMAX_VOICE_DESIGN_ENDPOINTS
+    assert voice_design.MINIMAX_DEFAULT_REGION in endpoints
+    assert len(set(endpoints.values())) == len(endpoints)
+    for url in endpoints.values():
+        assert url.startswith("https://")
+        assert url.endswith("/v1/voice_design")
+
+
+def test_unknown_region_is_rejected():
+    with pytest.raises(ValueError, match="Unknown MiniMax API region"):
+        voice_design.resolve_region("nowhere")
+
+
+# ── Minting and validating the voice id we claim ──────────────────────
+
+
+def test_generated_voice_ids_are_prefixed_unique_and_valid():
+    first = voice_design.generate_voice_id()
+    second = voice_design.generate_voice_id()
+    assert first != second
+    assert first.startswith(voice_design.VOICE_ID_PREFIX)
+    assert voice_design.validate_voice_id(first) == first
+
+
+@pytest.mark.parametrize("bad_voice_id", ["", "   ", "short", "1leads_with_digit", "has spaces", "has.dot"])
+def test_invalid_voice_ids_are_rejected(bad_voice_id):
+    with pytest.raises(ValueError, match="voice_id"):
+        voice_design.validate_voice_id(bad_voice_id)
+
+
+def test_overlong_voice_id_is_rejected():
+    with pytest.raises(ValueError, match="at most"):
+        voice_design.validate_voice_id("a" * (voice_design.VOICE_ID_MAX_CHARS + 1))
+
+
+# ── Request payload ──────────────────────────────────────────────────
+
+
+def test_payload_carries_the_prompt_the_voice_id_and_a_preview():
+    payload = voice_design.build_request_payload(DESIGN_PROMPT, A_VOICE_ID)
+    assert payload == {
+        "prompt": DESIGN_PROMPT,
+        "voice_id": A_VOICE_ID,
+        "preview_text": voice_design.DEFAULT_PREVIEW_TEXT,
+    }
+
+
+def test_payload_keeps_a_caller_supplied_preview_text():
+    payload = voice_design.build_request_payload(DESIGN_PROMPT, A_VOICE_ID, "Hello from the studio.")
+    assert payload["preview_text"] == "Hello from the studio."
+
+
+def test_blank_design_prompt_is_rejected():
+    with pytest.raises(ValueError, match="design_prompt is required"):
+        voice_design.build_request_payload("   ", A_VOICE_ID)
+
+
+def test_overlong_design_prompt_is_rejected():
+    prompt = "a" * (voice_design.DESIGN_PROMPT_MAX_CHARS + 1)
+    with pytest.raises(ValueError, match="design_prompt must be at most"):
+        voice_design.build_request_payload(prompt, A_VOICE_ID)
+
+
+def test_overlong_preview_text_is_rejected():
+    preview = "a" * (voice_design.PREVIEW_TEXT_MAX_CHARS + 1)
+    with pytest.raises(ValueError, match="preview_text must be at most"):
+        voice_design.build_request_payload(DESIGN_PROMPT, A_VOICE_ID, preview)
+
+
+# ── Response envelope ────────────────────────────────────────────────
+
+
+def test_designed_voice_id_is_read_from_the_response():
+    body = {"voice_id": A_VOICE_ID, "base_resp": {"status_code": 0, "status_msg": "success"}}
+    assert voice_design.extract_voice_id(body, A_VOICE_ID) == A_VOICE_ID
+
+
+def test_provider_error_in_base_resp_is_surfaced():
+    body = {"base_resp": {"status_code": 1004, "status_msg": "authentication failed"}}
+    with pytest.raises(RuntimeError, match="1004"):
+        voice_design.extract_voice_id(body, A_VOICE_ID)
+
+
+def test_response_without_a_voice_id_is_rejected():
+    with pytest.raises(RuntimeError, match="did not contain a voice_id"):
+        voice_design.extract_voice_id({"base_resp": {"status_code": 0}}, A_VOICE_ID)
+
+
+# ── The design call ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def captured_request(monkeypatch):
+    """Replace the network call with a capturing stub and provide a key."""
+    captured = {}
+
+    async def fake_post_voice_design(url, api_key, payload):
+        captured["url"] = url
+        captured["api_key"] = api_key
+        captured["payload"] = payload
+        return {"voice_id": payload["voice_id"], "base_resp": {"status_code": 0}}
+
+    monkeypatch.setattr(voice_design, "post_voice_design", fake_post_voice_design)
+    monkeypatch.setenv(voice_design.API_KEY_ENV_VAR, "test-key")
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_design_voice_sends_the_prompt_and_a_generated_voice_id(captured_request):
+    voice_id = await voice_design.design_voice(DESIGN_PROMPT)
+
+    payload = captured_request["payload"]
+    assert payload["prompt"] == DESIGN_PROMPT
+    assert payload["voice_id"] == voice_id
+    assert voice_id.startswith(voice_design.VOICE_ID_PREFIX)
+    assert captured_request["api_key"] == "test-key"
+    assert captured_request["url"] == voice_design.MINIMAX_VOICE_DESIGN_ENDPOINTS["global_en"]
+
+
+@pytest.mark.asyncio
+async def test_design_voice_targets_the_requested_region(captured_request):
+    await voice_design.design_voice(DESIGN_PROMPT, region="cn_zh")
+    assert captured_request["url"] == voice_design.MINIMAX_VOICE_DESIGN_ENDPOINTS["cn_zh"]
+
+
+@pytest.mark.asyncio
+async def test_design_voice_requires_an_api_key(monkeypatch):
+    async def unreachable(*args, **kwargs):
+        raise AssertionError("the endpoint must not be called without a key")
+
+    monkeypatch.setattr(voice_design, "post_voice_design", unreachable)
+
+    with pytest.raises(RuntimeError, match=voice_design.API_KEY_ENV_VAR):
+        await voice_design.design_voice(DESIGN_PROMPT)
+
+
+# ── Persistence and reuse for synthesis ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_design_profile_voice_persists_the_returned_voice_id(test_db, monkeypatch):
+    _add_designed_profile(test_db)
+    seen = {}
+
+    async def fake_design_voice(design_prompt, voice_id=None, preview_text=None, region=None):
+        seen["design_prompt"] = design_prompt
+        seen["preview_text"] = preview_text
+        seen["region"] = region
+        return "voicebox_design_persisted01"
+
+    monkeypatch.setattr(voice_design, "design_voice", fake_design_voice)
+
+    response = await profiles.design_profile_voice(
+        "profile-designed", test_db, preview_text="Reading a line.", region="cn_zh"
+    )
+
+    assert seen == {
+        "design_prompt": DESIGN_PROMPT,
+        "preview_text": "Reading a line.",
+        "region": "cn_zh",
+    }
+    assert response.designed_voice_id == "voicebox_design_persisted01"
+
+    stored = test_db.query(DBVoiceProfile).filter_by(id="profile-designed").first()
+    assert stored.designed_voice_id == "voicebox_design_persisted01"
+
+
+@pytest.mark.asyncio
+async def test_voice_prompt_references_the_designed_voice(test_db):
+    profile = _add_designed_profile(test_db)
+    profile.designed_voice_id = "voicebox_design_persisted01"
+    test_db.commit()
+
+    voice_prompt = await profiles.create_voice_prompt_for_profile("profile-designed", test_db)
+
+    assert voice_prompt["voice_type"] == "designed"
+    assert voice_prompt["design_prompt"] == DESIGN_PROMPT
+    assert voice_prompt["voice_id"] == "voicebox_design_persisted01"
+
+
+@pytest.mark.asyncio
+async def test_voice_prompt_omits_the_voice_id_until_the_voice_is_designed(test_db):
+    _add_designed_profile(test_db)
+
+    voice_prompt = await profiles.create_voice_prompt_for_profile("profile-designed", test_db)
+
+    assert voice_prompt["design_prompt"] == DESIGN_PROMPT
+    assert "voice_id" not in voice_prompt
+
+
+@pytest.mark.asyncio
+async def test_designing_a_cloned_profile_is_rejected(test_db):
+    test_db.add(DBVoiceProfile(id="profile-cloned", name="Cloned voice", language="en", voice_type="cloned"))
+    test_db.commit()
+
+    with pytest.raises(ValueError, match="not a designed profile"):
+        await profiles.design_profile_voice("profile-cloned", test_db)
+
+
+@pytest.mark.asyncio
+async def test_designing_a_profile_without_a_prompt_is_rejected(test_db):
+    test_db.add(DBVoiceProfile(id="profile-empty", name="Empty design", language="en", voice_type="designed"))
+    test_db.commit()
+
+    with pytest.raises(ValueError, match="missing design_prompt"):
+        await profiles.design_profile_voice("profile-empty", test_db)
+
+
+@pytest.mark.asyncio
+async def test_designing_a_missing_profile_is_rejected(test_db):
+    with pytest.raises(ValueError, match="Profile not found"):
+        await profiles.design_profile_voice("does-not-exist", test_db)


### PR DESCRIPTION
Reason: Designed voice profiles stored a written description but nothing ever built a voice from it, so they silently rendered in a default voice.

## Background

The `profiles` schema has discriminated voices into `cloned | preset | designed` since v0.3.x, and `design_prompt` has been carried end to end — DB column, migration, pydantic models, service validation, response DTO. The `designed` arm was never finished at the other end: `create_voice_prompt_for_profile` returned the raw description, no backend read it, and there was nowhere to keep a voice built from it. A designed profile therefore fell back to whatever default voice the engine used, without an error.

## What this changes

**New service — `backend/services/voice_design.py`**

Posts the description plus a voice id to the MiniMax `POST /v1/voice_design` endpoint and returns the voice id to use for synthesis.

- Regional endpoint selection (`global_en`, `cn_zh`) resolved from `MINIMAX_API_REGION`, with an explicit per-call override; an unknown region is rejected rather than silently defaulted.
- The `voice_id` is minted by us (`voicebox_design_…` + random suffix) and sent with the request, so the profile row and the remote voice stay in sync without a follow-up lookup. The response id is still what gets persisted, and a mismatch is logged.
- Validation before the call: non-empty `design_prompt` capped at 2000 characters to match `VoiceProfileCreate.design_prompt`, `preview_text` capped at the documented 500, and a voice id format/length guard.
- Failures arrive inside the body — the endpoint answers HTTP 200 with a non-zero `base_resp.status_code` — so `base_resp` is checked first and its `status_msg` is surfaced. Transport errors, non-200 responses and non-JSON bodies each raise a distinct message.
- Credentials come from `MINIMAX_API_KEY`; nothing is attempted without it.

**Persisting the voice**

- `profiles.designed_voice_id` column plus an idempotent entry in `_migrate_profiles`, following the existing add-column pattern.
- `services.profiles.design_profile_voice()` designs the voice and stores the id, rejecting profiles that are missing, not `designed`, or have no prompt.
- `POST /profiles/{profile_id}/design` exposes it: 404 for an unknown profile, 400 for invalid input, 502 when credentials are missing or the upstream call fails.
- `create_voice_prompt_for_profile` now includes `voice_id` in the designed voice prompt once the voice exists, so synthesis references the built voice instead of the raw text. Profiles that have not been designed yet keep their current shape, so nothing that reads a designed voice prompt today changes behaviour.
- `designed_voice_id` is server-owned: it is exposed on `VoiceProfileResponse` (and the TS mirror) but is not accepted on create or update.

## Checks

- `python3 -m pytest backend/tests/test_minimax_voice_design.py -q` — 30 passed. Covers region resolution and endpoint mapping, voice id minting/validation, request payload construction, the `base_resp` envelope (success, provider error, missing id), API key enforcement, persistence of the returned id, and its reuse in the voice prompt. The endpoint is stubbed at the module seam, so no network access is required.
- `python3 -m pytest backend/tests -q` — the new tests pass and the pre-existing failures and collection errors are unchanged from `main` (verified by running the same command on a clean checkout).
- `ruff check` and `ruff format --check` on the two new files — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice design support for eligible voice profiles.
  * Profiles now expose the generated designed-voice identifier.
  * Added optional preview text and region settings for voice design requests.
  * Added regional processing and improved handling of provider responses and errors.
  * Designed voices are reused during subsequent synthesis.

* **Bug Fixes**
  * Added validation and clear error responses for invalid profiles, prompts, and design requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->