### PR TITLE
fix(qwen): guard all backends against EOS-miss runaway audio

### DIFF
--- a/app/src/lib/hooks/useGenerationForm.ts
+++ b/app/src/lib/hooks/useGenerationForm.ts
@@ -45,7 +45,16 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
   const generation = useGeneration();
   const addPendingGeneration = useGenerationStore((state) => state.addPendingGeneration);
   const { settings: genSettings } = useGenerationSettings();
-  const maxChunkChars = genSettings?.max_chunk_chars ?? 800;
+  // Factory default for the chunk slider. When the user hasn't customized
+  // it, leave max_chunk_chars unset so the backend can pick the engine's
+  // own default — Qwen engines use a smaller chunk as part of their
+  // EOS-miss runaway guard (300 chars vs the global 800).
+  const FACTORY_DEFAULT_CHUNK_CHARS = 800;
+  const customChunkChars =
+    genSettings?.max_chunk_chars != null &&
+    genSettings.max_chunk_chars !== FACTORY_DEFAULT_CHUNK_CHARS
+      ? genSettings.max_chunk_chars
+      : undefined;
   const crossfadeMs = genSettings?.crossfade_ms ?? 50;
   const normalizeAudio = genSettings?.normalize_audio ?? true;
   const selectedEngine = useUIStore((state) => state.selectedEngine);
@@ -153,7 +162,7 @@ export function useGenerationForm(options: UseGenerationFormOptions = {}) {
         engine,
         instruct: supportsInstruct ? data.instruct || undefined : undefined,
         personality: data.personality || undefined,
-        max_chunk_chars: maxChunkChars,
+        max_chunk_chars: customChunkChars,
         crossfade_ms: crossfadeMs,
         normalize: normalizeAudio,
         effects_chain: effectsChain?.length ? effectsChain : undefined,

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -57,6 +57,10 @@ class ModelConfig:
     size_mb: int = 0
     needs_trim: bool = False
     retries_runaway: bool = False
+    # Engine-specific chunking default. Used when a generation request does
+    # not set max_chunk_chars explicitly. None means "use the global
+    # DEFAULT_MAX_CHUNK_CHARS".
+    default_chunk_chars: Optional[int] = None
     supports_instruct: bool = False
     languages: list[str] = field(default_factory=lambda: ["en"])
 
@@ -233,9 +237,18 @@ def _get_qwen_model_configs() -> list[ModelConfig]:
         repo_1_7b = "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
         repo_0_6b = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 
-    # mlx-audio can continue after an EOS miss with silence followed by
-    # codec noise. Retry only the affected text as smaller chunks.
-    retries_runaway = backend_type == "mlx"
+    # Qwen3-TTS can miss its codec EOS on ANY inference path — the EOS
+    # probability collapses to ~1e-14 (rank ~1500+, far outside top_k=50)
+    # and the model keeps decoding until max_new_tokens. This is
+    # model-intrinsic (measured on PyTorch CPU, MLX and sglang; see
+    # QwenLM/Qwen3-TTS#118 and sgl-project/sglang-omni#1179), so the
+    # retry guard must not be limited to the MLX backend.
+    retries_runaway = True
+
+    # Smaller chunks keep each autoregressive roll short, which both
+    # lowers the odds of an EOS miss and caps the damage when one
+    # happens. 300 chars ≈ 60-100s of audio per roll.
+    default_chunk_chars = 300
 
     return [
         ModelConfig(
@@ -246,6 +259,7 @@ def _get_qwen_model_configs() -> list[ModelConfig]:
             model_size="1.7B",
             size_mb=3500,
             retries_runaway=retries_runaway,
+            default_chunk_chars=default_chunk_chars,
             supports_instruct=False,  # Base model drops instruct silently
             languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
         ),
@@ -257,6 +271,7 @@ def _get_qwen_model_configs() -> list[ModelConfig]:
             model_size="0.6B",
             size_mb=1200,
             retries_runaway=retries_runaway,
+            default_chunk_chars=default_chunk_chars,
             supports_instruct=False,
             languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
         ),
@@ -265,6 +280,8 @@ def _get_qwen_model_configs() -> list[ModelConfig]:
 
 def _get_qwen_custom_voice_configs() -> list[ModelConfig]:
     """Return Qwen CustomVoice model configs."""
+    # Same Qwen3-TTS autoregressive core as the Base engine, so the same
+    # EOS-miss runaway guard and chunking default apply.
     return [
         ModelConfig(
             model_name="qwen-custom-voice-1.7B",
@@ -273,6 +290,8 @@ def _get_qwen_custom_voice_configs() -> list[ModelConfig]:
             hf_repo_id="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
             model_size="1.7B",
             size_mb=3500,
+            retries_runaway=True,
+            default_chunk_chars=300,
             supports_instruct=True,
             languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
         ),
@@ -283,6 +302,8 @@ def _get_qwen_custom_voice_configs() -> list[ModelConfig]:
             hf_repo_id="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
             model_size="0.6B",
             size_mb=1200,
+            retries_runaway=True,
+            default_chunk_chars=300,
             supports_instruct=True,
             languages=["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"],
         ),
@@ -517,6 +538,18 @@ def engine_retries_runaway(engine: str) -> bool:
         if cfg.engine == engine:
             return cfg.retries_runaway
     return False
+
+
+def get_engine_default_chunk_chars(engine: str) -> Optional[int]:
+    """Engine-specific chunk size to use when a request doesn't set one.
+
+    Returns None when the engine has no opinion, in which case callers
+    fall back to the global ``DEFAULT_MAX_CHUNK_CHARS``.
+    """
+    for cfg in get_tts_model_configs():
+        if cfg.engine == engine:
+            return cfg.default_chunk_chars
+    return None
 
 
 def engine_has_model_sizes(engine: str) -> bool:

--- a/backend/backends/__init__.py
+++ b/backend/backends/__init__.py
@@ -57,10 +57,9 @@ class ModelConfig:
     size_mb: int = 0
     needs_trim: bool = False
     retries_runaway: bool = False
-    # Engine-specific chunking default. Used when a generation request does
-    # not set max_chunk_chars explicitly. None means "use the global
-    # DEFAULT_MAX_CHUNK_CHARS".
-    default_chunk_chars: Optional[int] = None
+    # Engine-specific chunking default, used when a generation request
+    # does not set one explicitly; None falls back to the global default.
+    default_chunk_chars: int | None = None
     supports_instruct: bool = False
     languages: list[str] = field(default_factory=lambda: ["en"])
 

--- a/backend/backends/base.py
+++ b/backend/backends/base.py
@@ -200,6 +200,36 @@ def manual_seed(seed: int, device: str) -> None:
         torch.xpu.manual_seed(seed)
 
 
+# ── Qwen3-TTS decode budget ──────────────────────────────────────────
+#
+# Qwen3-TTS-12Hz occasionally misses its codec EOS and keeps decoding
+# until ``max_new_tokens``. The checkpoint ships with a budget of 8192
+# tokens ≈ 11.4 minutes of audio at 12 Hz, so a single EOS miss near the
+# end of a long chunk can append many minutes of near-silent gibberish
+# (measured: 175 chars of text produced 613s of runaway audio).
+#
+# Capping the budget per call bounds that damage. Normal speech never
+# comes close: the slowest sane delivery observed is ~2 chars/sec with
+# pauses ≈ 6 tokens/char at 12 Hz, so 12 tokens/char leaves ~2× headroom
+# even for the most deliberate narration.
+
+QWEN_TOKENS_PER_CHAR = 12
+QWEN_MIN_NEW_TOKENS = 1500  # ~2 min floor — short text must never truncate
+QWEN_MAX_NEW_TOKENS_CAP = 8192  # model's own hard limit
+
+
+def estimate_max_new_tokens(text: str) -> int:
+    """Bound a Qwen3-TTS decode so a missed EOS can't run for minutes.
+
+    Scales with the input length (punctuation/whitespace included — they
+    map to pauses, which cost tokens too), with a generous floor for
+    short text and the model's own limit as the cap.
+    """
+    chars = max(len(text.strip()), 1)
+    budget = chars * QWEN_TOKENS_PER_CHAR + QWEN_MIN_NEW_TOKENS // 2
+    return min(QWEN_MAX_NEW_TOKENS_CAP, max(QWEN_MIN_NEW_TOKENS, budget))
+
+
 async def combine_voice_prompts(
     audio_paths: List[str],
     reference_texts: List[str],

--- a/backend/backends/pytorch_backend.py
+++ b/backend/backends/pytorch_backend.py
@@ -15,6 +15,7 @@ from .base import (
     is_model_cached,
     get_torch_device,
     empty_device_cache,
+    estimate_max_new_tokens,
     manual_seed,
     combine_voice_prompts as _combine_voice_prompts,
     model_load_progress,
@@ -231,11 +232,17 @@ class PyTorchTTSBackend:
 
             # See _create_prompt_sync comment — inference runs with the
             # process's default HF_HUB_OFFLINE state (issue #462).
+            #
+            # Bound the decode window: Qwen3-TTS occasionally misses its
+            # codec EOS and would otherwise keep decoding (as silence or
+            # gibberish) until the checkpoint's 8192-token default —
+            # potentially minutes of junk appended to the clip.
             wavs, sample_rate = self.model.generate_voice_clone(
                 text=text,
                 voice_clone_prompt=voice_prompt,
                 language=LANGUAGE_CODE_TO_NAME.get(language, "auto"),
                 instruct=instruct,
+                max_new_tokens=estimate_max_new_tokens(text),
             )
             return wavs[0], sample_rate
 

--- a/backend/backends/qwen_custom_voice_backend.py
+++ b/backend/backends/qwen_custom_voice_backend.py
@@ -26,6 +26,7 @@ from .base import (
     is_model_cached,
     get_torch_device,
     combine_voice_prompts as _combine_voice_prompts,
+    estimate_max_new_tokens,
     model_load_progress,
 )
 
@@ -207,7 +208,13 @@ class QwenCustomVoiceBackend:
             # state. Forcing offline here (issue #462) regressed online
             # users whose libraries issue legitimate metadata lookups
             # during generation.
-            wavs, sample_rate = self.model.generate_custom_voice(**kwargs)
+            #
+            # Bound the decode window — same EOS-miss runaway risk as the
+            # Base engine (see estimate_max_new_tokens).
+            wavs, sample_rate = self.model.generate_custom_voice(
+                **kwargs,
+                max_new_tokens=estimate_max_new_tokens(text),
+            )
             return wavs[0], sample_rate
 
         audio, sample_rate = await asyncio.to_thread(_generate_sync)

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -325,6 +325,7 @@ async def stream_speech(
         engine_needs_trim,
         engine_retries_runaway,
         ensure_model_cached_or_raise,
+        get_engine_default_chunk_chars,
         get_tts_backend_for_engine,
         load_engine_model,
     )
@@ -359,9 +360,9 @@ async def stream_speech(
 
         trim_fn = trim_tts_output
     if engine_retries_runaway(engine):
-        from ..utils.audio import has_tts_runaway
+        from ..utils.audio import detect_tts_runaway
 
-        runaway_detector = has_tts_runaway
+        runaway_detector = detect_tts_runaway
 
     audio, sample_rate = await generate_chunked(
         tts_model,
@@ -370,7 +371,11 @@ async def stream_speech(
         language=data.language,
         seed=data.seed,
         instruct=data.instruct,
-        max_chunk_chars=data.max_chunk_chars,
+        max_chunk_chars=(
+            data.max_chunk_chars
+            if data.max_chunk_chars is not None
+            else get_engine_default_chunk_chars(engine)
+        ),
         crossfade_ms=data.crossfade_ms,
         trim_fn=trim_fn,
         runaway_detector=runaway_detector,

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -51,11 +51,12 @@ async def run_generation(
     from ..backends import (
         engine_needs_trim,
         engine_retries_runaway,
+        get_engine_default_chunk_chars,
         get_tts_backend_for_engine,
         load_engine_model,
     )
     from ..utils.chunked_tts import generate_chunked
-    from ..utils.audio import has_tts_runaway, normalize_audio, save_audio, trim_tts_output
+    from ..utils.audio import detect_tts_runaway, normalize_audio, save_audio, trim_tts_output
 
     task_manager = get_task_manager()
     bg_db = next(get_db())
@@ -77,7 +78,7 @@ async def run_generation(
 
         await history.update_generation_status(generation_id, "generating", bg_db)
         trim_fn = trim_tts_output if engine_needs_trim(engine) else None
-        runaway_detector = has_tts_runaway if engine_retries_runaway(engine) else None
+        runaway_detector = detect_tts_runaway if engine_retries_runaway(engine) else None
 
         gen_kwargs: dict = dict(
             language=language,
@@ -88,6 +89,10 @@ async def run_generation(
         )
         if max_chunk_chars is not None:
             gen_kwargs["max_chunk_chars"] = max_chunk_chars
+        else:
+            engine_default = get_engine_default_chunk_chars(engine)
+            if engine_default is not None:
+                gen_kwargs["max_chunk_chars"] = engine_default
         if crossfade_ms is not None:
             gen_kwargs["crossfade_ms"] = crossfade_ms
 
@@ -277,11 +282,12 @@ async def generate_audio_sync(
     from ..backends import (
         engine_needs_trim,
         engine_retries_runaway,
+        get_engine_default_chunk_chars,
         get_tts_backend_for_engine,
         load_engine_model,
     )
     from ..utils.chunked_tts import generate_chunked
-    from ..utils.audio import has_tts_runaway, normalize_audio, trim_tts_output
+    from ..utils.audio import detect_tts_runaway, normalize_audio, trim_tts_output
     from . import tts
 
     bg_db = next(get_db())
@@ -299,7 +305,7 @@ async def generate_audio_sync(
         bg_db.close()
 
     trim_fn = trim_tts_output if engine_needs_trim(engine) else None
-    runaway_detector = has_tts_runaway if engine_retries_runaway(engine) else None
+    runaway_detector = detect_tts_runaway if engine_retries_runaway(engine) else None
 
     gen_kwargs: dict = dict(
         language=language,
@@ -310,6 +316,10 @@ async def generate_audio_sync(
     )
     if max_chunk_chars is not None:
         gen_kwargs["max_chunk_chars"] = max_chunk_chars
+    else:
+        engine_default = get_engine_default_chunk_chars(engine)
+        if engine_default is not None:
+            gen_kwargs["max_chunk_chars"] = engine_default
     if crossfade_ms is not None:
         gen_kwargs["crossfade_ms"] = crossfade_ms
 

--- a/backend/tests/test_qwen_generation_guards.py
+++ b/backend/tests/test_qwen_generation_guards.py
@@ -14,22 +14,19 @@ the three layers that bound the damage:
    and default to smaller chunks unless the request overrides.
 """
 
-import math
-
 import numpy as np
-import pytest
 
 from backend.backends import (
     get_engine_default_chunk_chars,
     get_tts_model_configs,
 )
-from backend.utils.audio import (
-    exceeds_plausible_speech_duration,
-    detect_tts_runaway,
-)
 from backend.backends.base import (
     QWEN_MAX_NEW_TOKENS_CAP,
     estimate_max_new_tokens,
+)
+from backend.utils.audio import (
+    detect_tts_runaway,
+    exceeds_plausible_speech_duration,
 )
 
 SAMPLE_RATE = 24000
@@ -89,6 +86,15 @@ def test_duration_detector_tolerates_trailing_silence():
     silence = np.zeros(2 * SAMPLE_RATE, dtype=np.float32)
     audio = np.concatenate([speech, silence])
     assert not detect_tts_runaway(audio, SAMPLE_RATE, "a" * 100)
+
+
+def test_duration_detector_ignores_whitespace_padding():
+    # Blank lines / indent runs must not raise the threshold: 100 spoken
+    # chars + 1500 padding chars still caps the plausible duration at
+    # 100/1.2 + 15 ≈ 98s, so a 110s runaway is flagged.
+    padded_text = ("a" * 100) + ("\n\n  \t" * 250)
+    audio = np.full(110 * SAMPLE_RATE, 0.01, dtype=np.float32)
+    assert exceeds_plausible_speech_duration(audio, SAMPLE_RATE, padded_text)
 
 
 def test_duration_detector_handles_empty_input():

--- a/backend/tests/test_qwen_generation_guards.py
+++ b/backend/tests/test_qwen_generation_guards.py
@@ -1,0 +1,121 @@
+"""Coverage for the Qwen3-TTS EOS-miss guards.
+
+Qwen3-TTS occasionally misses its codec EOS. The decode then runs to
+``max_new_tokens`` (the checkpoint ships 8192 ≈ 11.4 min of audio) and
+appends minutes of near-silent gibberish to the clip. These tests cover
+the three layers that bound the damage:
+
+1. ``estimate_max_new_tokens`` — per-call decode budget.
+2. ``exceeds_plausible_speech_duration`` / ``detect_tts_runaway`` —
+   catching runaways the internal-silence detector misses (measured in
+   the wild: 175 chars of text produced 613s of low-level gibberish
+   with no internal silence gap).
+3. Engine wiring — qwen engines retry flagged chunks on every backend
+   and default to smaller chunks unless the request overrides.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from backend.backends import (
+    get_engine_default_chunk_chars,
+    get_tts_model_configs,
+)
+from backend.utils.audio import (
+    exceeds_plausible_speech_duration,
+    detect_tts_runaway,
+)
+from backend.backends.base import (
+    QWEN_MAX_NEW_TOKENS_CAP,
+    estimate_max_new_tokens,
+)
+
+SAMPLE_RATE = 24000
+
+
+# ── decode budget ────────────────────────────────────────────────────
+
+
+def test_short_text_gets_minimum_budget():
+    assert estimate_max_new_tokens("hi") == 1500
+
+
+def test_budget_scales_with_text_length():
+    # 300 chars ≈ a default qwen chunk; the budget must exceed the
+    # slowest sane delivery (~6 tokens/char at 12 Hz) with headroom.
+    budget = estimate_max_new_tokens("a" * 300)
+    assert budget == 300 * 12 + 750
+    assert budget / 300 >= 12
+
+
+def test_budget_is_capped_at_model_limit():
+    assert estimate_max_new_tokens("a" * 100_000) == QWEN_MAX_NEW_TOKENS_CAP
+
+
+def test_budget_never_truncates_slow_normal_delivery():
+    # Worst sane pace: ~2 chars/sec incl. pauses = 6 tokens/char.
+    # The budget must exceed that for any length below the cap.
+    for chars in (50, 175, 300, 500, 800):
+        budget = estimate_max_new_tokens("a" * chars)
+        slow_normal = chars * 6
+        expected_cap = QWEN_MAX_NEW_TOKENS_CAP
+        if slow_normal < expected_cap:
+            assert budget >= slow_normal, chars
+
+
+# ── duration-based runaway detection ─────────────────────────────────
+
+
+def test_duration_detector_flags_eos_miss_runaway():
+    # Real-world failure: 175 chars of text → 613s of low-level noise.
+    audio = np.full(613 * SAMPLE_RATE, 0.01, dtype=np.float32)
+    assert exceeds_plausible_speech_duration(audio, SAMPLE_RATE, "a" * 175)
+    assert detect_tts_runaway(audio, SAMPLE_RATE, "a" * 175)
+
+
+def test_duration_detector_passes_normal_delivery():
+    # 800 chars at a very deliberate 2 chars/sec ≈ 400s — well within
+    # the plausible envelope (800 / 1.2 + 15 ≈ 682s).
+    audio = np.full(400 * SAMPLE_RATE, 0.2, dtype=np.float32)
+    assert not exceeds_plausible_speech_duration(audio, SAMPLE_RATE, "a" * 800)
+    assert not detect_tts_runaway(audio, SAMPLE_RATE, "a" * 800)
+
+
+def test_duration_detector_tolerates_trailing_silence():
+    # Normal clip plus a couple seconds of trailing silence.
+    speech = np.full(30 * SAMPLE_RATE, 0.2, dtype=np.float32)
+    silence = np.zeros(2 * SAMPLE_RATE, dtype=np.float32)
+    audio = np.concatenate([speech, silence])
+    assert not detect_tts_runaway(audio, SAMPLE_RATE, "a" * 100)
+
+
+def test_duration_detector_handles_empty_input():
+    assert not exceeds_plausible_speech_duration(np.array([], dtype=np.float32), SAMPLE_RATE, "text")
+    assert not exceeds_plausible_speech_duration(np.full(1000, 0.2, dtype=np.float32), SAMPLE_RATE, "")
+
+
+# ── engine wiring ────────────────────────────────────────────────────
+
+
+def test_qwen_engines_default_to_smaller_chunks():
+    assert get_engine_default_chunk_chars("qwen") == 300
+    assert get_engine_default_chunk_chars("qwen_custom_voice") == 300
+
+
+def test_other_engines_have_no_chunk_override():
+    assert get_engine_default_chunk_chars("kokoro") is None
+    assert get_engine_default_chunk_chars("luxtts") is None
+
+
+def test_every_qwen_config_carries_the_guards():
+    qwen_configs = [
+        c
+        for c in get_tts_model_configs()
+        if c.engine in ("qwen", "qwen_custom_voice")
+    ]
+    assert len(qwen_configs) == 4
+    for cfg in qwen_configs:
+        assert cfg.retries_runaway, cfg.model_name
+        assert cfg.default_chunk_chars == 300, cfg.model_name

--- a/backend/tests/test_qwen_runaway_retry.py
+++ b/backend/tests/test_qwen_runaway_retry.py
@@ -1,4 +1,4 @@
-"""Regression coverage for runaway MLX Qwen TTS output."""
+"""Regression coverage for runaway Qwen TTS output."""
 
 from unittest.mock import patch
 
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from backend.backends import engine_needs_trim, engine_retries_runaway
-from backend.utils.audio import has_tts_runaway
+from backend.utils.audio import detect_tts_runaway, has_tts_runaway
 from backend.utils.chunked_tts import generate_chunked
 
 SAMPLE_RATE = 1000
@@ -18,10 +18,21 @@ def test_mlx_qwen_enables_runaway_retry_without_aggressive_trim():
         assert engine_retries_runaway("qwen") is True
 
 
-def test_pytorch_qwen_keeps_runaway_retry_disabled():
+def test_pytorch_qwen_enables_runaway_retry_too():
+    # EOS misses are model-intrinsic (QwenLM/Qwen3-TTS#118) — the guard
+    # must cover the PyTorch CPU/GPU path as well, not just MLX.
     with patch("backend.backends.get_backend_type", return_value="pytorch"):
         assert engine_needs_trim("qwen") is False
-        assert engine_retries_runaway("qwen") is False
+        assert engine_retries_runaway("qwen") is True
+
+
+def test_qwen_custom_voice_enables_runaway_retry():
+    with patch("backend.backends.get_backend_type", return_value="pytorch"):
+        assert engine_retries_runaway("qwen_custom_voice") is True
+
+
+def test_non_qwen_engines_keep_runaway_retry_disabled():
+    assert engine_retries_runaway("kokoro") is False
 
 
 def test_detector_flags_long_internal_silence():
@@ -78,7 +89,7 @@ async def test_runaway_chunk_is_retried_as_smaller_chunks():
         {},
         max_chunk_chars=800,
         crossfade_ms=50,
-        runaway_detector=has_tts_runaway,
+        runaway_detector=detect_tts_runaway,
     )
 
     assert sample_rate == SAMPLE_RATE
@@ -111,7 +122,7 @@ async def test_persistent_runaway_fails_instead_of_returning_corrupt_audio():
             text,
             {},
             max_chunk_chars=800,
-            runaway_detector=has_tts_runaway,
+            runaway_detector=detect_tts_runaway,
         )
 
     assert [len(call) for call in backend.calls] == [241, 120, 100]

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -147,10 +147,12 @@ def has_tts_runaway(
     return False
 
 
-# Minimum delivery rate considered sane, in source characters per second
-# of audio. The slowest normal narration observed in the wild (very short
-# lines with heavy pausing) runs ~1.6 chars/sec; anything meaningfully
+# Minimum delivery rate considered sane, in non-whitespace characters per
+# second of audio. The slowest normal narration observed in the wild (very
+# short lines with heavy pausing) runs ~1.6 chars/sec; anything meaningfully
 # below this means the model is emitting silence/gibberish, not speech.
+# Whitespace is excluded so padding (blank lines, indent runs) can't
+# inflate the threshold and mask a runaway.
 MIN_PLAUSIBLE_CHARS_PER_SEC = 1.2
 # Grace period added on top of the expected duration to absorb leading/
 # trailing silence and natural end-of-clip decay.
@@ -170,14 +172,20 @@ def exceeds_plausible_speech_duration(
     (or degenerates immediately) and then emits near-silent "room tone"
     or gibberish for minutes. Such output is not always bounded by
     internal silence, so :func:`has_tts_runaway` alone misses it; the
-    duration ratio is the reliable signal. Trailing junk under the
-    buffer is tolerated, so healthy clips never trip this.
+    duration ratio is the reliable signal. Only non-whitespace characters
+    count (blank lines and padding must not raise the threshold), and
+    trailing junk under the buffer is tolerated, so healthy clips never
+    trip this.
     """
     if audio is None or len(audio) == 0 or not text:
         return False
 
+    spoken_chars = len("".join(text.split()))
+    if spoken_chars == 0:
+        return False
+
     duration_s = len(audio) / sample_rate
-    max_plausible_s = len(text) / min_chars_per_sec + buffer_seconds
+    max_plausible_s = spoken_chars / min_chars_per_sec + buffer_seconds
     return duration_s > max_plausible_s
 
 

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -147,6 +147,58 @@ def has_tts_runaway(
     return False
 
 
+# Minimum delivery rate considered sane, in source characters per second
+# of audio. The slowest normal narration observed in the wild (very short
+# lines with heavy pausing) runs ~1.6 chars/sec; anything meaningfully
+# below this means the model is emitting silence/gibberish, not speech.
+MIN_PLAUSIBLE_CHARS_PER_SEC = 1.2
+# Grace period added on top of the expected duration to absorb leading/
+# trailing silence and natural end-of-clip decay.
+PLAUSIBLE_DURATION_BUFFER_S = 15.0
+
+
+def exceeds_plausible_speech_duration(
+    audio: np.ndarray,
+    sample_rate: int,
+    text: str,
+    min_chars_per_sec: float = MIN_PLAUSIBLE_CHARS_PER_SEC,
+    buffer_seconds: float = PLAUSIBLE_DURATION_BUFFER_S,
+) -> bool:
+    """Detect a clip that runs far longer than its text can plausibly fill.
+
+    Catches the worst EOS-miss runaway shape — the model renders the text
+    (or degenerates immediately) and then emits near-silent "room tone"
+    or gibberish for minutes. Such output is not always bounded by
+    internal silence, so :func:`has_tts_runaway` alone misses it; the
+    duration ratio is the reliable signal. Trailing junk under the
+    buffer is tolerated, so healthy clips never trip this.
+    """
+    if audio is None or len(audio) == 0 or not text:
+        return False
+
+    duration_s = len(audio) / sample_rate
+    max_plausible_s = len(text) / min_chars_per_sec + buffer_seconds
+    return duration_s > max_plausible_s
+
+
+def detect_tts_runaway(
+    audio: np.ndarray,
+    sample_rate: int,
+    text: str,
+) -> bool:
+    """Combined runaway detector used for Qwen3-TTS engines.
+
+    Flags either shape of an EOS miss:
+      - speech → long internal silence → more output
+        (:func:`has_tts_runaway`), or
+      - output that runs implausibly long for its input text
+        (:func:`exceeds_plausible_speech_duration`).
+    """
+    return has_tts_runaway(audio, sample_rate) or exceeds_plausible_speech_duration(
+        audio, sample_rate, text
+    )
+
+
 def trim_tts_output(
     audio: np.ndarray,
     sample_rate: int = 24000,

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -243,8 +243,10 @@ async def generate_chunked(
         function applied to each chunk before concatenation (e.g.
         ``trim_tts_output`` for Chatterbox engines).
     runaway_detector : callable | None
-        Optional ``(audio, sample_rate) -> bool`` detector. When it flags
-        unstable output, the affected text is split in half and retried.
+        Optional ``(audio, sample_rate, chunk_text) -> bool`` detector.
+        When it flags unstable output, the affected text is split in
+        half and retried. Receives the chunk text so duration-based
+        checks can compare output length against input length.
 
     Returns
     -------
@@ -263,7 +265,9 @@ async def generate_chunked(
             instruct,
         )
 
-        if runaway_detector is not None and runaway_detector(chunk_audio, chunk_sr):
+        if runaway_detector is not None and runaway_detector(
+            chunk_audio, chunk_sr, chunk_text
+        ):
             if retry_depth >= MAX_RUNAWAY_RETRIES or len(chunk_text) <= MIN_RUNAWAY_RETRY_CHARS:
                 raise RuntimeError(
                     "TTS output remained unstable after retrying smaller text chunks"


### PR DESCRIPTION
## Summary

- enable the existing runaway retry (#964) for `qwen` / `qwen_custom_voice` on **all** backends — the guard was MLX-only, leaving the PyTorch CPU/GPU path unprotected against the same EOS-miss failure
- add a duration-based runaway detector (`exceeds_plausible_speech_duration`, non-whitespace chars vs audio length) alongside the internal-silence detector; combined as `detect_tts_runaway(audio, sample_rate, chunk_text)`
- bound every Qwen decode with a per-call `max_new_tokens` budget (`estimate_max_new_tokens`: 12 tokens/char + floor 1500, model cap 8192)
- give Qwen engines a 300-char default chunk, used when the request doesn't set one; the app omits the field while the chunk slider sits on its factory value

## Root cause

Qwen3-TTS occasionally misses its codec EOS. During the failure state the EOS probability collapses to ~1e-14 (rank ~1500+, far outside `top_k=50`), so sampling can never terminate the decode — measured model-intrinsic on PyTorch CPU, MLX and sglang (sgl-project/sglang-omni#1179; QwenLM/Qwen3-TTS#118). The checkpoint ships `max_new_tokens: 8192` ≈ 11.4 minutes of audio, so one miss can append many minutes of gibberish that still gets saved as a `completed` generation.

Two things made the existing protection miss it in practice:

1. `retries_runaway = backend_type == "mlx"` — PyTorch path had no retry at all.
2. `has_tts_runaway` only flags "speech → ≥2s internal silence → speech". The CPU runaway shapes are continuous low-level gibberish or mid-chunk babble at normal level — neither contains a silence gap.

## Reproduction and validation

Signal analysis (RMS / zero-crossing rate / spectral flatness per 10 s) + Whisper large-v3-turbo transcription of 3 affected local generations (details in #1077):

| generation | text | duration | corruption onset | runaway tail |
|---|---|---|---|---|
| `fd38149e` (0.6B) | 1719 chars | 973 s | ~360 s | ~613 s ≈ the 8192-token cap (683 s) |
| `402c4a22` (1.7B) | 1719 chars | 846 s | ~270 s | ~520 s |
| `f84cdd7d` (1.7B) | 1835 chars | 880 s | ~280 s | ~600 s |

- corrupted segments: ZCR 0.13–0.28 vs 0.05–0.09 for healthy speech; Whisper transcribes them as empty hallucinations ("so", "Thank you.") while healthy segments transcribe verbatim to the source text
- `fd38149e` chunk 3 is 175 chars (~40 s of normal speech) yet ran 613 s — the decode hit the token cap without EOS

CPU smoke on 0.6B Base (voice clone, zh, 44-char input):

- healthy run: 11.8 s audio against the 125 s budget — not truncated, detectors negative
- a second run happened to hit a real EOS miss (44 chars → 119.9 s of murmur): the budget cut the tail from 682 s to 125 s and the duration detector flagged it — both layers behaving as intended

## Tests

- `pytest backend/tests/test_qwen_runaway_retry.py backend/tests/test_qwen_generation_guards.py -q` — 21 passed (budget math, duration detector incl. whitespace-padding regression, engine wiring on both backends, retry recovery + persistent-failure)
- full backend suite minus pre-existing failures unrelated to this change — 155 passed
- `bun run typecheck` — clean
- ruff clean on all lines added by this PR

Fixes #1077


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen speech generation reliability by limiting excessive decoding and detecting unusually long or runaway audio.
  * Applied engine-specific chunking defaults when the chunk-size setting remains unchanged.
  * Enabled safer retry behavior for affected Qwen voice-generation modes while preserving other engines’ behavior.
  * Improved duration checks so whitespace padding cannot mask runaway audio.
* **Tests**
  * Added coverage for decode limits, runaway detection, retry behavior, chunk defaults, normal audio duration, and trailing silence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->