### PR TITLE
fix: use language-specific aligners for TADA multilingual

### DIFF
--- a/backend/backends/hume_backend.py
+++ b/backend/backends/hume_backend.py
@@ -52,6 +52,21 @@ _TADA_CODEC_WEIGHT_FILES = [
     "encoder/model.safetensors",
 ]
 
+_TADA_ALIGNER_LANGUAGES = frozenset({"ar", "ch", "de", "es", "fr", "it", "ja", "pl", "pt"})
+_TADA_LANGUAGE_ALIASES = {"zh": "ch"}
+
+
+def _get_tada_aligner_language(language: str | None, model_size: str) -> str | None:
+    """Return the documented TADA aligner code for a 3B language."""
+    if model_size != "3B":
+        return None
+
+    normalized = (language or "").strip().lower()
+    normalized = _TADA_LANGUAGE_ALIASES.get(normalized, normalized)
+    if not normalized or normalized == "en":
+        return None
+    return normalized if normalized in _TADA_ALIGNER_LANGUAGES else None
+
 
 class HumeTadaBackend:
     """HumeAI TADA TTS backend for high-quality voice cloning."""
@@ -64,6 +79,8 @@ class HumeTadaBackend:
         self.model_size = "1B"  # default to 1B
         self._device = None
         self._model_load_lock = asyncio.Lock()
+        self._encoder_lock = asyncio.Lock()
+        self._encoder_language: str | None = None
 
     def _get_device(self) -> str:
         # Force CPU on macOS — MPS has issues with flow matching
@@ -176,6 +193,7 @@ class HumeTadaBackend:
             logger.info("Loading TADA encoder...")
             self.encoder = Encoder.from_pretrained(TADA_CODEC_REPO, subfolder="encoder").to(device)
             self.encoder.eval()
+            self._encoder_language = None
 
             # Load the causal LM (includes decoder for wav generation).
             # TadaForCausalLM.from_pretrained() calls
@@ -200,6 +218,7 @@ class HumeTadaBackend:
         if self.encoder is not None:
             del self.encoder
             self.encoder = None
+        self._encoder_language = None
 
         device = self._device
         self._device = None
@@ -214,6 +233,7 @@ class HumeTadaBackend:
         audio_path: str,
         reference_text: str,
         use_cache: bool = True,
+        language: str | None = None,
     ) -> Tuple[dict, bool]:
         """
         Create voice prompt from reference audio using TADA's encoder.
@@ -221,61 +241,101 @@ class HumeTadaBackend:
         TADA's encoder performs forced alignment between audio and text tokens,
         producing an EncoderOutput with 1:1 token-audio alignment. If no
         reference_text is provided, the encoder uses built-in ASR (English only).
+        The 3B model selects a documented language aligner here; 1B always uses
+        the default English aligner.
 
         We serialize the EncoderOutput to a dict for caching.
         """
         await self.load_model(self.model_size)
 
-        cache_key = ("tada_" + get_cache_key(audio_path, reference_text)) if use_cache else None
+        aligner_language = _get_tada_aligner_language(language, self.model_size)
+        requested_language = (language or "").strip().lower()
+        if self.model_size == "3B" and requested_language not in {"", "en"} and aligner_language is None:
+            logger.warning("[TADA] Unsupported aligner language=%s; using the default English aligner", language)
+
+        if self.model_size == "3B":
+            cache_prefix = f"tada_v2_{aligner_language or 'en'}_"
+        else:
+            cache_prefix = "tada_"
+        cache_key = cache_prefix + get_cache_key(audio_path, reference_text) if use_cache else None
 
         if cache_key:
             cached = get_cached_voice_prompt(cache_key)
             if cached is not None and isinstance(cached, dict):
                 return cached, True
 
-        def _encode_sync():
-            import torch
-            import soundfile as sf
+        async with self._encoder_lock:
+            # A concurrent request may have populated the cache while this one waited.
+            if cache_key:
+                cached = get_cached_voice_prompt(cache_key)
+                if cached is not None and isinstance(cached, dict):
+                    return cached, True
 
-            device = self._device
+            if self.encoder is None or self._encoder_language != aligner_language:
 
-            # Load audio with soundfile (torchaudio 2.10+ requires torchcodec)
-            audio_np, sr = sf.read(str(audio_path), dtype="float32")
-            audio = torch.from_numpy(audio_np).float()
-            if audio.ndim == 1:
-                audio = audio.unsqueeze(0)  # (samples,) -> (1, samples)
-            else:
-                audio = audio.T  # (samples, channels) -> (channels, samples)
-            audio = audio.to(device)
+                def _load_encoder_sync():
+                    from tada.modules.encoder import Encoder
 
-            # Encode with forced alignment.
-            # Must run under inference_mode: encoder params still require
-            # grad by default, and an autograd graph across the DAC/Snake
-            # stack can balloon VRAM far past the model footprint (#890).
-            text_arg = [reference_text] if reference_text else None
-            with torch.inference_mode():
-                prompt = self.encoder(audio, text=text_arg, sample_rate=sr)
+                    self.encoder = None
+                    self._encoder_language = None
+                    empty_device_cache(self._device)
 
-            # Serialize EncoderOutput to a dict of CPU tensors for caching
-            prompt_dict = {}
-            for field_name in prompt.__dataclass_fields__:
-                val = getattr(prompt, field_name)
-                if isinstance(val, torch.Tensor):
-                    prompt_dict[field_name] = val.detach().cpu()
-                elif isinstance(val, list):
-                    prompt_dict[field_name] = val
-                elif isinstance(val, (int, float)):
-                    prompt_dict[field_name] = val
+                    encoder_kwargs = {"subfolder": "encoder"}
+                    if aligner_language is not None:
+                        encoder_kwargs["language"] = aligner_language
+
+                    encoder = Encoder.from_pretrained(TADA_CODEC_REPO, **encoder_kwargs).to(self._device)
+                    encoder.eval()
+                    return encoder
+
+                self.encoder = await asyncio.to_thread(_load_encoder_sync)
+                self._encoder_language = aligner_language
+
+            logger.info("[TADA] Encoding voice prompt with aligner language=%s", aligner_language or "en")
+
+            def _encode_sync():
+                import soundfile as sf
+                import torch
+
+                device = self._device
+
+                # Load audio with soundfile (torchaudio 2.10+ requires torchcodec)
+                audio_np, sr = sf.read(str(audio_path), dtype="float32")
+                audio = torch.from_numpy(audio_np).float()
+                if audio.ndim == 1:
+                    audio = audio.unsqueeze(0)  # (samples,) -> (1, samples)
                 else:
-                    prompt_dict[field_name] = val
-            return prompt_dict
+                    audio = audio.T  # (samples, channels) -> (channels, samples)
+                audio = audio.to(device)
 
-        encoded = await asyncio.to_thread(_encode_sync)
+                # Encode with forced alignment.
+                # Must run under inference_mode: encoder params still require
+                # grad by default, and an autograd graph across the DAC/Snake
+                # stack can balloon VRAM far past the model footprint (#890).
+                text_arg = [reference_text] if reference_text else None
+                with torch.inference_mode():
+                    prompt = self.encoder(audio, text=text_arg, sample_rate=sr)
 
-        if cache_key:
-            cache_voice_prompt(cache_key, encoded)
+                # Serialize EncoderOutput to a dict of CPU tensors for caching
+                prompt_dict = {}
+                for field_name in prompt.__dataclass_fields__:
+                    val = getattr(prompt, field_name)
+                    if isinstance(val, torch.Tensor):
+                        prompt_dict[field_name] = val.detach().cpu()
+                    elif isinstance(val, list):
+                        prompt_dict[field_name] = val
+                    elif isinstance(val, (int, float)):
+                        prompt_dict[field_name] = val
+                    else:
+                        prompt_dict[field_name] = val
+                return prompt_dict
 
-        return encoded, False
+            encoded = await asyncio.to_thread(_encode_sync)
+
+            if cache_key:
+                cache_voice_prompt(cache_key, encoded)
+
+            return encoded, False
 
     async def combine_voice_prompts(
         self,
@@ -331,12 +391,8 @@ class HumeTadaBackend:
 
             prompt = EncoderOutput(**restored)
 
-            # For non-English with the 3B-ML model, we could reload the
-            # encoder with the language-specific aligner. However, the
-            # generation itself is language-agnostic — only the encoder's
-            # aligner changes. Since we encode at create_voice_prompt time,
-            # the language is already baked in. For simplicity, we don't
-            # reload the encoder here.
+            # Generation is language-agnostic. The language-specific aligner
+            # was selected when create_voice_prompt encoded this prompt.
 
             logger.info(f"[TADA] Generating ({language}), text length: {len(text)}")
 

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -577,6 +577,9 @@ async def create_voice_prompt_for_profile(
         raise ValueError(f"No samples found for profile {profile_id}")
 
     tts_model = get_tts_backend_for_engine(engine)
+    prompt_kwargs = {"use_cache": use_cache}
+    if engine == "tada":
+        prompt_kwargs["language"] = profile.language
 
     if len(samples) == 1:
         sample = samples[0]
@@ -586,7 +589,7 @@ async def create_voice_prompt_for_profile(
         voice_prompt, _ = await tts_model.create_voice_prompt(
             str(sample_audio_path),
             sample.reference_text,
-            use_cache=use_cache,
+            **prompt_kwargs,
         )
         return voice_prompt
 
@@ -619,7 +622,7 @@ async def create_voice_prompt_for_profile(
     voice_prompt, _ = await tts_model.create_voice_prompt(
         str(combined_path),
         combined_text,
-        use_cache=use_cache,
+        **prompt_kwargs,
     )
     return voice_prompt
 

--- a/backend/tests/test_hume_multilingual_aligner.py
+++ b/backend/tests/test_hume_multilingual_aligner.py
@@ -1,0 +1,295 @@
+"""Regression coverage for TADA 3B multilingual prompt alignment (#1067)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.backends.hume_backend import HumeTadaBackend
+from backend.database import Base, ProfileSample, VoiceProfile
+from backend.services.profiles import create_voice_prompt_for_profile
+
+
+@dataclass
+class _FakeEncoderOutput:
+    emb: torch.Tensor
+    aligner_language: str
+
+
+class _FakeEncoder:
+    def __init__(self, aligner_language: str) -> None:
+        self.aligner_language = aligner_language
+
+    def to(self, device: str):
+        return self
+
+    def eval(self) -> None:
+        return None
+
+    def __call__(self, audio, text=None, sample_rate=None):
+        return _FakeEncoderOutput(
+            emb=torch.zeros(1, 4, device=audio.device),
+            aligner_language=self.aligner_language,
+        )
+
+
+class _CountingEncoder(_FakeEncoder):
+    def __init__(self, aligner_language: str) -> None:
+        super().__init__(aligner_language)
+        self.call_count = 0
+
+    def __call__(self, audio, text=None, sample_rate=None):
+        self.call_count += 1
+        time.sleep(0.05)
+        return super().__call__(audio, text=text, sample_rate=sample_rate)
+
+
+def _write_reference_wav(tmp_path):
+    wav = tmp_path / "reference.wav"
+    sf.write(str(wav), np.zeros(2400, dtype=np.float32), 24000)
+    return wav
+
+
+def _loaded_backend(model_size: str) -> HumeTadaBackend:
+    backend = HumeTadaBackend()
+    backend.model = object()
+    backend.model_size = model_size
+    backend._device = "cpu"
+    backend.encoder = _FakeEncoder("en")
+    return backend
+
+
+def _install_encoder_factory(monkeypatch):
+    from backend.utils.dac_shim import install_dac_shim
+
+    install_dac_shim()
+
+    from tada.modules.encoder import Encoder
+
+    requested_languages: list[str] = []
+
+    def fake_from_pretrained(repo_id, *, subfolder, **kwargs):
+        language = kwargs.get("language", "en")
+        requested_languages.append(language)
+        return _FakeEncoder(language)
+
+    monkeypatch.setattr(Encoder, "from_pretrained", fake_from_pretrained)
+    return requested_languages
+
+
+@pytest.mark.asyncio
+async def test_tada_3b_switches_between_polish_and_default_english_aligners(tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("3B")
+    requested_languages = _install_encoder_factory(monkeypatch)
+
+    polish_prompt, _ = await backend.create_voice_prompt(
+        str(wav),
+        "To jest próbka głosu.",
+        use_cache=False,
+        language="pl",
+    )
+    english_prompt, _ = await backend.create_voice_prompt(
+        str(wav),
+        "This is a voice sample.",
+        use_cache=False,
+        language="en",
+    )
+
+    assert polish_prompt["aligner_language"] == "pl"
+    assert english_prompt["aligner_language"] == "en"
+    assert requested_languages == ["pl", "en"]
+
+
+@pytest.mark.asyncio
+async def test_tada_3b_maps_voicebox_chinese_to_tada_ch_aligner(tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("3B")
+    requested_languages = _install_encoder_factory(monkeypatch)
+
+    prompt, _ = await backend.create_voice_prompt(
+        str(wav),
+        "这是语音样本。",
+        use_cache=False,
+        language="zh",
+    )
+
+    assert prompt["aligner_language"] == "ch"
+    assert requested_languages == ["ch"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("language", ["ar", "ch", "de", "es", "fr", "it", "ja", "pl", "pt"])
+async def test_tada_3b_accepts_documented_aligner_codes(language, tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("3B")
+    requested_languages = _install_encoder_factory(monkeypatch)
+
+    prompt, _ = await backend.create_voice_prompt(
+        str(wav),
+        "reference transcript",
+        use_cache=False,
+        language=language,
+    )
+
+    assert prompt["aligner_language"] == language
+    assert requested_languages == [language]
+
+
+@pytest.mark.asyncio
+async def test_tada_3b_prompt_cache_is_scoped_by_aligner_language(tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("3B")
+    cache_keys: list[str] = []
+
+    def cached_prompt(key):
+        cache_keys.append(key)
+        return {"cache_key": key}
+
+    monkeypatch.setattr("backend.backends.hume_backend.get_cached_voice_prompt", cached_prompt)
+
+    polish_prompt, polish_cached = await backend.create_voice_prompt(
+        str(wav),
+        "shared transcript",
+        language="pl",
+    )
+    english_prompt, english_cached = await backend.create_voice_prompt(
+        str(wav),
+        "shared transcript",
+        language="en",
+    )
+
+    assert polish_cached is True
+    assert english_cached is True
+    assert polish_prompt["cache_key"].startswith("tada_v2_pl_")
+    assert english_prompt["cache_key"].startswith("tada_v2_en_")
+    assert polish_prompt["cache_key"] != english_prompt["cache_key"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tada_prompts_encode_once_and_reuse_the_locked_cache(tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("3B")
+    encoder = _CountingEncoder("pl")
+    backend.encoder = encoder
+    backend._encoder_language = "pl"
+    cached_prompts = {}
+
+    monkeypatch.setattr(
+        "backend.backends.hume_backend.get_cached_voice_prompt",
+        lambda key: cached_prompts.get(key),
+    )
+    monkeypatch.setattr(
+        "backend.backends.hume_backend.cache_voice_prompt",
+        lambda key, prompt: cached_prompts.__setitem__(key, prompt),
+    )
+
+    results = await asyncio.gather(
+        backend.create_voice_prompt(str(wav), "shared transcript", language="pl"),
+        backend.create_voice_prompt(str(wav), "shared transcript", language="pl"),
+    )
+
+    assert encoder.call_count == 1
+    assert sorted(from_cache for _, from_cache in results) == [False, True]
+    assert results[0][0]["aligner_language"] == "pl"
+    assert results[1][0]["aligner_language"] == "pl"
+
+
+@pytest.mark.asyncio
+async def test_tada_1b_keeps_default_encoder_and_legacy_cache(tmp_path, monkeypatch):
+    wav = _write_reference_wav(tmp_path)
+    backend = _loaded_backend("1B")
+    requested_languages = _install_encoder_factory(monkeypatch)
+    cache_keys: list[str] = []
+
+    def no_cached_prompt(key):
+        cache_keys.append(key)
+
+    monkeypatch.setattr("backend.backends.hume_backend.get_cached_voice_prompt", no_cached_prompt)
+    monkeypatch.setattr("backend.backends.hume_backend.cache_voice_prompt", lambda key, prompt: None)
+
+    prompt, from_cache = await backend.create_voice_prompt(
+        str(wav),
+        "To jest próbka głosu.",
+        language="pl",
+    )
+
+    assert from_cache is False
+    assert prompt["aligner_language"] == "en"
+    assert requested_languages == []
+    assert cache_keys[0].startswith("tada_")
+    assert not cache_keys[0].startswith("tada_v2_")
+
+
+class _PromptBackend:
+    async def create_voice_prompt(
+        self,
+        audio_path: str,
+        reference_text: str,
+        use_cache: bool = True,
+        language: str | None = None,
+    ):
+        return {"language": language}, False
+
+
+class _PromptBackendWithoutLanguage:
+    async def create_voice_prompt(self, audio_path: str, reference_text: str, use_cache: bool = True):
+        return {"language_argument_received": False}, False
+
+
+@pytest.fixture
+def profile_db(tmp_path):
+    db_engine = create_engine(f"sqlite:///{tmp_path / 'profiles.db'}")
+    Base.metadata.create_all(bind=db_engine)
+    session = sessionmaker(bind=db_engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        db_engine.dispose()
+
+
+def _add_polish_profile(profile_db, wav_path) -> str:
+    profile = VoiceProfile(name="Polish voice", language="pl", voice_type="cloned")
+    profile_db.add(profile)
+    profile_db.flush()
+    profile_db.add(
+        ProfileSample(
+            profile_id=profile.id,
+            audio_path=str(wav_path),
+            reference_text="To jest próbka głosu.",
+        )
+    )
+    profile_db.commit()
+    return profile.id
+
+
+@pytest.mark.asyncio
+async def test_profile_language_reaches_tada_prompt_encoding(tmp_path, profile_db, monkeypatch):
+    profile_id = _add_polish_profile(profile_db, _write_reference_wav(tmp_path))
+    monkeypatch.setattr("backend.backends.get_tts_backend_for_engine", lambda engine: _PromptBackend())
+
+    prompt = await create_voice_prompt_for_profile(profile_id, profile_db, engine="tada")
+
+    assert prompt == {"language": "pl"}
+
+
+@pytest.mark.asyncio
+async def test_profile_language_is_not_passed_to_other_backends(tmp_path, profile_db, monkeypatch):
+    profile_id = _add_polish_profile(profile_db, _write_reference_wav(tmp_path))
+    monkeypatch.setattr(
+        "backend.backends.get_tts_backend_for_engine",
+        lambda engine: _PromptBackendWithoutLanguage(),
+    )
+
+    prompt = await create_voice_prompt_for_profile(profile_id, profile_db, engine="qwen")
+
+    assert prompt == {"language_argument_received": False}


### PR DESCRIPTION
## Summary

- propagate the voice profile language into TADA prompt encoding
- select documented TADA 3B aligners, including Voicebox `zh` to TADA `ch`
- keep TADA 1B on the default English encoder and legacy cache namespace
- separate TADA 3B prompt caches by normalized aligner language
- serialize encoder switching and prompt encoding around one active encoder to bound memory and prevent cross-language races

## Root cause

Voicebox encoded every TADA prompt with the encoder loaded at model startup, which omits `language` and therefore uses the default English aligner. The generation language arrived only after the prompt was already encoded, and the prompt cache key did not distinguish aligner languages.

`create_voice_prompt_for_profile` now passes language only to the TADA backend. TADA 3B normalizes the documented aligner code and reloads a single active encoder when necessary; cache hits avoid encoder switching, and a second cache check under the encoder lock prevents duplicate concurrent encoding. Unsupported languages retain the existing default-English fallback with a warning.

## Tests

- `pytest backend/tests/test_hume_multilingual_aligner.py backend/tests/test_hume_encode_inference_mode.py -q` — 17 passed
- broad backend suite excluding two unchanged upstream test problems — 166 passed, 8 skipped, 1 deselected
- regression RED on upstream — 6 failed, 2 passed because language was not accepted or propagated
- concurrency mutation check — removing the locked cache recheck fails with 2 encoder calls instead of 1
- Ruff check for the new regression tests and format check for the changed TADA/test files — passed
- `git diff --check` — passed

The unfiltered suite currently also encounters two unrelated existing problems: `test_profile_duplicate_names.py` fails during collection due its top-level `database` import, and `test_hf_progress_tracker` receives no tqdm callbacks in this container. Neither file nor the progress implementation is changed here.

## Controlled A/B

A local Docker A/B used the same Polish reference WAV, transcript, target text, TADA 3B settings, `seed=1067`, and disabled output normalization. Only the prompt aligner differed:

- default English aligner: 7.07975 s output, 5.16 s leading silence at a -40 dB/20 ms frame threshold
- Polish `pl` aligner: 7.17975 s output, 0.06 s leading silence at the same threshold

This is one controlled sample, not evidence of a general audio-quality improvement. Prior listening showed small and inconsistent subjective differences. The change fixes integration correctness by selecting the aligner documented by upstream TADA; it does not promise better synthesis quality.

Fixes #1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multilingual voice prompt alignment for TADA 3B, including Chinese and supported European and Asian languages.
  * Profile language settings are now applied automatically when creating TADA voice prompts.
  * Language-specific prompt caching improves reuse when switching between languages.

* **Bug Fixes**
  * Prevented duplicate prompt encoding during concurrent requests.
  * Preserved existing English alignment behavior for TADA 1B and unsupported languages.
  * Improved reliability when changing alignment languages between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->