### PR TITLE
fix(backend): batch generation-version queries to eliminate N+1 in history listing

### DIFF
--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -15,21 +15,30 @@ from ..database import Generation as DBGeneration, GenerationVersion as DBGenera
 from .. import config
 
 
-def _get_versions_for_generation(generation_id: str, db: Session) -> tuple:
-    """Get versions list and active version ID for a generation."""
+def _get_versions_for_generations(generation_ids: list[str], db: Session) -> dict:
+    """Fetch versions for many generations in a single query.
+
+    Returns a mapping of ``generation_id -> (versions, active_version_id)``
+    using the same shape as ``_get_versions_for_generation()``, so callers
+    can batch a whole page of generations without an N+1 query.
+    """
     import json
+
+    ids = list(dict.fromkeys(generation_ids))
+    if not ids:
+        return {}
+
     versions_rows = (
         db.query(DBGenerationVersion)
-        .filter_by(generation_id=generation_id)
+        .filter(DBGenerationVersion.generation_id.in_(ids))
         .order_by(DBGenerationVersion.created_at)
         .all()
     )
-    if not versions_rows:
-        return None, None
 
-    versions = []
-    active_version_id = None
+    versions_by_generation: dict[str, list] = {}
+    active_by_generation: dict[str, Optional[str]] = {}
     for v in versions_rows:
+        versions = versions_by_generation.setdefault(v.generation_id, [])
         effects_chain = None
         if v.effects_chain:
             try:
@@ -47,9 +56,20 @@ def _get_versions_for_generation(generation_id: str, db: Session) -> tuple:
             created_at=v.created_at,
         ))
         if v.is_default:
-            active_version_id = v.id
+            active_by_generation[v.generation_id] = v.id
 
-    return versions, active_version_id
+    return {
+        generation_id: (
+            versions_by_generation.get(generation_id),
+            active_by_generation.get(generation_id),
+        )
+        for generation_id in ids
+    }
+
+
+def _get_versions_for_generation(generation_id: str, db: Session) -> tuple:
+    """Get versions list and active version ID for a single generation."""
+    return _get_versions_for_generations([generation_id], db)[generation_id]
 
 
 async def create_generation(
@@ -205,10 +225,16 @@ async def list_generations(
     # Execute query
     results = q.all()
     
+    # Fetch versions for every generation on this page with a single
+    # query instead of one SELECT per generation (N+1).
+    versions_by_generation = _get_versions_for_generations(
+        [generation.id for generation, _ in results], db
+    )
+
     # Convert to HistoryResponse with profile_name
     items = []
     for generation, profile_name in results:
-        versions, active_version_id = _get_versions_for_generation(generation.id, db)
+        versions, active_version_id = versions_by_generation[generation.id]
         items.append(HistoryResponse(
             id=generation.id,
             profile_id=generation.profile_id,


### PR DESCRIPTION
## Summary

Fixes a performance issue in the History
endpoint: `list_generations()` in `backend/services/history.py` was executing
**one SQL query per generation row** to fetch its versions. A page of 50
generations cost **51 queries** (1 page query + 50 version queries) — and the
History tab is one of the most frequently called endpoints of the app.

After this change, a page of 50 generations costs exactly **2 queries**.

## Root cause

`list_generations()` looped over the page results and called
`_get_versions_for_generation(generation.id, db)` for every row, each call
issuing its own `SELECT ... FROM generation_versions WHERE generation_id = ?`
against SQLite. With SQLAlchemy + SQLite, each query is a round-trip that
grows linearly with the page size, and the latency compounds as the history
grows.

## Changes

All in `backend/services/history.py`:

- **New `_get_versions_for_generations(generation_ids, db)`** — fetches all
  versions for a set of generation IDs in a single
  `WHERE generation_id IN (...)` query and groups the results in memory into a
  `{generation_id: (versions, active_version_id)}` mapping.
  - Deduplicates IDs (`dict.fromkeys`), so duplicate IDs in a page cost nothing
    extra.
  - No-op (`{}`) on an empty page — no unnecessary query.
  - Preserves the previous semantics exactly: rows ordered by `created_at`,
    default version = last `is_default` row (same iteration order as before),
    missing versions → `(None, None)`.
- **`_get_versions_for_generation()`** (single-generation helper) now delegates
  to the batched helper, so the return shape is unchanged and callers like
  `services/stories.py` keep working without modification.
- **`list_generations()`** builds the page results, fetches all versions once,
  and resolves each row from the in-memory mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved generation history loading by reducing the number of database queries required for each page.
  * Generation version information is now retrieved more efficiently in batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->