### PR TITLE
fix(ui): make long error toasts readable and copyable

### DIFF
--- a/app/src/components/ui/toast.tsx
+++ b/app/src/components/ui/toast.tsx
@@ -22,7 +22,9 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  // items-start rather than items-center: a long description scrolls inside a
+  // capped box, and centring it would push the title out of view.
+  'group pointer-events-auto relative flex w-full items-start justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {
@@ -98,7 +100,15 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn('text-sm opacity-90', className)}
+    // A server traceback can run to thousands of characters. Unbounded, it
+    // overflowed the viewport and got clipped at both ends with the close
+    // button pushed off-screen, so the text was unreadable and the toast
+    // undismissable. Cap it and let it scroll; break-words keeps a long
+    // unspaced token (a path, a URL) from widening the toast.
+    className={cn(
+      'max-h-[40vh] overflow-y-auto overscroll-contain whitespace-pre-wrap break-words pr-1 text-sm opacity-90',
+      className,
+    )}
     {...props}
   />
 ));

--- a/app/src/lib/hooks/useGenerationProgress.tsx
+++ b/app/src/lib/hooks/useGenerationProgress.tsx
@@ -148,7 +148,23 @@ export function useGenerationProgress() {
                 <ToastAction
                   altText="Copy the full error text"
                   onClick={() => {
-                    void navigator.clipboard.writeText(condensed.full);
+                    // Two ways this fails: the Clipboard API is absent outside
+                    // a secure context (property access throws), or writeText
+                    // rejects because permission was denied. The try/catch
+                    // covers both, so the click never becomes an unhandled
+                    // rejection and the user is told nothing was copied.
+                    void (async () => {
+                      try {
+                        await navigator.clipboard.writeText(condensed.full);
+                      } catch {
+                        toast({
+                          title: 'Could not copy',
+                          description:
+                            'Clipboard unavailable. The full error is in Settings → Logs.',
+                          variant: 'destructive',
+                        });
+                      }
+                    })();
                   }}
                 >
                   Copy

--- a/app/src/lib/hooks/useGenerationProgress.tsx
+++ b/app/src/lib/hooks/useGenerationProgress.tsx
@@ -1,7 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
+import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 import { apiClient } from '@/lib/api/client';
+import { condenseError } from '@/lib/utils/errorText';
 import { useGenerationSettings } from '@/lib/hooks/useSettings';
 import { useGenerationStore } from '@/stores/generationStore';
 import { usePlayerStore } from '@/stores/playerStore';
@@ -131,10 +133,27 @@ export function useGenerationProgress() {
 
             queryClient.refetchQueries({ queryKey: ['history'] });
 
+            const condensed = condenseError(
+              data.error || 'An error occurred during generation',
+            );
             toast({
               title: data.status === 'not_found' ? 'Generation not found' : 'Generation failed',
-              description: data.error || 'An error occurred during generation',
+              description: condensed.truncated
+                ? `${condensed.display}\n\n(${condensed.omitted} more characters — copy for the full error, or see Settings → Logs)`
+                : condensed.display,
               variant: 'destructive',
+              // Only offered when there is more to read than what is shown, so
+              // the common short error keeps a plain toast.
+              action: condensed.truncated ? (
+                <ToastAction
+                  altText="Copy the full error text"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(condensed.full);
+                  }}
+                >
+                  Copy
+                </ToastAction>
+              ) : undefined,
             });
           }
         } catch {

--- a/app/src/lib/utils/errorText.ts
+++ b/app/src/lib/utils/errorText.ts
@@ -28,7 +28,12 @@ const TOAST_ERROR_BUDGET = 400;
 const MIN_TO_CONDENSE = TOAST_ERROR_BUDGET + 120;
 
 export interface CondensedError {
-  /** What to show in the toast. Trimmed, and shortened when oversized. */
+  /** What to show in the toast.
+   *
+   * Byte-identical to `full` whenever nothing is omitted, so a message that
+   * fits is never altered. Only an oversized one is rewritten, into a trimmed
+   * head followed by an ellipsis.
+   */
   display: string;
   /** The original string exactly as received, for copying. Never modified. */
   full: string;
@@ -40,14 +45,15 @@ export interface CondensedError {
 
 export function condenseError(raw: string | null | undefined): CondensedError {
   // `full` is what the Copy action hands over, so it stays byte-for-byte what
-  // the server sent. All the measuring and cutting below works on the trimmed
-  // copy instead — surrounding blank space should not count toward the budget
-  // or the omitted count.
+  // the server sent. The measuring and cutting below works on a trimmed copy
+  // instead — surrounding blank space should not count toward the budget or
+  // the omitted count — but `text` is never what gets returned as `display`
+  // unless the message is actually being shortened.
   const full = raw ?? '';
   const text = full.trim();
 
   if (text.length <= MIN_TO_CONDENSE) {
-    return { display: text, full, truncated: false, omitted: 0 };
+    return { display: full, full, truncated: false, omitted: 0 };
   }
 
   // A traceback's first line is nearly always the message; prefer it whenever
@@ -71,9 +77,10 @@ export function condenseError(raw: string | null | undefined): CondensedError {
   head = head.trimEnd();
   const omitted = text.length - head.length;
 
-  // Guard against the boundary search having produced nothing shorter.
+  // Guard against the boundary search having produced nothing shorter. Nothing
+  // is omitted here either, so the message goes back exactly as it arrived.
   if (omitted <= 0) {
-    return { display: text, full, truncated: false, omitted: 0 };
+    return { display: full, full, truncated: false, omitted: 0 };
   }
 
   return { display: `${head} …`, full, truncated: true, omitted };

--- a/app/src/lib/utils/errorText.ts
+++ b/app/src/lib/utils/errorText.ts
@@ -1,0 +1,67 @@
+/**
+ * Condense a server error for display in a toast.
+ *
+ * Some backend errors are enormous and mostly noise. The transformers
+ * "Unrecognized model" error is ~4.8KB, of which the first sentence carries all
+ * the meaning and the remaining 4.7KB is an alphabetical list of every model
+ * architecture it knows about. Rendering that in a 420px toast clipped the text
+ * at both ends and pushed the close button off-screen.
+ *
+ * The rule is deliberately generic rather than pattern-matching any one
+ * library: keep the head, cut at the most natural boundary available inside the
+ * budget, and report how much was dropped so nobody assumes they read it all.
+ */
+
+/** Characters of an error worth putting in a toast. Roughly the first
+ * paragraph — enough for a sentence or two of real message. */
+const TOAST_ERROR_BUDGET = 400;
+
+/** Below this there is nothing to gain by condensing. */
+const MIN_TO_CONDENSE = TOAST_ERROR_BUDGET + 120;
+
+export interface CondensedError {
+  /** What to show in the toast. */
+  display: string;
+  /** The untouched original, for copying. */
+  full: string;
+  /** Whether `display` is shorter than `full`. */
+  truncated: boolean;
+  /** How many characters `display` leaves out. */
+  omitted: number;
+}
+
+export function condenseError(raw: string | null | undefined): CondensedError {
+  const full = (raw ?? '').trim();
+
+  if (full.length <= MIN_TO_CONDENSE) {
+    return { display: full, full, truncated: false, omitted: 0 };
+  }
+
+  // A traceback's first line is nearly always the message; prefer it whenever
+  // it fits, since a newline is a stronger boundary than any punctuation.
+  const firstLine = full.split('\n', 1)[0].trim();
+  let head =
+    firstLine.length > 0 && firstLine.length <= TOAST_ERROR_BUDGET
+      ? firstLine
+      : full.slice(0, TOAST_ERROR_BUDGET);
+
+  if (head.length < full.length && head === full.slice(0, head.length)) {
+    // Back off to the last sentence end inside the budget so the text does not
+    // stop mid-word. Only accept it if it keeps most of the budget — otherwise
+    // a stray early period would throw away usable context.
+    const lastStop = Math.max(head.lastIndexOf('. '), head.lastIndexOf('? '));
+    if (lastStop > TOAST_ERROR_BUDGET * 0.4) {
+      head = head.slice(0, lastStop + 1);
+    }
+  }
+
+  head = head.trimEnd();
+  const omitted = full.length - head.length;
+
+  // Guard against the boundary search having produced nothing shorter.
+  if (omitted <= 0) {
+    return { display: full, full, truncated: false, omitted: 0 };
+  }
+
+  return { display: `${head} …`, full, truncated: true, omitted };
+}

--- a/app/src/lib/utils/errorText.ts
+++ b/app/src/lib/utils/errorText.ts
@@ -12,9 +12,19 @@
  * budget, and report how much was dropped so nobody assumes they read it all.
  */
 
-/** Characters of an error worth putting in a toast. Roughly the first
- * paragraph — enough for a sentence or two of real message. */
-const TOAST_ERROR_BUDGET = 400;
+/** Longest head of an oversized error kept for the toast, before the ellipsis.
+ *
+ * Roughly the first paragraph — enough for a sentence or two of real message.
+ * This bounds the *message* rather than the rendered string: `display` is this
+ * plus `TRUNCATION_SUFFIX` when something was cut. Spending two of these
+ * characters on the ellipsis instead would shorten the message to no purpose,
+ * since nothing downstream has a hard character limit — the description box
+ * scrolls.
+ */
+const HEAD_BUDGET = 400;
+
+/** Marks a `display` value as incomplete. Appended after the head. */
+const TRUNCATION_SUFFIX = ' …';
 
 /** Below this, condensing is not worth it and the whole message is shown.
  *
@@ -25,7 +35,7 @@ const TOAST_ERROR_BUDGET = 400;
  * around a single character. No Copy action is offered in this range because
  * nothing is being withheld: `display` already holds the entire message.
  */
-const MIN_TO_CONDENSE = TOAST_ERROR_BUDGET + 120;
+const MIN_TO_CONDENSE = HEAD_BUDGET + 120;
 
 export interface CondensedError {
   /** What to show in the toast.
@@ -60,16 +70,16 @@ export function condenseError(raw: string | null | undefined): CondensedError {
   // it fits, since a newline is a stronger boundary than any punctuation.
   const firstLine = text.split('\n', 1)[0].trim();
   let head =
-    firstLine.length > 0 && firstLine.length <= TOAST_ERROR_BUDGET
+    firstLine.length > 0 && firstLine.length <= HEAD_BUDGET
       ? firstLine
-      : text.slice(0, TOAST_ERROR_BUDGET);
+      : text.slice(0, HEAD_BUDGET);
 
   if (head.length < text.length && head === text.slice(0, head.length)) {
     // Back off to the last sentence end inside the budget so the text does not
     // stop mid-word. Only accept it if it keeps most of the budget — otherwise
     // a stray early period would throw away usable context.
     const lastStop = Math.max(head.lastIndexOf('. '), head.lastIndexOf('? '));
-    if (lastStop > TOAST_ERROR_BUDGET * 0.4) {
+    if (lastStop > HEAD_BUDGET * 0.4) {
       head = head.slice(0, lastStop + 1);
     }
   }
@@ -83,5 +93,5 @@ export function condenseError(raw: string | null | undefined): CondensedError {
     return { display: full, full, truncated: false, omitted: 0 };
   }
 
-  return { display: `${head} …`, full, truncated: true, omitted };
+  return { display: `${head}${TRUNCATION_SUFFIX}`, full, truncated: true, omitted };
 }

--- a/app/src/lib/utils/errorText.ts
+++ b/app/src/lib/utils/errorText.ts
@@ -16,36 +16,49 @@
  * paragraph — enough for a sentence or two of real message. */
 const TOAST_ERROR_BUDGET = 400;
 
-/** Below this there is nothing to gain by condensing. */
+/** Below this, condensing is not worth it and the whole message is shown.
+ *
+ * Deliberately above the budget rather than equal to it. An error of 450
+ * characters would otherwise be cut to 400 to save 50 — a worse result than
+ * showing all of it, since the description scrolls anyway. The gap also gives
+ * the threshold hysteresis instead of flipping between full and truncated
+ * around a single character. No Copy action is offered in this range because
+ * nothing is being withheld: `display` already holds the entire message.
+ */
 const MIN_TO_CONDENSE = TOAST_ERROR_BUDGET + 120;
 
 export interface CondensedError {
-  /** What to show in the toast. */
+  /** What to show in the toast. Trimmed, and shortened when oversized. */
   display: string;
-  /** The untouched original, for copying. */
+  /** The original string exactly as received, for copying. Never modified. */
   full: string;
-  /** Whether `display` is shorter than `full`. */
+  /** Whether `display` omits part of the message. */
   truncated: boolean;
   /** How many characters `display` leaves out. */
   omitted: number;
 }
 
 export function condenseError(raw: string | null | undefined): CondensedError {
-  const full = (raw ?? '').trim();
+  // `full` is what the Copy action hands over, so it stays byte-for-byte what
+  // the server sent. All the measuring and cutting below works on the trimmed
+  // copy instead — surrounding blank space should not count toward the budget
+  // or the omitted count.
+  const full = raw ?? '';
+  const text = full.trim();
 
-  if (full.length <= MIN_TO_CONDENSE) {
-    return { display: full, full, truncated: false, omitted: 0 };
+  if (text.length <= MIN_TO_CONDENSE) {
+    return { display: text, full, truncated: false, omitted: 0 };
   }
 
   // A traceback's first line is nearly always the message; prefer it whenever
   // it fits, since a newline is a stronger boundary than any punctuation.
-  const firstLine = full.split('\n', 1)[0].trim();
+  const firstLine = text.split('\n', 1)[0].trim();
   let head =
     firstLine.length > 0 && firstLine.length <= TOAST_ERROR_BUDGET
       ? firstLine
-      : full.slice(0, TOAST_ERROR_BUDGET);
+      : text.slice(0, TOAST_ERROR_BUDGET);
 
-  if (head.length < full.length && head === full.slice(0, head.length)) {
+  if (head.length < text.length && head === text.slice(0, head.length)) {
     // Back off to the last sentence end inside the budget so the text does not
     // stop mid-word. Only accept it if it keeps most of the budget — otherwise
     // a stray early period would throw away usable context.
@@ -56,11 +69,11 @@ export function condenseError(raw: string | null | undefined): CondensedError {
   }
 
   head = head.trimEnd();
-  const omitted = full.length - head.length;
+  const omitted = text.length - head.length;
 
   // Guard against the boundary search having produced nothing shorter.
   if (omitted <= 0) {
-    return { display: full, full, truncated: false, omitted: 0 };
+    return { display: text, full, truncated: false, omitted: 0 };
   }
 
   return { display: `${head} …`, full, truncated: true, omitted };


### PR DESCRIPTION
A failed generation put the server's error straight into a toast. The transformers "Unrecognized model" error is ~4.8KB, of which the first sentence carries the meaning and the remaining 4.7KB is an alphabetical list of every architecture it knows. In a 420px toast with overflow-hidden and no scroll, that clipped the text at both ends and pushed the close button off-screen: unreadable and undismissable.

- ToastDescription is capped at 40vh and scrolls, wraps on whitespace and breaks long unspaced tokens so a path cannot widen the toast.
- The toast aligns to the start rather than centring, so the title stays visible next to a tall description.
- condenseError() keeps the head of an oversized error, cutting at the first newline or the last sentence end inside a 400-char budget, and reports how many characters it dropped. Short errors pass through untouched.
- When it does truncate, the toast offers a Copy action for the full text and points at Settings -> Logs.

Verified against the real 4795-char error: 4795 -> 400 chars keeping both meaningful sentences.

The hook moves to .tsx to render ToastAction, matching useAutoUpdater.tsx which is a .tsx hook for the same reason. createElement was tried first but this repo's ToastActionElement type is the older shadcn definition (ReactElement<typeof ToastAction>) which only accepts JSX-constructed elements.

------------------------------

## OLD error toast

<img width="575" height="1200" alt="image" src="https://github.com/user-attachments/assets/bc3cb699-9351-44bd-903f-ae376406703f" />

## NEW error toast

<img width="512" height="503" alt="image" src="https://github.com/user-attachments/assets/98507177-8445-41d2-91e0-ef6e0a46d347" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long generation errors are summarized in notifications, with an option to copy the complete error text.
  * Error messages preserve readable formatting and support scrolling for lengthy content.

* **Bug Fixes**
  * Toast content now aligns consistently and wraps long unbroken text more effectively.
  * Lengthy descriptions are constrained to improve readability.
  * Short error messages continue to display as standard error notifications.
  * Clipboard failures now display an error notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->