### PR TITLE
Fix: make the runtime image work non-root under a mounted data volume (data perms + HF cache + SoX)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     gosu \
+    sox \
     && rm -rf /var/lib/apt/lists/*
+
+# Keep the HuggingFace model cache on the writable data volume, so the
+# non-root user can download models (default ~/.cache is not writable here).
+ENV HF_HOME=/app/data/cache
 
 # Copy installed Python packages from builder stage
 COPY --from=backend-builder /install /usr/local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,6 @@ services:
       # Named volume for profiles, DB, cache (persists across container restarts)
       - voicebox-data:/app/data
 
-      # HuggingFace model cache (so models aren't re-downloaded on rebuild)
-      - huggingface-cache:/home/voicebox/.cache/huggingface
-
     environment:
       - LOG_LEVEL=info
       - NUMBA_CACHE_DIR=/tmp/numba_cache
@@ -44,4 +41,3 @@ networks:
 
 volumes:
   voicebox-data:
-  huggingface-cache:

--- a/scripts/rocm-entrypoint.sh
+++ b/scripts/rocm-entrypoint.sh
@@ -12,4 +12,11 @@ for dev in /dev/kfd /dev/dri/render*; do
     }
     usermod -aG "$grp" voicebox
 done
+
+# Ensure the mounted data volume is writable by the non-root user.
+# The Dockerfile chowns /app/data at build time, but a runtime volume mount
+# re-creates it owned by root, so fix ownership here (still root) before
+# dropping privileges.
+chown -R voicebox:voicebox /app/data || true
+
 exec gosu voicebox "$@"

--- a/scripts/rocm-entrypoint.sh
+++ b/scripts/rocm-entrypoint.sh
@@ -13,10 +13,33 @@ for dev in /dev/kfd /dev/dri/render*; do
     usermod -aG "$grp" voicebox
 done
 
-# Ensure the mounted data volume is writable by the non-root user.
-# The Dockerfile chowns /app/data at build time, but a runtime volume mount
-# re-creates it owned by root, so fix ownership here (still root) before
-# dropping privileges.
-chown -R voicebox:voicebox /app/data || true
+# Ensure the app data directories are writable by the non-root user.
+# /app/data/generations is normally a host bind-mount, so never chown/chmod it:
+# adopt the uid/gid that owns it instead, the same way we adopt the GPU groups
+# above. The rest of /app/data lives in the image or a named volume and is ours
+# to fix, so it gets chowned to match (dirs only, no -R on user content).
+gen=/app/data/generations
+mkdir -p "$gen"
+gen_uid=$(stat -c %u "$gen")
+gen_gid=$(stat -c %g "$gen")
+if [ "$gen_uid" = 0 ]; then
+    # Docker created it for us; nothing on the host cares who owns it.
+    chown voicebox:voicebox "$gen"
+elif [ "$gen_uid" != "$(id -u voicebox)" ]; then
+    getent group "$gen_gid" >/dev/null || groupadd -g "$gen_gid" hostdata
+    usermod -u "$gen_uid" -g "$gen_gid" voicebox
+    # Re-own what the old uid owned inside the image / named volume.
+    find /app/data -path "$gen" -prune -o -exec chown "$gen_uid:$gen_gid" {} +
+fi
+
+for dir in /app/data/cache /app/data/profiles "$gen"; do
+    mkdir -p "$dir"
+    [ "$dir" = "$gen" ] || chown voicebox:voicebox "$dir"
+    gosu voicebox test -w "$dir" || {
+        echo "error: $dir is not writable by the voicebox user (uid $(id -u voicebox))" >&2
+        [ "$dir" = "$gen" ] && echo "hint: make the host dir mounted there writable by that uid" >&2
+        exit 1
+    }
+done
 
 exec gosu voicebox "$@"


### PR DESCRIPTION
## Problem

Running the shipped Docker image with the default `docker-compose.yml` on Linux
(non-root `voicebox` user, named volume mounted on `/app/data`) hits three
runtime issues that prevent generation from working out of the box.

### 1. `/app/data` not writable by the `voicebox` user

The `Dockerfile` already runs `chown -R voicebox:voicebox /app/data`, but that
happens at *build* time. At *runtime*, the named volume mounted on `/app/data`
(see `docker-compose.yml`) shadows the built directory and comes up owned by
`root`, so the non-root process can't write generated files:

```
soundfile.LibsndfileError: Error opening
  '/app/data/generations/<id>.wav.tmp': System error.
OSError: Failed to save audio to /app/data/generations/<id>.wav
```

A build-time `chown` can't fix a directory that only exists after the runtime
mount; it has to run after the mount, i.e. in the entrypoint (which already runs
as root before dropping to `voicebox` via `gosu`).

### 2. HuggingFace cache not writable

By default the model cache lands in `/home/voicebox/.cache/huggingface`, which
is not writable in this setup, so model download fails:

```
PermissionError: [Errno 13] Permission denied:
  '/home/voicebox/.cache/huggingface/hub'
...
ERROR: Marked qwen-tts-1.7B as error: PermissionError at
  /home/voicebox/.cache/huggingface/hub when downloading Qwen/Qwen3-TTS-...
```

Pointing `HF_HOME` at `/app/data/cache` (a directory the entrypoint fix above
makes writable) resolves it, and keeps the model cache on the same data volume.

### 3. SoX missing from the runtime image

Some engines call SoX at generation time; the runtime image installs
`ffmpeg curl gosu` but not `sox`:

```
/bin/sh: 1: sox: not found
WARNING: SoX could not be found!
```

## Changes

- **`scripts/rocm-entrypoint.sh`:** `chown -R voicebox:voicebox /app/data` right
  before dropping privileges, so the mounted volume is writable at runtime.
- **`Dockerfile` (runtime stage):** set `ENV HF_HOME=/app/data/cache` so the
  model cache lives on the writable data volume, and add `sox` to the
  `apt-get install` line.

Doing all three at the image/entrypoint level keeps it working for every run
method (compose, plain `docker run`, remote mode) with no compose changes
required.

## Diffs

`scripts/rocm-entrypoint.sh` : add the chown just before the final `exec`:

```diff
     usermod -aG "$grp" voicebox
 done
+
+# Ensure the mounted data volume is writable by the non-root user.
+# The Dockerfile chowns /app/data at build time, but a runtime volume mount
+# re-creates it owned by root, so fix ownership here (still root) before
+# dropping privileges.
+chown -R voicebox:voicebox /app/data || true
+
 exec gosu voicebox "$@"
```

`Dockerfile` (runtime stage) : add `sox` to the install line:

```diff
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
     gosu \
+    sox \
     && rm -rf /var/lib/apt/lists/*
```

`Dockerfile` (runtime stage) : point the HF cache at the writable data dir
(place it near the other runtime `ENV`/config lines):

```diff
+# Keep the HuggingFace model cache on the writable data volume, so the
+# non-root user can download models (default ~/.cache is not writable here).
+ENV HF_HOME=/app/data/cache
```

## Notes

- `|| true` on the chown keeps `set -e` from aborting startup if the chown ever
  fails on an unusual host.
- The chown runs on every start; on a large `/app/data` (multi-GB model cache)
  this adds a couple of seconds. If preferred, it can be narrowed to the
  work dirs only (`/app/data/generations` and `/app/data/profiles`).

## Testing

- `docker-compose down && docker-compose up --build`
- Create a Qwen 1.7B profile, generate a short sentence.
- Model downloads into `/app/data/cache`, the `.wav` is written under
  `/app/data/generations/`, and `GET /audio/{id}` serves it (RIFF).
- No permission errors, no `sox: not found`, no manual `chown`/`apt-get`
  needed inside the container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability with mounted data volumes by preserving host-managed generation files and validating required directories are writable.
  - Improved compatibility with data volumes created under different user or group permissions.

- **Improvements**
  - Hugging Face model downloads are now stored in the application’s writable data area.
  - Added the required audio-processing support for runtime operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->