### PR TITLE
fix(security): close remaining gaps in remote-access middleware (follow-up to #1002)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,4 +110,5 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
 COPY --chmod=755 scripts/rocm-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "17493"]
+ENV VOICEBOX_HOST=127.0.0.1
+CMD ["python", "-m", "backend.main", "--port", "17493"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -164,7 +164,10 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    from .utils.security import SecurityMiddleware
+
     _configure_cors(application)
+    application.add_middleware(SecurityMiddleware)
     application.add_middleware(ClientIdMiddleware)
     register_routers(application)
     application.mount("/mcp", mcp_app)

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,13 +10,15 @@ import uvicorn
 from .app import app  # noqa: F401 -- re-export for uvicorn "backend.main:app"
 from . import config, database
 
+import os
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="voicebox backend server")
     parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
-        help="Host to bind to (use 0.0.0.0 for remote access)",
+        default=os.environ.get("VOICEBOX_HOST", "127.0.0.1"),
+        help="Host to bind to (use 0.0.0.0 for remote access or set VOICEBOX_HOST)",
     )
     parser.add_argument(
         "--port",

--- a/backend/server.py
+++ b/backend/server.py
@@ -241,8 +241,8 @@ if __name__ == "__main__":
         parser.add_argument(
             "--host",
             type=str,
-            default="127.0.0.1",
-            help="Host to bind to (use 0.0.0.0 for remote access)",
+            default=os.environ.get("VOICEBOX_HOST", "127.0.0.1"),
+            help="Host to bind to (use 0.0.0.0 for remote access or set VOICEBOX_HOST)",
         )
         parser.add_argument(
             "--port",

--- a/backend/tests/test_api_security.py
+++ b/backend/tests/test_api_security.py
@@ -31,6 +31,10 @@ def _build_app() -> FastAPI:
     async def delete_profile(profile_id: str):
         return {"message": f"deleted {profile_id}"}
 
+    @app.get("/profiles")
+    async def list_profiles():
+        return {"profiles": []}
+
     return app
 
 
@@ -113,6 +117,38 @@ def test_remote_caller_with_api_key_requires_auth(client):
             assert client.get("/health", headers=headers_valid).status_code == 200
             assert client.post("/shutdown", headers=headers_valid).status_code == 200
             assert client.delete("/profiles/123", headers=headers_valid).status_code == 200
+
+
+def test_forged_forwarded_header_from_real_remote_peer_is_ignored():
+    # A genuinely remote peer cannot spoof loopback trust by forging
+    # X-Forwarded-For: 127.0.0.1 -- the header is only honoured when the
+    # direct TCP peer is itself loopback (a trusted local proxy).
+    fake_client = type("Client", (), {"host": "203.0.113.5"})()
+    fake_request = type(
+        "Req",
+        (),
+        {"client": fake_client, "headers": {"X-Forwarded-For": "127.0.0.1"}},
+    )()
+    assert get_client_ip(fake_request) == "203.0.113.5"
+    assert is_loopback(get_client_ip(fake_request)) is False
+
+
+def test_no_api_key_only_allows_explicit_safe_get_paths(client):
+    # Endpoints not on the explicit allowlist are blocked for remote callers
+    # even though they are plain GET requests, since the middleware is an
+    # allowlist (not a denylist of destructive methods/paths).
+    with patch("backend.utils.security.is_loopback", return_value=False):
+        with patch.dict(os.environ, {}, clear=True):
+            res = client.get("/profiles")
+            assert res.status_code == 403
+            assert "restricted to loopback callers" in res.json()["detail"]
+
+
+def test_bearer_scheme_is_case_insensitive(client):
+    with patch("backend.utils.security.is_loopback", return_value=False):
+        with patch.dict(os.environ, {"VOICEBOX_API_KEY": "secret_token"}):
+            headers = {"Authorization": "bearer secret_token"}
+            assert client.get("/health", headers=headers).status_code == 200
 
 
 def test_options_preflight_is_always_allowed(client):

--- a/backend/tests/test_api_security.py
+++ b/backend/tests/test_api_security.py
@@ -1,0 +1,116 @@
+import os
+import pytest
+from unittest.mock import patch
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+from starlette.responses import JSONResponse
+
+from backend.utils.security import SecurityMiddleware, is_loopback
+
+
+from fastapi.middleware.cors import CORSMiddleware
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+    app.add_middleware(SecurityMiddleware)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/shutdown")
+    async def shutdown():
+        return {"message": "shutting down"}
+
+    @app.post("/models/unload")
+    async def unload_model():
+        return {"message": "unloaded"}
+
+    @app.delete("/profiles/{profile_id}")
+    async def delete_profile(profile_id: str):
+        return {"message": f"deleted {profile_id}"}
+
+    return app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_build_app())
+
+
+def test_is_loopback_helper():
+    assert is_loopback("127.0.0.1") is True
+    assert is_loopback("::1") is True
+    assert is_loopback("localhost") is True
+    assert is_loopback("testclient") is True
+    assert is_loopback(None) is True
+    
+    assert is_loopback("192.168.1.1") is False
+    assert is_loopback("10.0.0.5") is False
+    assert is_loopback("8.8.8.8") is False
+
+
+def test_loopback_caller_unrestricted(client):
+    # Loopback callers should bypass all security gates
+    with patch("backend.utils.security.is_loopback", return_value=True):
+        # Admin / Destructive endpoints
+        assert client.post("/shutdown").status_code == 200
+        assert client.post("/models/unload").status_code == 200
+        assert client.delete("/profiles/123").status_code == 200
+        # Safe endpoints
+        assert client.get("/health").status_code == 200
+
+
+def test_remote_caller_no_api_key_blocks_destructive(client):
+    # Remote callers with no VOICEBOX_API_KEY environment variable set
+    with patch("backend.utils.security.is_loopback", return_value=False):
+        with patch.dict(os.environ, {}, clear=True):
+            # Safe endpoints should be allowed
+            assert client.get("/health").status_code == 200
+            
+            # Administrative POST endpoints should be blocked (403)
+            res_shutdown = client.post("/shutdown")
+            assert res_shutdown.status_code == 403
+            assert "restricted to loopback callers" in res_shutdown.json()["detail"]
+            
+            res_unload = client.post("/models/unload")
+            assert res_unload.status_code == 403
+            assert "restricted to loopback callers" in res_unload.json()["detail"]
+            
+            # Destructive DELETE endpoints should be blocked (403)
+            res_delete = client.delete("/profiles/123")
+            assert res_delete.status_code == 403
+            assert "restricted to loopback callers" in res_delete.json()["detail"]
+
+
+def test_remote_caller_with_api_key_requires_auth(client):
+    # Remote callers with VOICEBOX_API_KEY environment variable set
+    with patch("backend.utils.security.is_loopback", return_value=False):
+        with patch.dict(os.environ, {"VOICEBOX_API_KEY": "secret_token"}):
+            # Accessing any endpoint without credentials should fail (401)
+            assert client.get("/health").status_code == 401
+            assert client.post("/shutdown").status_code == 401
+            assert client.delete("/profiles/123").status_code == 401
+            
+            # Accessing with invalid token should fail (401)
+            headers = {"Authorization": "Bearer wrong_token"}
+            assert client.get("/health", headers=headers).status_code == 401
+            
+            # Accessing with valid token should succeed (200)
+            headers_valid = {"Authorization": "Bearer secret_token"}
+            assert client.get("/health", headers=headers_valid).status_code == 200
+            assert client.post("/shutdown", headers=headers_valid).status_code == 200
+            assert client.delete("/profiles/123", headers=headers_valid).status_code == 200
+
+
+def test_options_preflight_is_always_allowed(client):
+    # OPTIONS requests (CORS preflight) must bypass authentication check
+    with patch("backend.utils.security.is_loopback", return_value=False):
+        with patch.dict(os.environ, {"VOICEBOX_API_KEY": "secret_token"}):
+            headers = {
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            }
+            assert client.options("/health", headers=headers).status_code == 200
+            assert client.options("/shutdown", headers=headers).status_code == 200

--- a/backend/tests/test_api_security.py
+++ b/backend/tests/test_api_security.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, Request
 from starlette.testclient import TestClient
 from starlette.responses import JSONResponse
 
-from backend.utils.security import SecurityMiddleware, is_loopback
+from backend.utils.security import SecurityMiddleware, is_loopback, get_client_ip
 
 
 from fastapi.middleware.cors import CORSMiddleware
@@ -44,11 +44,22 @@ def test_is_loopback_helper():
     assert is_loopback("::1") is True
     assert is_loopback("localhost") is True
     assert is_loopback("testclient") is True
-    assert is_loopback(None) is True
     
+    # Fail closed for None and external IPs
+    assert is_loopback(None) is False
     assert is_loopback("192.168.1.1") is False
     assert is_loopback("10.0.0.5") is False
     assert is_loopback("8.8.8.8") is False
+
+
+def test_x_forwarded_for_remote_client_detection(client):
+    # Even if connection peer is 127.0.0.1 (reverse proxy),
+    # X-Forwarded-For carrying a remote IP should enforce security
+    with patch.dict(os.environ, {}, clear=True):
+        headers = {"X-Forwarded-For": "192.168.1.100, 127.0.0.1"}
+        res = client.post("/shutdown", headers=headers)
+        assert res.status_code == 403
+        assert "restricted to loopback callers" in res.json()["detail"]
 
 
 def test_loopback_caller_unrestricted(client):

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -8,10 +8,23 @@ from starlette.responses import JSONResponse
 logger = logging.getLogger(__name__)
 
 
+def get_client_ip(request: Request) -> str | None:
+    """Extract the client IP address, checking X-Forwarded-For headers if behind a proxy."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        client_ip = forwarded.split(",")[0].strip()
+        if client_ip:
+            return client_ip
+    return request.client.host if request.client else None
+
+
 def is_loopback(host: str | None) -> bool:
-    """Check if the given host IP is a loopback address."""
+    """Check if the given host IP is a loopback address.
+    
+    Fails closed (returns False) if host is None or missing.
+    """
     if not host:
-        return True  # Internal calls or tests default to True
+        return False  # Fail closed for missing/unknown client address
     if host in ("localhost", "testclient"):
         return True
     try:
@@ -33,7 +46,7 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             if request.method.upper() == "OPTIONS":
                 return await call_next(request)
 
-            client_host = request.client.host if request.client else None
+            client_host = get_client_ip(request)
 
             # Loopback is always trusted
             if is_loopback(client_host):

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -16,7 +16,7 @@ def is_loopback(host: str | None) -> bool:
         return True
     try:
         return ipaddress.ip_address(host).is_loopback
-    except ValueError:
+    except (ValueError, TypeError, Exception):
         return False
 
 
@@ -29,62 +29,69 @@ class SecurityMiddleware(BaseHTTPMiddleware):
        - If VOICEBOX_API_KEY is NOT configured, block all administrative or destructive requests (DELETE, shutdown, etc.) with 403 Forbidden.
     """
     async def dispatch(self, request: Request, call_next) -> Response:
-        if request.method.upper() == "OPTIONS":
-            return await call_next(request)
+        try:
+            if request.method.upper() == "OPTIONS":
+                return await call_next(request)
 
-        client_host = request.client.host if request.client else None
+            client_host = request.client.host if request.client else None
 
-        # Loopback is always trusted
-        if is_loopback(client_host):
-            return await call_next(request)
+            # Loopback is always trusted
+            if is_loopback(client_host):
+                return await call_next(request)
 
-        # Check for configured API key
-        api_key = os.environ.get("VOICEBOX_API_KEY")
+            # Check for configured API key
+            api_key = os.environ.get("VOICEBOX_API_KEY")
 
-        # Extract authorization token
-        auth_header = request.headers.get("Authorization")
-        token = None
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header[7:].strip()
+            # Extract authorization token
+            auth_header = request.headers.get("Authorization")
+            token = None
+            if auth_header and auth_header.startswith("Bearer "):
+                token = auth_header[7:].strip()
 
-        if api_key:
-            # Enforce API key verification for all remote requests
-            if not token or token != api_key:
-                return JSONResponse(
-                    status_code=401,
-                    content={"detail": "Unauthorized: Invalid or missing API token"}
+            if api_key:
+                # Enforce API key verification for all remote requests
+                if not token or token != api_key:
+                    return JSONResponse(
+                        status_code=401,
+                        content={"detail": "Unauthorized: Invalid or missing API token"}
+                    )
+            else:
+                # Destructive/Administrative endpoints are blocked for remote callers by default
+                method = request.method.upper()
+                path = request.url.path.lower()
+                
+                is_destructive = False
+
+                # Any DELETE request is considered destructive
+                if method == "DELETE":
+                    is_destructive = True
+
+                # Check for specific administrative/destructive paths
+                admin_paths = (
+                    "/shutdown",
+                    "/watchdog/disable",
+                    "/cache/clear",
+                    "/tasks/clear",
+                    "/models/unload",
+                    "/models/download",
+                    "/models/migrate",
                 )
-        else:
-            # Destructive/Administrative endpoints are blocked for remote callers by default
-            method = request.method.upper()
-            path = request.url.path.lower()
-            
-            is_destructive = False
 
-            # Any DELETE request is considered destructive
-            if method == "DELETE":
-                is_destructive = True
+                if any(path.startswith(p) for p in admin_paths) or any(f"{p}/" in path for p in admin_paths):
+                    is_destructive = True
 
-            # Check for specific administrative/destructive paths
-            admin_paths = (
-                "/shutdown",
-                "/watchdog/disable",
-                "/cache/clear",
-                "/tasks/clear",
-                "/models/unload",
-                "/models/download",
-                "/models/migrate",
+                if is_destructive:
+                    return JSONResponse(
+                        status_code=403,
+                        content={
+                            "detail": "Access denied: Administrative/destructive endpoints are restricted to loopback callers. Set VOICEBOX_API_KEY to enable remote access."
+                        }
+                    )
+
+            return await call_next(request)
+        except Exception as e:
+            logger.exception("Error in SecurityMiddleware: %s", e)
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "Internal server error in security middleware"}
             )
-
-            if any(path.startswith(p) for p in admin_paths) or any(f"{p}/" in path for p in admin_paths):
-                is_destructive = True
-
-            if is_destructive:
-                return JSONResponse(
-                    status_code=403,
-                    content={
-                        "detail": "Access denied: Administrative/destructive endpoints are restricted to loopback callers. Set VOICEBOX_API_KEY to enable remote access."
-                    }
-                )
-
-        return await call_next(request)

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -9,13 +9,22 @@ logger = logging.getLogger(__name__)
 
 
 def get_client_ip(request: Request) -> str | None:
-    """Extract the client IP address, checking X-Forwarded-For headers if behind a proxy."""
+    """Extract the client IP address.
+
+    X-Forwarded-For is only honoured when the direct TCP peer is itself
+    loopback (i.e. a trusted local reverse proxy). Otherwise a remote
+    attacker could forge the header (e.g. "X-Forwarded-For: 127.0.0.1")
+    to impersonate a loopback caller and bypass all security checks.
+    """
+    direct_host = request.client.host if request.client else None
+
     forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
+    if forwarded and is_loopback(direct_host):
         client_ip = forwarded.split(",")[0].strip()
         if client_ip:
             return client_ip
-    return request.client.host if request.client else None
+
+    return direct_host
 
 
 def is_loopback(host: str | None) -> bool:
@@ -33,13 +42,26 @@ def is_loopback(host: str | None) -> bool:
         return False
 
 
+# Endpoints considered safe to expose to remote callers when no API key is
+# configured: read-only, non-destructive, and carrying no sensitive data.
+# Everything else (including every mutating request) requires either a
+# loopback caller or a valid VOICEBOX_API_KEY bearer token. This is an
+# allowlist, not a denylist, so newly added routes are protected by default.
+SAFE_REMOTE_GET_PATHS = frozenset({
+    "/",
+    "/health",
+    "/health/filesystem",
+})
+
+
 class SecurityMiddleware(BaseHTTPMiddleware):
     """Middleware to secure the REST API for non-loopback callers.
-    
+
     1. Loopback callers (localhost/127.0.0.1/::1) are always allowed.
     2. Non-loopback callers:
        - If VOICEBOX_API_KEY is configured in the environment, require matching Bearer token.
-       - If VOICEBOX_API_KEY is NOT configured, block all administrative or destructive requests (DELETE, shutdown, etc.) with 403 Forbidden.
+       - If VOICEBOX_API_KEY is NOT configured, only GET requests to SAFE_REMOTE_GET_PATHS
+         are allowed; every other request gets 403 Forbidden.
     """
     async def dispatch(self, request: Request, call_next) -> Response:
         try:
@@ -55,10 +77,10 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             # Check for configured API key
             api_key = os.environ.get("VOICEBOX_API_KEY")
 
-            # Extract authorization token
+            # Extract authorization token (scheme name is case-insensitive per RFC 7235)
             auth_header = request.headers.get("Authorization")
             token = None
-            if auth_header and auth_header.startswith("Bearer "):
+            if auth_header and auth_header[:7].lower() == "bearer ":
                 token = auth_header[7:].strip()
 
             if api_key:
@@ -66,38 +88,20 @@ class SecurityMiddleware(BaseHTTPMiddleware):
                 if not token or token != api_key:
                     return JSONResponse(
                         status_code=401,
-                        content={"detail": "Unauthorized: Invalid or missing API token"}
+                        content={"detail": "Unauthorized: Invalid or missing API token"},
+                        headers={"WWW-Authenticate": "Bearer"},
                     )
             else:
-                # Destructive/Administrative endpoints are blocked for remote callers by default
+                # No API key configured: only allow a small explicit allowlist
+                # of safe read-only endpoints for remote callers.
                 method = request.method.upper()
-                path = request.url.path.lower()
-                
-                is_destructive = False
+                path = request.url.path
 
-                # Any DELETE request is considered destructive
-                if method == "DELETE":
-                    is_destructive = True
-
-                # Check for specific administrative/destructive paths
-                admin_paths = (
-                    "/shutdown",
-                    "/watchdog/disable",
-                    "/cache/clear",
-                    "/tasks/clear",
-                    "/models/unload",
-                    "/models/download",
-                    "/models/migrate",
-                )
-
-                if any(path.startswith(p) for p in admin_paths) or any(f"{p}/" in path for p in admin_paths):
-                    is_destructive = True
-
-                if is_destructive:
+                if method != "GET" or path not in SAFE_REMOTE_GET_PATHS:
                     return JSONResponse(
                         status_code=403,
                         content={
-                            "detail": "Access denied: Administrative/destructive endpoints are restricted to loopback callers. Set VOICEBOX_API_KEY to enable remote access."
+                            "detail": "Access denied: this endpoint is restricted to loopback callers. Set VOICEBOX_API_KEY to enable remote access."
                         }
                     )
 

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -1,0 +1,90 @@
+import os
+import logging
+import ipaddress
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+def is_loopback(host: str | None) -> bool:
+    """Check if the given host IP is a loopback address."""
+    if not host:
+        return True  # Internal calls or tests default to True
+    if host in ("localhost", "testclient"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+class SecurityMiddleware(BaseHTTPMiddleware):
+    """Middleware to secure the REST API for non-loopback callers.
+    
+    1. Loopback callers (localhost/127.0.0.1/::1) are always allowed.
+    2. Non-loopback callers:
+       - If VOICEBOX_API_KEY is configured in the environment, require matching Bearer token.
+       - If VOICEBOX_API_KEY is NOT configured, block all administrative or destructive requests (DELETE, shutdown, etc.) with 403 Forbidden.
+    """
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.method.upper() == "OPTIONS":
+            return await call_next(request)
+
+        client_host = request.client.host if request.client else None
+
+        # Loopback is always trusted
+        if is_loopback(client_host):
+            return await call_next(request)
+
+        # Check for configured API key
+        api_key = os.environ.get("VOICEBOX_API_KEY")
+
+        # Extract authorization token
+        auth_header = request.headers.get("Authorization")
+        token = None
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header[7:].strip()
+
+        if api_key:
+            # Enforce API key verification for all remote requests
+            if not token or token != api_key:
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Unauthorized: Invalid or missing API token"}
+                )
+        else:
+            # Destructive/Administrative endpoints are blocked for remote callers by default
+            method = request.method.upper()
+            path = request.url.path.lower()
+            
+            is_destructive = False
+
+            # Any DELETE request is considered destructive
+            if method == "DELETE":
+                is_destructive = True
+
+            # Check for specific administrative/destructive paths
+            admin_paths = (
+                "/shutdown",
+                "/watchdog/disable",
+                "/cache/clear",
+                "/tasks/clear",
+                "/models/unload",
+                "/models/download",
+                "/models/migrate",
+            )
+
+            if any(path.startswith(p) for p in admin_paths) or any(f"{p}/" in path for p in admin_paths):
+                is_destructive = True
+
+            if is_destructive:
+                return JSONResponse(
+                    status_code=403,
+                    content={
+                        "detail": "Access denied: Administrative/destructive endpoints are restricted to loopback callers. Set VOICEBOX_API_KEY to enable remote access."
+                    }
+                )
+
+        return await call_next(request)


### PR DESCRIPTION
## Summary

This builds on #1002 (fixes #934), which added `SecurityMiddleware` for loopback trust, bearer-token auth, and blocking destructive endpoints for remote callers. CodeRabbit flagged three unresolved issues on that PR that were never addressed before it went stale — this PR closes them:

1. **Loopback-trust spoofing via `X-Forwarded-For`.** The original code trusted `X-Forwarded-For` from *any* caller, so a remote attacker could send `X-Forwarded-For: 127.0.0.1` and be treated as a trusted loopback client, bypassing every check. `X-Forwarded-For` is now only honored when the direct TCP peer is itself loopback (i.e. a trusted local reverse proxy) — a genuinely remote peer can no longer spoof loopback trust.

2. **Denylist → allowlist for the no-API-key case.** When `VOICEBOX_API_KEY` is unset, the original code only blocked `DELETE` and a fixed list of admin paths — every other route (profiles, history, stories, models, captures, effects, settings, MCP bindings, cloud login, etc.) was reachable by unauthenticated remote callers. Replaced with an explicit allowlist of safe, read-only `GET` paths (`/`, `/health`, `/health/filesystem`); everything else now requires loopback or a valid API key, so newly added routes are protected by default instead of requiring an update to a denylist.

3. **Case-sensitive Bearer scheme.** `Authorization: bearer <token>` (lowercase) was rejected because of an exact `startswith("Bearer ")` check, though HTTP auth schemes are case-insensitive per RFC 7235. Fixed, and added a `WWW-Authenticate: Bearer` header on 401 responses.

## Test plan
- [x] `pytest backend/tests/test_api_security.py -v` — 9/9 passed (6 original + 3 new covering the fixes above)
- [x] `pytest backend/tests` (excluding pre-existing unrelated failures and a module needing the optional `fastmcp` dependency) — 137 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcJZZeGqTCybZGWgZS9JFV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API security controls for remote requests, including optional bearer-token authentication.
  * Allowed safe health and status endpoints for unauthenticated remote access.
  * Preserved local access while blocking unauthorized administrative or destructive requests.
  * Added support for configuring the server bind address through the `VOICEBOX_HOST` environment variable.

* **Bug Fixes**
  * Prevented untrusted forwarded headers from falsely identifying remote clients as local.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->