### PR TITLE
fix(backend): honour VOICEBOX_FORCE_CPU in device selection

### DIFF
--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -6,6 +6,7 @@ voice prompt combination, and model loading progress tracking.
 """
 
 import logging
+import os
 import platform
 from contextlib import contextmanager
 from pathlib import Path
@@ -77,6 +78,13 @@ def is_model_cached(
         return False
 
 
+# Documented escape hatch (docs/content/docs/overview/gpu-acceleration.mdx):
+# users whose GPU has no compiled kernels in the bundled PyTorch set this to run
+# on CPU instead of crashing at generation time.
+FORCE_CPU_ENV_VAR = "VOICEBOX_FORCE_CPU"
+FORCE_CPU_ENABLED_VALUE = "1"
+
+
 def get_torch_device(
     *,
     allow_xpu: bool = False,
@@ -92,7 +100,16 @@ def get_torch_device(
         allow_directml: Check for DirectML (Windows) support.
         allow_mps: Allow MPS (Apple Silicon). If False, MPS falls back to CPU.
         force_cpu_on_mac: Force CPU on macOS regardless of GPU availability.
+
+    The VOICEBOX_FORCE_CPU override wins over every other candidate, and is
+    resolved before torch is imported so it still works when the installed
+    build is the reason CPU is wanted.
     """
+    # Stripped: on Windows, where this override matters most, it is usually set
+    # through the GUI environment editor.
+    if os.environ.get(FORCE_CPU_ENV_VAR, "").strip() == FORCE_CPU_ENABLED_VALUE:
+        return "cpu"
+
     if force_cpu_on_mac and platform.system() == "Darwin":
         return "cpu"
 

--- a/backend/tests/test_force_cpu_env.py
+++ b/backend/tests/test_force_cpu_env.py
@@ -1,0 +1,80 @@
+"""
+Regression tests for the VOICEBOX_FORCE_CPU environment override.
+
+The docs promise (docs/content/docs/developer/tts-generation.mdx) that
+get_torch_device() layers "VOICEBOX_FORCE_CPU environment override" ahead of
+CUDA/XPU/MPS detection, and gpu-acceleration.mdx tells users to set it to fall
+back to CPU when the bundled PyTorch has no kernels for their GPU.
+
+torch is stubbed through sys.modules so these run without a torch install and
+without any GPU.
+
+Usage:
+    python -m pytest backend/tests/test_force_cpu_env.py -v
+"""
+
+import sys
+
+import pytest
+
+from backend.backends.base import get_torch_device
+
+# The documented public name and value of the override. Pinned here independently
+# of the production constants so a rename of either fails these tests.
+FORCE_CPU_ENV_VAR = "VOICEBOX_FORCE_CPU"
+
+# Sentinel for "the variable is not set at all".
+UNSET = None
+
+
+class _FakeCuda:
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _FakeTorch:
+    """Minimal stand-in for a CUDA-enabled torch install."""
+
+    cuda = _FakeCuda
+
+
+@pytest.fixture
+def cuda_available(monkeypatch):
+    """Make torch report a usable CUDA device without installing torch."""
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch)
+
+
+def _set_override(monkeypatch, value):
+    if value is UNSET:
+        monkeypatch.delenv(FORCE_CPU_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(FORCE_CPU_ENV_VAR, value)
+
+
+@pytest.mark.parametrize("value", ["1", " 1 "])
+def test_force_cpu_wins_over_available_cuda(monkeypatch, cuda_available, value):
+    """The documented value must beat an otherwise usable CUDA device.
+
+    Surrounding whitespace is tolerated: on Windows, where this override
+    matters most, it is typically set through the GUI environment editor."""
+    _set_override(monkeypatch, value)
+
+    assert get_torch_device(allow_xpu=True, allow_directml=True, allow_mps=True) == "cpu"
+
+
+@pytest.mark.parametrize("value", [UNSET, "", "0"])
+def test_without_override_cuda_is_still_selected(monkeypatch, cuda_available, value):
+    """Unset or disabled must not disturb normal device detection."""
+    _set_override(monkeypatch, value)
+
+    assert get_torch_device() == "cuda"
+
+
+def test_force_cpu_does_not_need_torch(monkeypatch):
+    """The override is honoured before torch is imported, so it works on a
+    broken/incompatible torch install — which is the case it exists for."""
+    _set_override(monkeypatch, "1")
+    monkeypatch.setitem(sys.modules, "torch", None)  # makes `import torch` raise
+
+    assert get_torch_device() == "cpu"


### PR DESCRIPTION
## Problem

`VOICEBOX_FORCE_CPU` is documented in two places:

- `docs/content/docs/overview/gpu-acceleration.mdx` — *"Fall back to CPU temporarily — set `VOICEBOX_FORCE_CPU=1` before launching"*
- `docs/content/docs/developer/tts-generation.mdx` — lists it as **step 1** of the `get_torch_device()` precedence chain, ahead of CUDA / XPU / MPS / CPU

It is implemented nowhere. On `main`:

```
$ grep -rn VOICEBOX_FORCE_CPU --exclude-dir=node_modules .
docs/content/docs/overview/gpu-acceleration.mdx:153:4. **Fall back to CPU** temporarily — set `VOICEBOX_FORCE_CPU=1` before launching
docs/content/docs/developer/tts-generation.mdx:120:1. `VOICEBOX_FORCE_CPU` environment override
```

Two doc hits, zero code hits. `get_torch_device()` in `backend/backends/base.py` goes straight to `torch.cuda.is_available()`.

That leaves users whose GPU has no compiled kernels in the bundled PyTorch with no documented way out — the reporter in #998 (GTX 1050 Ti, Pascal / sm_61) set the variable as instructed, confirmed it in a fresh shell, restarted, and the server still selected CUDA and failed with `cudaErrorNoKernelImageForDevice`. Their only working escape was renaming `%APPDATA%\sh.voicebox.app\backends\cuda` on disk.

## Fix

Honour the variable in `get_torch_device()`, which is the single device-selection chokepoint for every PyTorch engine — the other `torch.cuda.is_available()` call sites in `backend/backends/` only clear caches or seed RNGs, they do not pick a device.

The check runs **before** `import torch`, so the override still works when the installed torch build is itself the reason CPU is wanted. The value is stripped before comparison: on Windows, where this matters most, the variable is usually set through the GUI environment editor.

Only the documented value `1` activates it, so nothing changes for anyone not already following the docs.

## Test verification (RED → GREEN)

New test: `backend/tests/test_force_cpu_env.py`. It stubs `torch` through `sys.modules` (same technique as `test_amd_gpu_detect.py::test_torch_not_installed`), so it runs with no GPU and no torch install.

**RED** — on `main` with only the test file added, production code untouched:

```
$ python -m pytest backend/tests/test_force_cpu_env.py -v
backend/tests/test_force_cpu_env.py::test_force_cpu_wins_over_available_cuda[1] FAILED   [ 16%]
backend/tests/test_force_cpu_env.py::test_force_cpu_wins_over_available_cuda[ 1 ] FAILED [ 33%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[None] PASSED [ 50%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[] PASSED     [ 66%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[0] PASSED    [ 83%]
backend/tests/test_force_cpu_env.py::test_force_cpu_does_not_need_torch FAILED                 [100%]

E       AssertionError: assert 'cuda' == 'cpu'

========================= 3 failed, 3 passed in 0.55s ==========================
```

The three that pass on `main` are the control cases — no override set, CUDA still selected. They must not change, and they don't.

**GREEN** — same test file, with this patch:

```
$ python -m pytest backend/tests/test_force_cpu_env.py -v
backend/tests/test_force_cpu_env.py::test_force_cpu_wins_over_available_cuda[1] PASSED   [ 16%]
backend/tests/test_force_cpu_env.py::test_force_cpu_wins_over_available_cuda[ 1 ] PASSED [ 33%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[None] PASSED [ 50%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[] PASSED     [ 66%]
backend/tests/test_force_cpu_env.py::test_without_override_cuda_is_still_selected[0] PASSED    [ 83%]
backend/tests/test_force_cpu_env.py::test_force_cpu_does_not_need_torch PASSED                 [100%]

============================== 6 passed in 0.47s ===============================
```

## Local CI

The `frontend-quality` job from `.github/workflows/ci.yml` — the entire `pull_request` gate — was replayed on both `main` and this commit, plus `ruff` and the touched test path:

| Step | `main` | this PR |
| --- | --- | --- |
| `bun install --frozen-lockfile` | PASS | PASS |
| `bun run typecheck` | PASS | PASS |
| `bun run build:web` | PASS | PASS |
| `ruff check` (touched files) | 13 findings | same 13, none added |
| `ruff format --check` (touched files) | PASS | PASS |
| `pytest backend/tests/test_force_cpu_env.py` | n/a | 6 passed |

The 13 `ruff` findings in `base.py` (`UP006`/`UP035`/`UP045`/`I001`/`F401`/`SIM102`/`SIM110`) pre-date this change and are left alone deliberately. Coverage on the changed executable production lines: 5/5.

## Not in this PR

#998 raises a second, separate point: `check_cuda_compatibility()` returned no warning for sm_61, so Settings → GPU showed the card as Active with no `[UNSUPPORTED]` flag. That function reads `torch.cuda._get_arch_list()` and looks correct by inspection — presumably `compute_61` was present, so the PTX-JIT path was expected to cover the card and didn't. Confirming that needs the actual hardware, so I've left it untouched rather than guess. Happy to split it out if someone with a Pascal card can capture `torch.cuda._get_arch_list()`.

Because of that, this PR references #998 without auto-closing it.

Issue: #998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment option to force the application to use the CPU for processing.
  * CPU mode takes priority over automatic hardware detection and works even when GPU libraries are unavailable.

* **Bug Fixes**
  * Improved device selection reliability for systems with unavailable or incompatible GPU support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->