### PR TITLE
fix(build): pick a supported Python and fail loudly on Windows setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,18 +87,26 @@ setup-python:
 setup-python:
     if (-not (Test-Path "{{ venv }}")) { \
         Write-Host "Creating Python virtual environment..."; \
-        $pyMinor = & {{ system_python }} -c "import sys; print(sys.version_info[1])"; \
-        if ([int]$pyMinor -gt 12) { \
-            Write-Host "Python 3.$pyMinor is not supported: requirements.txt pins numpy<2.0," -ForegroundColor Red; \
-            Write-Host "and numpy 1.x ships no wheels past cp312, so pip resolves nothing and" -ForegroundColor Red; \
-            Write-Host "leaves the venv silently incomplete." -ForegroundColor Red; \
-            Write-Host "Install Python 3.12 (winget install Python.Python.3.12), then re-run."; \
-            throw "Unsupported Python 3.$pyMinor for venv creation"; \
+        $pyVer = & "{{ system_python }}" -c "import sys; print(sys.version_info[0], sys.version_info[1], sep=chr(46))"; \
+        if ($LASTEXITCODE -ne 0 -or -not $pyVer) { \
+            Write-Host "Could not run a Python interpreter to check its version." -ForegroundColor Red; \
+            Write-Host "Tried: {{ system_python }}" -ForegroundColor Red; \
+            throw "No usable Python found for venv creation"; \
         }; \
-        & {{ system_python }} -m venv {{ venv }}; \
+        if ($pyVer.Trim() -ne "3.12") { \
+            Write-Host "Python $($pyVer.Trim()) is not supported. This project needs 3.12:" -ForegroundColor Red; \
+            Write-Host "  backend/pyproject.toml requires-python is >=3.12" -ForegroundColor Red; \
+            Write-Host "  requirements.txt pins numpy<2.0, whose last wheels are cp312" -ForegroundColor Red; \
+            Write-Host "On anything newer pip resolves nothing and leaves the venv silently incomplete."; \
+            Write-Host "Install Python 3.12 (winget install Python.Python.3.12), then re-run."; \
+            throw "Unsupported Python $($pyVer.Trim()) for venv creation"; \
+        }; \
+        & "{{ system_python }}" -m venv {{ venv }}; \
+        if ($LASTEXITCODE -ne 0) { throw "python -m venv failed with exit code $LASTEXITCODE" }; \
     }
     Write-Host "Installing Python dependencies..."
-    & "{{ python }}" -m pip install --upgrade pip -q
+    & "{{ python }}" -m pip install --upgrade pip -q; \
+    if ($LASTEXITCODE -ne 0) { throw "pip self-upgrade failed with exit code $LASTEXITCODE" }
     $gpus = Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name; \
     Write-Host "Detected GPUs: $($gpus -join ', ')"; \
     $hasNvidia = ($gpus | Where-Object { $_ -match 'NVIDIA' }).Count -gt 0; \
@@ -106,10 +114,13 @@ setup-python:
     if ($hasNvidia) { \
         Write-Host "NVIDIA GPU detected — installing PyTorch with CUDA support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128; \
+        if ($LASTEXITCODE -ne 0) { throw "CUDA PyTorch install failed with exit code $LASTEXITCODE" }; \
     } elseif ($hasIntelArc) { \
         Write-Host "Intel Arc GPU detected — installing PyTorch with XPU support..."; \
         & "{{ pip }}" install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu; \
+        if ($LASTEXITCODE -ne 0) { throw "XPU PyTorch install failed with exit code $LASTEXITCODE" }; \
         & "{{ pip }}" install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu; \
+        if ($LASTEXITCODE -ne 0) { throw "intel-extension-for-pytorch install failed with exit code $LASTEXITCODE" }; \
     } else { \
         Write-Host "No NVIDIA or Intel Arc GPU detected — using CPU-only PyTorch."; \
         Write-Host "If you have an Intel Arc GPU, install XPU support manually:"; \

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ pip := if os() == "windows" { venv_bin / "pip.exe" } else { venv_bin / "pip" }
 set windows-shell := ["powershell", "-NoProfile", "-Command"]
 
 # Detect best python for venv creation (platform-aware)
-system_python := if os() == "windows" { "python" } else { `command -v python3.12 2>/dev/null || command -v python3.13 2>/dev/null || echo python3` }
+system_python := if os() == "windows" { `$best='python'; if (Get-Command py -ErrorAction SilentlyContinue) { foreach ($v in @('3.12','3.13')) { $p = (& py "-$v" -c "import sys; print(sys.executable)" 2>$null); if ($LASTEXITCODE -eq 0 -and $p) { $best = $p.Trim(); break } } }; $best` } else { `command -v python3.12 2>/dev/null || command -v python3.13 2>/dev/null || echo python3` }
 
 # ─── Setup ────────────────────────────────────────────────────────────
 
@@ -88,8 +88,12 @@ setup-python:
     if (-not (Test-Path "{{ venv }}")) { \
         Write-Host "Creating Python virtual environment..."; \
         $pyMinor = & {{ system_python }} -c "import sys; print(sys.version_info[1])"; \
-        if ([int]$pyMinor -gt 13) { \
-            Write-Host "Warning: Python 3.$pyMinor detected. ML packages may not be compatible."; \
+        if ([int]$pyMinor -gt 12) { \
+            Write-Host "Python 3.$pyMinor is not supported: requirements.txt pins numpy<2.0," -ForegroundColor Red; \
+            Write-Host "and numpy 1.x ships no wheels past cp312, so pip resolves nothing and" -ForegroundColor Red; \
+            Write-Host "leaves the venv silently incomplete." -ForegroundColor Red; \
+            Write-Host "Install Python 3.12 (winget install Python.Python.3.12), then re-run."; \
+            throw "Unsupported Python 3.$pyMinor for venv creation"; \
         }; \
         & {{ system_python }} -m venv {{ venv }}; \
     }
@@ -112,11 +116,16 @@ setup-python:
         Write-Host "  pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu"; \
         Write-Host "  pip install intel-extension-for-pytorch --index-url https://download.pytorch.org/whl/xpu"; \
     }
-    & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt
-    & "{{ pip }}" install --no-deps chatterbox-tts
-    & "{{ pip }}" install --no-deps hume-tada
-    & "{{ pip }}" install git+https://github.com/QwenLM/Qwen3-TTS.git
-    & "{{ pip }}" install pyinstaller ruff pytest pytest-asyncio -q
+    & "{{ pip }}" install -r {{ backend_dir }}/requirements.txt; \
+    if ($LASTEXITCODE -ne 0) { throw "pip install -r requirements.txt failed with exit code $LASTEXITCODE" }
+    & "{{ pip }}" install --no-deps chatterbox-tts; \
+    if ($LASTEXITCODE -ne 0) { throw "pip install chatterbox-tts failed with exit code $LASTEXITCODE" }
+    & "{{ pip }}" install --no-deps hume-tada; \
+    if ($LASTEXITCODE -ne 0) { throw "pip install hume-tada failed with exit code $LASTEXITCODE" }
+    & "{{ pip }}" install git+https://github.com/QwenLM/Qwen3-TTS.git; \
+    if ($LASTEXITCODE -ne 0) { throw "pip install Qwen3-TTS failed with exit code $LASTEXITCODE" }
+    & "{{ pip }}" install pyinstaller ruff pytest pytest-asyncio -q; \
+    if ($LASTEXITCODE -ne 0) { throw "pip install build/test tooling failed with exit code $LASTEXITCODE" }
     Write-Host "Python environment ready."
 
 # Install JavaScript dependencies


### PR DESCRIPTION
`just setup-python` could report success while installing almost nothing, leaving a venv that builds a sidecar which dies on its first import.

Three causes, all Windows-only:

- system_python was the literal "python", unlike the unix branch which prefers python3.12. On a machine whose default is 3.14 the venv was created there.
- requirements.txt pins numpy>=1.24,<2.0, and numpy 1.x publishes no wheels past cp312, so pip resolved nothing and installed none of the requirements. 18 declared packages were missing, including sqlalchemy.
- pip.exe is a native command, so $ErrorActionPreference = "Stop" does not trap its failure. Setup continued through the remaining steps and finished with "Python environment ready".

PyInstaller then only *warns* about hidden imports it cannot find, so the build also succeeded and produced a 361MB binary that exited 1 on `import sqlalchemy` from backend/database/models.py -- surfacing in the app as a generic "server failed to start".

Now: the interpreter is resolved through the py launcher (3.12, then 3.13), an unsupported version is a hard error naming the numpy constraint rather than a Write-Host warning, and every pip step checks $LASTEXITCODE. The guards are joined to their pip calls with a line continuation because just runs each recipe line in its own shell, where $LASTEXITCODE from the previous line is $null.

Wheel availability confirmed for the pinned numpy: cp312 yes, cp313 and cp314 no.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows Python detection by selecting supported Python 3.12 or 3.13 installations when available.
  - Added validation and clear errors for unsupported Python versions or failed virtual-environment creation.
  - Dependency installation now reports package installation failures immediately with descriptive errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->