### PR TITLE
Fix Chatterbox non-Latin chunk budgeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ Ships with 4 built-in presets (Robotic, Radio, Echo Chamber, Deep Voice) and sup
 
 Text is automatically split at sentence boundaries and each chunk is generated independently, then crossfaded together. Works with all engines.
 
-- Configurable auto-chunking limit (100–5,000 chars)
+- Configurable auto-chunking limit (100–5,000 chars; Chatterbox uses a UTF-8 byte budget)
 - Crossfade slider (0–200ms) for smooth transitions
 - Max text length: 50,000 characters
-- Smart splitting respects abbreviations, CJK punctuation, and `[tags]`
+- Smart splitting respects abbreviations, Indic/Arabic/CJK punctuation, and `[tags]`
 
 ### Generation Versions
 

--- a/backend/routes/generations.py
+++ b/backend/routes/generations.py
@@ -350,7 +350,7 @@ async def stream_speech(
         engine=engine,
     )
 
-    from ..utils.chunked_tts import generate_chunked
+    from ..utils.chunked_tts import generate_chunked_for_engine
 
     trim_fn = None
     runaway_detector = None
@@ -363,10 +363,11 @@ async def stream_speech(
 
         runaway_detector = has_tts_runaway
 
-    audio, sample_rate = await generate_chunked(
+    audio, sample_rate = await generate_chunked_for_engine(
         tts_model,
         data.text,
         voice_prompt,
+        engine=engine,
         language=data.language,
         seed=data.seed,
         instruct=data.instruct,

--- a/backend/services/generation.py
+++ b/backend/services/generation.py
@@ -54,8 +54,8 @@ async def run_generation(
         get_tts_backend_for_engine,
         load_engine_model,
     )
-    from ..utils.chunked_tts import generate_chunked
     from ..utils.audio import has_tts_runaway, normalize_audio, save_audio, trim_tts_output
+    from ..utils.chunked_tts import generate_chunked_for_engine
 
     task_manager = get_task_manager()
     bg_db = next(get_db())
@@ -91,7 +91,13 @@ async def run_generation(
         if crossfade_ms is not None:
             gen_kwargs["crossfade_ms"] = crossfade_ms
 
-        audio, sample_rate = await generate_chunked(tts_model, text, voice_prompt, **gen_kwargs)
+        audio, sample_rate = await generate_chunked_for_engine(
+            tts_model,
+            text,
+            voice_prompt,
+            engine=engine,
+            **gen_kwargs,
+        )
 
         # --- Normalize (generate and regenerate always; retry skips) -----
         if normalize or mode == "regenerate":
@@ -280,8 +286,8 @@ async def generate_audio_sync(
         get_tts_backend_for_engine,
         load_engine_model,
     )
-    from ..utils.chunked_tts import generate_chunked
     from ..utils.audio import has_tts_runaway, normalize_audio, trim_tts_output
+    from ..utils.chunked_tts import generate_chunked_for_engine
     from . import tts
 
     bg_db = next(get_db())
@@ -313,8 +319,12 @@ async def generate_audio_sync(
     if crossfade_ms is not None:
         gen_kwargs["crossfade_ms"] = crossfade_ms
 
-    audio, sample_rate = await generate_chunked(
-        tts_model, text, voice_prompt, **gen_kwargs
+    audio, sample_rate = await generate_chunked_for_engine(
+        tts_model,
+        text,
+        voice_prompt,
+        engine=engine,
+        **gen_kwargs,
     )
 
     if normalize:

--- a/backend/tests/test_chunked_tts_non_latin.py
+++ b/backend/tests/test_chunked_tts_non_latin.py
@@ -1,0 +1,287 @@
+"""Regression coverage for non-Latin long-text chunking."""
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from backend.utils import chunked_tts
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GENERATIONS_ROUTE = PROJECT_ROOT / "backend" / "routes" / "generations.py"
+GENERATION_SERVICE = PROJECT_ROOT / "backend" / "services" / "generation.py"
+ENGINE_AWARE_GENERATOR = "generate_chunked_for_engine"
+GENERATION_SERVICE_CALL_COUNT = 2
+SAMPLE_RATE = 1000
+CHATTERBOX_ENGINE = "chatterbox"
+QWEN_ENGINE = "qwen"
+TEST_UTF8_ENCODING = "utf-8"
+MISSING_CHUNK_MEASURE_MESSAGE = "Chatterbox should measure chunks with UTF-8 bytes"
+HINDI_SENTENCE_REPETITIONS = 7
+EXPECTED_MIN_CHUNKS = 2
+ARABIC_PREFIX_LENGTH = 10
+ARABIC_BOUNDARY_EXTRA_CHARS = 1
+SINGLE_BYTE_BUDGET = 1
+HARD_CUT_BUDGET = 5
+TAG_STRADDLE_BUDGET = 10
+WHITESPACE_OVERHEAD = 2
+BYTE_RETRY_TEXT_CHARS = 44
+EMPTY_TEXT_ERROR = "Cannot generate TTS audio from empty text"
+DEFAULT_MAX_CHUNK_CHARS = chunked_tts.DEFAULT_MAX_CHUNK_CHARS
+HINDI_SENTENCE = (
+    "\u092d\u093e\u0930\u0924 \u092e\u0947\u0902 \u0935\u0930\u094d\u0937\u093e "
+    "\u090b\u0924\u0941 \u0915\u093e \u0906\u0917\u092e\u0928 \u091c\u0942\u0928 "
+    "\u0915\u0947 \u092e\u0939\u0940\u0928\u0947 \u092e\u0947\u0902 "
+    "\u0939\u094b\u0924\u093e \u0939\u0948\u0964"
+)
+HINDI_TEXT = " ".join([HINDI_SENTENCE] * HINDI_SENTENCE_REPETITIONS)
+ARABIC_ALEF = "\u0627"
+ARABIC_BEH = "\u0628"
+ARABIC_FULL_STOP = "\u06d4"
+ARABIC_QUESTION_MARK = "\u061f"
+BRACKETED_ARABIC_FULL_STOP = f"[{ARABIC_FULL_STOP}]"
+ASCII_HARD_CUT_TEXT = "abcdefghijklmnopqrstuvwxyz"
+HINDI_NO_BOUNDARY_TEXT = HINDI_SENTENCE[0] * DEFAULT_MAX_CHUNK_CHARS
+TAG_STRADDLE_TEXT = "prefix[noise]suffix"
+BOUNDARY_TAG_TEXT = "[noise]suffix"
+UNMATCHED_TAG_TEXT = "prefix[noise suffix"
+UNMATCHED_TAG_PAST_BUDGET_TEXT = "abcdefghij[unfinished"
+
+
+def _called_functions(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    calls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            calls.append(node.func.id)
+    return calls
+
+
+def _utf8_byte_length(text: str) -> int:
+    return len(text.encode(TEST_UTF8_ENCODING))
+
+
+def test_generation_entrypoints_use_engine_aware_chunking():
+    route_calls = _called_functions(GENERATIONS_ROUTE)
+    service_calls = _called_functions(GENERATION_SERVICE)
+
+    assert ENGINE_AWARE_GENERATOR in route_calls
+    assert service_calls.count(ENGINE_AWARE_GENERATOR) == GENERATION_SERVICE_CALL_COUNT
+
+
+def test_chatterbox_uses_utf8_byte_budget_for_non_latin_text():
+    measure = getattr(chunked_tts, "chunk_measure_for_engine", None)
+
+    assert measure is not None, MISSING_CHUNK_MEASURE_MESSAGE
+    assert measure(CHATTERBOX_ENGINE) is chunked_tts.utf8_byte_length
+    assert len(HINDI_TEXT) < DEFAULT_MAX_CHUNK_CHARS
+    assert _utf8_byte_length(HINDI_TEXT) > DEFAULT_MAX_CHUNK_CHARS
+
+    chunks = chunked_tts.split_text_into_chunks(
+        HINDI_TEXT,
+        DEFAULT_MAX_CHUNK_CHARS,
+        measure=measure(CHATTERBOX_ENGINE),
+    )
+
+    assert len(chunks) >= EXPECTED_MIN_CHUNKS
+    assert all(_utf8_byte_length(chunk) <= DEFAULT_MAX_CHUNK_CHARS for chunk in chunks)
+    assert all(chunk.endswith("\u0964") for chunk in chunks[:-1])
+
+
+def test_non_chatterbox_engines_keep_character_budget():
+    assert chunked_tts.chunk_measure_for_engine(QWEN_ENGINE) is len
+
+
+def test_splitter_keeps_progress_when_one_character_exceeds_byte_budget():
+    chunks = chunked_tts.split_text_into_chunks(
+        HINDI_SENTENCE,
+        SINGLE_BYTE_BUDGET,
+        measure=chunked_tts.utf8_byte_length,
+    )
+
+    assert chunks[0] == HINDI_SENTENCE[0]
+
+
+def test_default_character_budget_hard_cuts_without_custom_measure():
+    chunks = chunked_tts.split_text_into_chunks(ASCII_HARD_CUT_TEXT, HARD_CUT_BUDGET)
+
+    assert chunks[0] == ASCII_HARD_CUT_TEXT[:HARD_CUT_BUDGET]
+
+
+def test_byte_budget_hard_cut_stays_within_measured_segment():
+    chunks = chunked_tts.split_text_into_chunks(
+        HINDI_NO_BOUNDARY_TEXT,
+        DEFAULT_MAX_CHUNK_CHARS,
+        measure=chunked_tts.utf8_byte_length,
+    )
+
+    assert all(_utf8_byte_length(chunk) <= DEFAULT_MAX_CHUNK_CHARS for chunk in chunks)
+
+
+def test_hard_cut_does_not_split_tag_straddling_budget():
+    chunks = chunked_tts.split_text_into_chunks(TAG_STRADDLE_TEXT, TAG_STRADDLE_BUDGET)
+
+    assert chunks[0] == "prefix"
+    assert chunks[1].startswith("[noise]")
+
+
+def test_hard_cut_keeps_boundary_starting_tag_atomic():
+    chunks = chunked_tts.split_text_into_chunks(BOUNDARY_TAG_TEXT, HARD_CUT_BUDGET)
+
+    assert chunks[0] == "[noise]"
+    assert chunks[1] == "suffi"
+
+
+def test_hard_cut_avoids_unmatched_tag_prefix():
+    chunks = chunked_tts.split_text_into_chunks(UNMATCHED_TAG_TEXT, TAG_STRADDLE_BUDGET)
+
+    assert chunks[0] == "prefix"
+
+
+def test_unmatched_tag_after_budget_does_not_expand_chunk():
+    chunks = chunked_tts.split_text_into_chunks(UNMATCHED_TAG_PAST_BUDGET_TEXT, HARD_CUT_BUDGET)
+
+    assert chunks[0] == UNMATCHED_TAG_PAST_BUDGET_TEXT[:HARD_CUT_BUDGET]
+
+
+def test_arabic_full_stop_is_a_sentence_boundary():
+    text = (
+        f"{ARABIC_ALEF * ARABIC_PREFIX_LENGTH}{ARABIC_FULL_STOP}"
+        f"{ARABIC_BEH * DEFAULT_MAX_CHUNK_CHARS}{ARABIC_FULL_STOP}"
+    )
+
+    chunks = chunked_tts.split_text_into_chunks(
+        text,
+        ARABIC_PREFIX_LENGTH + len(ARABIC_FULL_STOP) + ARABIC_BOUNDARY_EXTRA_CHARS,
+    )
+
+    assert chunks[0].endswith(ARABIC_FULL_STOP)
+
+
+def test_arabic_question_mark_is_a_sentence_boundary():
+    text = (
+        f"{ARABIC_ALEF * ARABIC_PREFIX_LENGTH}{ARABIC_QUESTION_MARK}"
+        f"{ARABIC_BEH * DEFAULT_MAX_CHUNK_CHARS}{ARABIC_QUESTION_MARK}"
+    )
+
+    chunks = chunked_tts.split_text_into_chunks(
+        text,
+        ARABIC_PREFIX_LENGTH + len(ARABIC_QUESTION_MARK) + ARABIC_BOUNDARY_EXTRA_CHARS,
+    )
+
+    assert chunks[0].endswith(ARABIC_QUESTION_MARK)
+
+
+def test_arabic_full_stop_inside_bracket_tag_is_not_a_boundary():
+    first_sentence = (
+        f"{BRACKETED_ARABIC_FULL_STOP}{ARABIC_ALEF * ARABIC_PREFIX_LENGTH}"
+        f"{ARABIC_FULL_STOP}"
+    )
+    text = f"{first_sentence}{ARABIC_BEH * DEFAULT_MAX_CHUNK_CHARS}"
+
+    chunks = chunked_tts.split_text_into_chunks(
+        text,
+        len(first_sentence) + ARABIC_BOUNDARY_EXTRA_CHARS,
+    )
+
+    assert chunks[0] == first_sentence
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_for_engine_uses_chatterbox_byte_budget():
+    class FakeBackend:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        async def generate(self, text, *_args):
+            self.calls.append(text)
+            return np.full(SAMPLE_RATE, 0.2, dtype=np.float32), SAMPLE_RATE
+
+    backend = FakeBackend()
+
+    audio, sample_rate = await chunked_tts.generate_chunked_for_engine(
+        backend,
+        HINDI_TEXT,
+        {},
+        engine=CHATTERBOX_ENGINE,
+        max_chunk_chars=DEFAULT_MAX_CHUNK_CHARS,
+        crossfade_ms=0,
+    )
+
+    assert sample_rate == SAMPLE_RATE
+    assert len(audio) == (len(backend.calls) * SAMPLE_RATE)
+    assert len(backend.calls) >= EXPECTED_MIN_CHUNKS
+    assert all(_utf8_byte_length(chunk) <= DEFAULT_MAX_CHUNK_CHARS for chunk in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_fast_path_uses_measured_chunk_text():
+    class FakeBackend:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        async def generate(self, text, *_args):
+            self.calls.append(text)
+            return np.full(SAMPLE_RATE, 0.2, dtype=np.float32), SAMPLE_RATE
+
+    backend = FakeBackend()
+    text = f" {HINDI_NO_BOUNDARY_TEXT[: DEFAULT_MAX_CHUNK_CHARS // 3]} "
+    max_chunk_bytes = _utf8_byte_length(text.strip())
+
+    await chunked_tts.generate_chunked(
+        backend,
+        text,
+        {},
+        max_chunk_chars=max_chunk_bytes,
+        crossfade_ms=0,
+        chunk_measure=chunked_tts.utf8_byte_length,
+    )
+
+    assert backend.calls == [text.strip()]
+    assert _utf8_byte_length(backend.calls[0]) <= max_chunk_bytes
+    assert _utf8_byte_length(text) == max_chunk_bytes + WHITESPACE_OVERHEAD
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_retries_use_configured_measure():
+    class FakeBackend:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        async def generate(self, text, *_args):
+            self.calls.append(text)
+            return np.full(SAMPLE_RATE, 0.2, dtype=np.float32), SAMPLE_RATE
+
+    backend = FakeBackend()
+    text = HINDI_NO_BOUNDARY_TEXT[:BYTE_RETRY_TEXT_CHARS]
+
+    def is_runaway(_audio, _sample_rate):
+        return _utf8_byte_length(backend.calls[-1]) > chunked_tts.MIN_RUNAWAY_RETRY_CHARS
+
+    await chunked_tts.generate_chunked(
+        backend,
+        text,
+        {},
+        max_chunk_chars=DEFAULT_MAX_CHUNK_CHARS,
+        crossfade_ms=0,
+        runaway_detector=is_runaway,
+        chunk_measure=chunked_tts.utf8_byte_length,
+    )
+
+    assert len(backend.calls) > 1
+    assert _utf8_byte_length(backend.calls[0]) > chunked_tts.MIN_RUNAWAY_RETRY_CHARS
+    assert all(
+        _utf8_byte_length(chunk) <= chunked_tts.MIN_RUNAWAY_RETRY_CHARS
+        for chunk in backend.calls[1:]
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_chunked_rejects_whitespace_only_text():
+    class FakeBackend:
+        async def generate(self, *_args):
+            raise AssertionError("empty text should not reach backend")
+
+    with pytest.raises(RuntimeError, match=EMPTY_TEXT_ERROR):
+        await chunked_tts.generate_chunked(FakeBackend(), "   ", {})

--- a/backend/utils/chunked_tts.py
+++ b/backend/utils/chunked_tts.py
@@ -11,6 +11,7 @@ overhead.
 
 import logging
 import re
+from collections.abc import Callable
 from typing import List, Tuple
 
 import numpy as np
@@ -22,6 +23,12 @@ logger = logging.getLogger("voicebox.chunked-tts")
 DEFAULT_MAX_CHUNK_CHARS = 800
 MAX_RUNAWAY_RETRIES = 2
 MIN_RUNAWAY_RETRY_CHARS = 100
+UTF8_ENCODING = "utf-8"
+CHATTERBOX_ENGINE = "chatterbox"
+BYTE_MEASURED_CHUNK_ENGINES = frozenset({CHATTERBOX_ENGINE})
+MIN_PREFIX_LENGTH = 1
+
+ChunkMeasure = Callable[[str], int]
 
 # Common abbreviations that should NOT be treated as sentence endings.
 # Lowercase for case-insensitive matching.
@@ -58,21 +65,42 @@ _ABBREVIATIONS = frozenset(
 # Paralinguistic tags used by Chatterbox Turbo.  The splitter must never
 # cut inside one of these.
 _PARA_TAG_RE = re.compile(r"\[[^\]]*\]")
+_ASCII_SENTENCE_END_RE = re.compile(r"[.!?](?:\s|$)")
+_UNICODE_SENTENCE_END_RE = re.compile(r"[\u061f\u0964\u0965\u3002\uff01\uff1f\u06d4]")
 
 
-def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> List[str]:
+def utf8_byte_length(text: str) -> int:
+    """Return the number of UTF-8 bytes needed to encode *text*."""
+    return len(text.encode(UTF8_ENCODING))
+
+
+def chunk_measure_for_engine(engine: str) -> ChunkMeasure:
+    """Return the chunk budget measure used by *engine*."""
+    if engine in BYTE_MEASURED_CHUNK_ENGINES:
+        return utf8_byte_length
+    return len
+
+
+def split_text_into_chunks(
+    text: str,
+    max_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    measure: ChunkMeasure = len,
+) -> List[str]:
     """Split *text* at natural boundaries into chunks of at most *max_chars*.
 
-    Priority: sentence-end (``.!?`` not preceded by an abbreviation and not
-    inside brackets) → clause boundary (``;:,—``) → whitespace → hard cut.
+    Priority: sentence-end (``.!?``, Indic, Arabic, and CJK endings not preceded
+    by an abbreviation and not inside brackets) → clause boundary (``;:,—``)
+    → whitespace → hard cut.
 
     Paralinguistic tags like ``[laugh]`` are treated as atomic and will not
-    be split across chunks.
+    be split across chunks.  ``measure`` controls the budget unit; by default
+    it is character length, but engines with byte/token-like ceilings can use
+    :func:`utf8_byte_length`.
     """
     text = text.strip()
     if not text:
         return []
-    if len(text) <= max_chars:
+    if measure(text) <= max_chars:
         return [text]
 
     chunks: List[str] = []
@@ -82,11 +110,11 @@ def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) 
         remaining = remaining.lstrip()
         if not remaining:
             break
-        if len(remaining) <= max_chars:
+        if measure(remaining) <= max_chars:
             chunks.append(remaining)
             break
 
-        segment = remaining[:max_chars]
+        segment = _slice_to_budget(remaining, max_chars, measure)
 
         # Try to split at the last real sentence ending
         split_pos = _find_last_sentence_end(segment)
@@ -96,7 +124,7 @@ def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) 
             split_pos = segment.rfind(" ")
         if split_pos == -1:
             # Absolute fallback: hard cut but avoid splitting inside a tag
-            split_pos = _safe_hard_cut(segment, max_chars)
+            split_pos = _safe_hard_cut(remaining, len(segment))
 
         chunk = remaining[: split_pos + 1].strip()
         if chunk:
@@ -106,16 +134,35 @@ def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) 
     return chunks
 
 
+def _slice_to_budget(text: str, max_chars: int, measure: ChunkMeasure) -> str:
+    """Return the longest prefix of *text* within the configured budget."""
+    if measure is len:
+        return text[:max_chars]
+
+    low = 0
+    high = len(text)
+    while low < high:
+        mid = (low + high + 1) // 2
+        if measure(text[:mid]) <= max_chars:
+            low = mid
+        else:
+            high = mid - 1
+
+    if low < MIN_PREFIX_LENGTH:
+        return text[:MIN_PREFIX_LENGTH]
+    return text[:low]
+
+
 def _find_last_sentence_end(text: str) -> int:
     """Return the index of the last sentence-ending punctuation in *text*.
 
     Skips periods that follow common abbreviations (``Dr.``, ``Mr.``, etc.)
-    and periods inside bracket tags (``[laugh]``).  Also handles CJK
-    sentence-ending punctuation (``。！？``).
+    and periods inside bracket tags (``[laugh]``).  Also handles Indic,
+    Arabic, and CJK sentence-ending punctuation.
     """
     best = -1
     # ASCII sentence ends
-    for m in re.finditer(r"[.!?](?:\s|$)", text):
+    for m in _ASCII_SENTENCE_END_RE.finditer(text):
         pos = m.start()
         char = text[pos]
         # Skip periods after abbreviations
@@ -134,8 +181,9 @@ def _find_last_sentence_end(text: str) -> int:
         if _inside_bracket_tag(text, pos):
             continue
         best = pos
-    # CJK sentence-ending punctuation
-    for m in re.finditer(r"[\u3002\uff01\uff1f]", text):
+    for m in _UNICODE_SENTENCE_END_RE.finditer(text):
+        if _inside_bracket_tag(text, m.start()):
+            continue
         if m.start() > best:
             best = m.start()
     return best
@@ -166,8 +214,11 @@ def _safe_hard_cut(segment: str, max_chars: int) -> int:
     cut = max_chars - 1
     # Check if the cut falls inside a bracket tag; if so, move before it
     for m in _PARA_TAG_RE.finditer(segment):
-        if m.start() < cut < m.end():
-            return m.start() - 1 if m.start() > 0 else cut
+        if m.start() <= cut < m.end():
+            return m.start() - 1 if m.start() > 0 else m.end() - 1
+    unmatched_tag_start = segment.rfind("[", 0, cut + 1)
+    if unmatched_tag_start != -1 and segment.find("]", unmatched_tag_start) == -1:
+        return unmatched_tag_start - 1 if unmatched_tag_start > 0 else cut
     return cut
 
 
@@ -214,7 +265,8 @@ async def generate_chunked(
     crossfade_ms: int = 50,
     trim_fn=None,
     runaway_detector=None,
-) -> Tuple[np.ndarray, int]:
+    chunk_measure: ChunkMeasure = len,
+) -> tuple[np.ndarray, int]:
     """Generate audio with automatic chunking for long text.
 
     For text shorter than *max_chunk_chars* this is a thin wrapper around
@@ -245,6 +297,8 @@ async def generate_chunked(
     runaway_detector : callable | None
         Optional ``(audio, sample_rate) -> bool`` detector. When it flags
         unstable output, the affected text is split in half and retried.
+    chunk_measure : callable
+        Function used to measure text against ``max_chunk_chars``.
 
     Returns
     -------
@@ -264,13 +318,18 @@ async def generate_chunked(
         )
 
         if runaway_detector is not None and runaway_detector(chunk_audio, chunk_sr):
-            if retry_depth >= MAX_RUNAWAY_RETRIES or len(chunk_text) <= MIN_RUNAWAY_RETRY_CHARS:
+            chunk_size = chunk_measure(chunk_text)
+            if retry_depth >= MAX_RUNAWAY_RETRIES or chunk_size <= MIN_RUNAWAY_RETRY_CHARS:
                 raise RuntimeError(
                     "TTS output remained unstable after retrying smaller text chunks"
                 )
 
-            retry_max_chars = max(MIN_RUNAWAY_RETRY_CHARS, len(chunk_text) // 2)
-            retry_chunks = split_text_into_chunks(chunk_text, retry_max_chars)
+            retry_max_chars = max(MIN_RUNAWAY_RETRY_CHARS, chunk_size // 2)
+            retry_chunks = split_text_into_chunks(
+                chunk_text,
+                retry_max_chars,
+                measure=chunk_measure,
+            )
             if len(retry_chunks) <= 1:
                 raise RuntimeError("Unable to split unstable TTS output for retry")
 
@@ -306,11 +365,14 @@ async def generate_chunked(
             chunk_audio = trim_fn(chunk_audio, chunk_sr)
         return np.asarray(chunk_audio, dtype=np.float32), chunk_sr
 
-    chunks = split_text_into_chunks(text, max_chunk_chars)
+    chunks = split_text_into_chunks(text, max_chunk_chars, measure=chunk_measure)
+
+    if not chunks:
+        raise RuntimeError("Cannot generate TTS audio from empty text")
 
     if len(chunks) <= 1:
         # Short text — single-shot fast path
-        return await generate_one(text, seed)
+        return await generate_one(chunks[0], seed)
 
     # Long text — chunked generation
     logger.info(
@@ -345,3 +407,33 @@ async def generate_chunked(
 
     audio = concatenate_audio_chunks(audio_chunks, sample_rate, crossfade_ms=crossfade_ms)
     return audio, sample_rate
+
+
+async def generate_chunked_for_engine(
+    backend,
+    text: str,
+    voice_prompt: dict,
+    *,
+    engine: str,
+    language: str = "en",
+    seed: int | None = None,
+    instruct: str | None = None,
+    max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    crossfade_ms: int = 50,
+    trim_fn=None,
+    runaway_detector=None,
+) -> Tuple[np.ndarray, int]:
+    """Generate audio using the chunk measurement policy for *engine*."""
+    return await generate_chunked(
+        backend,
+        text,
+        voice_prompt,
+        language=language,
+        seed=seed,
+        instruct=instruct,
+        max_chunk_chars=max_chunk_chars,
+        crossfade_ms=crossfade_ms,
+        trim_fn=trim_fn,
+        runaway_detector=runaway_detector,
+        chunk_measure=chunk_measure_for_engine(engine),
+    )

--- a/docs/content/docs/developer/tts-generation.mdx
+++ b/docs/content/docs/developer/tts-generation.mdx
@@ -160,7 +160,7 @@ The request path from frontend to audio file:
 
 ## Chunking for Long Text
 
-Text longer than `max_chunk_chars` (default 800, range 100–5000) is split at sentence boundaries, generated in sequence, and crossfaded together. The chunking behavior is engine-agnostic — it lives in the service layer, not in individual backends.
+Text longer than `max_chunk_chars` (default 800, range 100–5000) is split at sentence boundaries, generated in sequence, and crossfaded together. The chunking behavior lives in the service layer, not in individual backends. Chatterbox uses a UTF-8 byte budget for this limit so non-Latin text is chunked before it can exceed the model's token ceiling.
 
 ## Instruct Mode
 


### PR DESCRIPTION
## Summary

Fixes #1066.

This changes Chatterbox multilingual chunk budgeting so `max_chunk_chars` is measured as UTF-8 bytes for that engine, while other engines keep the existing character-count behavior. It also expands sentence boundary detection for Indic, Arabic, and CJK punctuation and keeps bracket tags atomic across hard-cut fallback cases.

Production generation now routes through `generate_chunked_for_engine(...)` so queued generation, sync generation, and stream generation all use the same engine-aware chunk measure.

## Test verification (RED -> GREEN)

RED on upstream `origin/main` with only the new regression test copied in:

```text
python3 -m pytest backend/tests/test_chunked_tts_non_latin.py -q
15 failed, 2 passed in 0.33s
```

RED after reverting the final production patch while keeping the new test:

```text
python3 -m pytest backend/tests/test_chunked_tts_non_latin.py -q
4 failed, 13 passed in 0.17s
```

GREEN focused backend tests:

```text
python3 -m pytest backend/tests/test_qwen_runaway_retry.py backend/tests/test_chunked_tts_non_latin.py -q
24 passed in 0.21s
```

Full local suite proof:

```text
./run-ci.sh
bun install --frozen-lockfile: passed
bun run typecheck: passed
bun run build:web: passed
backend focused pytest: 24 passed in 0.21s
backend trace coverage: 24 passed in 1.48s
diff coverage PASS: 82 changed executable lines covered
```

Additional checks:

```text
python3 -m ruff check backend/tests/test_chunked_tts_non_latin.py
All checks passed!

Ruff delta on post-review touched existing Python modules:
baseline findings: 28
final findings: 28
new findings: 0

git diff --check
passed
```

## Review notes

Independent sub-agent review found tag-splitting, production-wiring coverage, and fast-path whitespace edge cases during development; all were fixed and covered by regression tests before opening this PR. CodeRabbit then found Arabic question mark, retry-budget, unmatched-tag, empty-text, and README clarification issues; those are addressed in the latest commit. OCR native review could not run locally because no LLM endpoint was configured, and `claude -p`/`runllm` were unavailable due an expired OAuth session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved long-text speech generation for Indic, Arabic, CJK, and other non-Latin content.
  - Chunking now respects engine-specific limits, including UTF-8 byte limits for Chatterbox.
  - Improved sentence boundary detection and handling of bracketed tags during text splitting.
  - Increased reliability when generating audio from oversized text.

- **Documentation**
  - Updated guidance to explain UTF-8 byte-based chunking for Chatterbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->