### PR TITLE
[fix] Offer a way to grant microphone access when recording is denied

### DIFF
--- a/app/src/components/MicrophoneGate/MicrophoneGate.tsx
+++ b/app/src/components/MicrophoneGate/MicrophoneGate.tsx
@@ -16,6 +16,7 @@ export function useMicrophonePermissionHelp() {
 
   const canOpenSettings = platform.metadata.isTauri;
 
+  /** Reveal the microphone pane in the OS settings app. No-op on the web. */
   const openSettings = useCallback(async () => {
     if (!platform.metadata.isTauri) return;
     try {

--- a/app/src/components/MicrophoneGate/MicrophoneGate.tsx
+++ b/app/src/components/MicrophoneGate/MicrophoneGate.tsx
@@ -5,6 +5,9 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { usePlatform } from '@/platform/PlatformContext';
 
+const isMacOSAgent = () => /Mac|iPhone|iPad/.test(navigator.userAgent);
+const isWindowsAgent = () => /Win/.test(navigator.userAgent);
+
 /**
  * Deep-link into the OS microphone privacy pane. Unlike the Accessibility and
  * Input Monitoring gates there is no `check_*` counterpart: WKWebView exposes
@@ -14,17 +17,22 @@ import { usePlatform } from '@/platform/PlatformContext';
 export function useMicrophonePermissionHelp() {
   const platform = usePlatform();
 
-  const canOpenSettings = platform.metadata.isTauri;
+  // Only macOS and Windows have a settings pane to deep-link into; the Rust
+  // command errors elsewhere, so Linux must not be offered the button.
+  const canOpenSettings = platform.metadata.isTauri && (isMacOSAgent() || isWindowsAgent());
 
-  /** Reveal the microphone pane in the OS settings app. No-op on the web. */
+  /**
+   * Reveal the microphone pane in the OS settings app. No-op where there is
+   * no such pane to open, which is the web build and Linux.
+   */
   const openSettings = useCallback(async () => {
-    if (!platform.metadata.isTauri) return;
+    if (!canOpenSettings) return;
     try {
       await invoke('open_microphone_settings');
     } catch (err) {
       console.warn('[microphone] open settings failed:', err);
     }
-  }, [platform.metadata.isTauri]);
+  }, [canOpenSettings]);
 
   return { canOpenSettings, openSettings };
 }
@@ -47,14 +55,19 @@ export function MicrophonePermissionNotice({
   showRestartHint?: boolean;
 }) {
   const { t } = useTranslation();
+  const platform = usePlatform();
   const { canOpenSettings, openSettings } = useMicrophonePermissionHelp();
-  const isMacOS = /Mac|iPhone|iPad/.test(navigator.userAgent);
+  const isMacOS = isMacOSAgent();
 
-  const bodyKey = !canOpenSettings
+  // Linux Tauri builds have no settings pane to point at, so they get generic
+  // wording rather than the Windows steps.
+  const bodyKey = !platform.metadata.isTauri
     ? 'captures.permissions.microphone.bodyWeb'
     : isMacOS
       ? 'captures.permissions.microphone.bodyMac'
-      : 'captures.permissions.microphone.bodyWindows';
+      : isWindowsAgent()
+        ? 'captures.permissions.microphone.bodyWindows'
+        : 'captures.permissions.microphone.bodyLinux';
 
   return (
     <div className="w-full rounded-lg border border-amber-500/30 bg-amber-500/10 px-3.5 py-3">

--- a/app/src/components/MicrophoneGate/MicrophoneGate.tsx
+++ b/app/src/components/MicrophoneGate/MicrophoneGate.tsx
@@ -1,0 +1,91 @@
+import { invoke } from '@tauri-apps/api/core';
+import { AlertTriangle, ExternalLink } from 'lucide-react';
+import { useCallback } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { usePlatform } from '@/platform/PlatformContext';
+
+/**
+ * Deep-link into the OS microphone privacy pane. Unlike the Accessibility and
+ * Input Monitoring gates there is no `check_*` counterpart: WKWebView exposes
+ * no permission-state query, so the recording UI learns about a denial by
+ * classifying the `getUserMedia` rejection and only then offers this way out.
+ */
+export function useMicrophonePermissionHelp() {
+  const platform = usePlatform();
+
+  const canOpenSettings = platform.metadata.isTauri;
+
+  const openSettings = useCallback(async () => {
+    if (!platform.metadata.isTauri) return;
+    try {
+      await invoke('open_microphone_settings');
+    } catch (err) {
+      console.warn('[microphone] open settings failed:', err);
+    }
+  }, [platform.metadata.isTauri]);
+
+  return { canOpenSettings, openSettings };
+}
+
+/**
+ * Inline notice shown in place of the record button once macOS (or the
+ * browser) has refused the microphone. macOS never re-prompts after a denial,
+ * so without this the user is stuck on an error toast with nothing to act on.
+ */
+export function MicrophonePermissionNotice({
+  onRetry,
+  showRestartHint = false,
+}: {
+  onRetry?: () => void;
+  /**
+   * A retry has already failed. Owned by the caller, not this component: a
+   * retry re-renders the record surface, so state kept here would reset
+   * before the hint could ever show.
+   */
+  showRestartHint?: boolean;
+}) {
+  const { t } = useTranslation();
+  const { canOpenSettings, openSettings } = useMicrophonePermissionHelp();
+  const isMacOS = /Mac|iPhone|iPad/.test(navigator.userAgent);
+
+  const bodyKey = !canOpenSettings
+    ? 'captures.permissions.microphone.bodyWeb'
+    : isMacOS
+      ? 'captures.permissions.microphone.bodyMac'
+      : 'captures.permissions.microphone.bodyWindows';
+
+  return (
+    <div className="w-full rounded-lg border border-amber-500/30 bg-amber-500/10 px-3.5 py-3">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-500" />
+        <div className="flex-1 min-w-0 space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            {t('captures.permissions.microphone.title')}
+          </p>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            <Trans i18nKey={bodyKey} components={{ path: <span /> }} />
+          </p>
+          <div className="flex items-center gap-2 pt-1.5">
+            {canOpenSettings && (
+              <Button type="button" size="sm" onClick={openSettings} className="gap-1.5">
+                <ExternalLink className="h-3.5 w-3.5" />
+                {t('captures.permissions.microphone.openSettings')}
+              </Button>
+            )}
+            {onRetry && (
+              <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                {t('captures.permissions.microphone.retry')}
+              </Button>
+            )}
+          </div>
+          {showRestartHint && isMacOS && canOpenSettings && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
+              {t('captures.permissions.microphone.stillMissing')}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
+++ b/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
@@ -39,6 +39,15 @@ interface AudioSampleRecordingProps {
   permissionDenied?: boolean;
 }
 
+/**
+ * The record-a-sample surface shared by the Create Voice and Add Sample
+ * dialogs: a mic button that becomes a live waveform, then playback and
+ * transcribe controls once a clip exists.
+ *
+ * When the microphone is denied it swaps the record button for
+ * {@link MicrophonePermissionNotice}, which is the only affordance the user
+ * gets: macOS does not re-prompt once a denial is on record.
+ */
 export function AudioSampleRecording({
   file,
   isRecording,

--- a/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
+++ b/app/src/components/VoiceProfiles/AudioSampleRecording.tsx
@@ -2,6 +2,7 @@ import { Mic, Pause, Play, Square } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Visualizer } from 'react-sound-visualizer';
+import { MicrophonePermissionNotice } from '@/components/MicrophoneGate/MicrophoneGate';
 import { Button } from '@/components/ui/button';
 import { FormControl, FormItem, FormMessage } from '@/components/ui/form';
 import { formatAudioDuration } from '@/lib/utils/audio';
@@ -34,6 +35,8 @@ interface AudioSampleRecordingProps {
   isPlaying: boolean;
   isTranscribing?: boolean;
   showWaveform?: boolean;
+  /** The parent's last recording attempt failed with a denied microphone. */
+  permissionDenied?: boolean;
 }
 
 export function AudioSampleRecording({
@@ -48,9 +51,18 @@ export function AudioSampleRecording({
   isPlaying,
   isTranscribing = false,
   showWaveform = true,
+  permissionDenied = false,
 }: AudioSampleRecordingProps) {
   const { t } = useTranslation();
   const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
+  // The visualizer's own mic request is the first thing to hit the denial —
+  // catching it here means the notice is up before the user clicks Record,
+  // rather than after a failed attempt.
+  const [visualizerDenied, setVisualizerDenied] = useState(false);
+  // Retrying clears the denial flags, so the notice unmounts and remounts on
+  // every attempt. Remember here, where the state survives, that an attempt
+  // has already been made and come back denied.
+  const [retriedWhileDenied, setRetriedWhileDenied] = useState(false);
 
   // Request microphone access when component mounts
   useEffect(() => {
@@ -65,8 +77,12 @@ export function AudioSampleRecording({
         stream = s;
         setAudioStream(s);
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         console.warn('Could not access microphone for visualization:', err);
+        const name = err instanceof Error ? err.name : '';
+        if (name === 'NotAllowedError' || name === 'SecurityError') {
+          setVisualizerDenied(true);
+        }
       });
 
     return () => {
@@ -78,25 +94,40 @@ export function AudioSampleRecording({
     };
   }, [showWaveform]);
 
+  const micDenied = permissionDenied || visualizerDenied;
+
   return (
     <FormItem>
       <FormControl>
         <div className="space-y-4">
           {!isRecording && !file && (
             <div className="relative flex flex-col items-center justify-center gap-4 p-4 border-2 border-dashed rounded-lg min-h-[180px] overflow-hidden">
-              {showWaveform && audioStream && <MemoizedWaveform audioStream={audioStream} />}
-              <Button
-                type="button"
-                onClick={onStart}
-                size="lg"
-                className="relative z-10 flex items-center gap-2"
-              >
-                <Mic className="h-5 w-5" />
-                {t('audioSample.startRecording')}
-              </Button>
-              <p className="relative z-10 text-sm text-muted-foreground text-center">
-                {t('audioSample.recordHint')}
-              </p>
+              {micDenied ? (
+                <MicrophonePermissionNotice
+                  showRestartHint={retriedWhileDenied}
+                  onRetry={() => {
+                    setRetriedWhileDenied(true);
+                    setVisualizerDenied(false);
+                    onStart();
+                  }}
+                />
+              ) : (
+                <>
+                  {showWaveform && audioStream && <MemoizedWaveform audioStream={audioStream} />}
+                  <Button
+                    type="button"
+                    onClick={onStart}
+                    size="lg"
+                    className="relative z-10 flex items-center gap-2"
+                  >
+                    <Mic className="h-5 w-5" />
+                    {t('audioSample.startRecording')}
+                  </Button>
+                  <p className="relative z-10 text-sm text-muted-foreground text-center">
+                    {t('audioSample.recordHint')}
+                  </p>
+                </>
+              )}
             </div>
           )}
 

--- a/app/src/components/VoiceProfiles/ProfileForm.tsx
+++ b/app/src/components/VoiceProfiles/ProfileForm.tsx
@@ -226,6 +226,7 @@ export function ProfileForm() {
     isRecording,
     duration,
     error: recordingError,
+    errorKind: recordingErrorKind,
     startRecording,
     stopRecording,
     cancelRecording,
@@ -293,16 +294,18 @@ export function ProfileForm() {
     (option) => !isSampleBasedProfile || !PRESET_ONLY_ENGINES.has(option.value),
   );
 
-  // Show recording errors
+  // Show recording errors. A denied microphone is handled inline by
+  // AudioSampleRecording instead — a toast would scroll away the one control
+  // that can actually fix it.
   useEffect(() => {
-    if (recordingError) {
+    if (recordingError && recordingErrorKind !== 'permission-denied') {
       toast({
         title: t('profileForm.toast.recordingError'),
         description: recordingError,
         variant: 'destructive',
       });
     }
-  }, [recordingError, toast, t]);
+  }, [recordingError, recordingErrorKind, toast, t]);
 
   useEffect(() => {
     if (systemRecordingError) {
@@ -1012,6 +1015,7 @@ export function ProfileForm() {
                                     onPlayPause={handlePlayPause}
                                     isPlaying={isPlaying}
                                     isTranscribing={transcribe.isPending}
+                                    permissionDenied={recordingErrorKind === 'permission-denied'}
                                   />
                                 )}
                               />

--- a/app/src/components/VoiceProfiles/SampleUpload.tsx
+++ b/app/src/components/VoiceProfiles/SampleUpload.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Mic, Monitor, Upload } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import * as z from 'zod';
 import { Button } from '@/components/ui/button';
 import {
@@ -49,6 +50,7 @@ interface SampleUploadProps {
 }
 
 export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProps) {
+  const { t } = useTranslation();
   const platform = usePlatform();
   const addSample = useAddSample();
   const transcribe = useTranscription();
@@ -70,6 +72,7 @@ export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProp
     isRecording,
     duration,
     error: recordingError,
+    errorKind: recordingErrorKind,
     startRecording,
     stopRecording,
     cancelRecording,
@@ -119,16 +122,18 @@ export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProp
     },
   });
 
-  // Show recording errors
+  // Show recording errors. A denied microphone is handled inline by
+  // AudioSampleRecording instead — a toast would scroll away the one control
+  // that can actually fix it.
   useEffect(() => {
-    if (recordingError) {
+    if (recordingError && recordingErrorKind !== 'permission-denied') {
       toast({
-        title: 'Recording error',
+        title: t('profileForm.toast.recordingError'),
         description: recordingError,
         variant: 'destructive',
       });
     }
-  }, [recordingError, toast]);
+  }, [recordingError, recordingErrorKind, toast, t]);
 
   // Show system audio recording errors
   useEffect(() => {
@@ -285,6 +290,7 @@ export function SampleUpload({ profileId, open, onOpenChange }: SampleUploadProp
                       onPlayPause={handlePlayPause}
                       isPlaying={isPlaying}
                       isTranscribing={transcribe.isPending}
+                      permissionDenied={recordingErrorKind === 'permission-denied'}
                     />
                   )}
                 />

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -162,6 +162,15 @@
         "recheck": "I've enabled it",
         "rechecking": "Checking…",
         "stillMissing": "Still not detected. macOS usually requires quitting and reopening Voicebox after toggling the permission."
+      },
+      "microphone": {
+        "title": "Microphone access is turned off",
+        "bodyMac": "Voicebox can't record until you allow it in <path>System Settings → Privacy & Security → Microphone</path>. Turn Voicebox on there, then come back and try again.",
+        "bodyWindows": "Voicebox can't record until you allow it in <path>Settings → Privacy & security → Microphone</path>. Turn Voicebox on there, then come back and try again.",
+        "bodyWeb": "Your browser is blocking microphone access for Voicebox. Allow the microphone from the icon in the address bar, then try again.",
+        "openSettings": "Open Settings",
+        "retry": "Try again",
+        "stillMissing": "Still blocked. macOS usually requires quitting and reopening Voicebox after turning the permission on."
       }
     }
   },
@@ -355,7 +364,16 @@
     "systemHint": "Capture audio from your system. Maximum duration: 30 seconds.",
     "stopCapture": "Stop Capture",
     "captureComplete": "Capture complete",
-    "captureAgain": "Capture Again"
+    "captureAgain": "Capture Again",
+    "errors": {
+      "permissionDenied": "Microphone access is turned off for Voicebox.",
+      "noDevice": "No microphone was found. Connect an input device and try again.",
+      "deviceBusy": "Your microphone is in use by another app. Close it and try again.",
+      "unavailableTauri": "Microphone access isn't available. Check that Voicebox is allowed to use the microphone in your system settings, then restart the app.",
+      "unavailableWeb": "Microphone access isn't available. Make sure you're on a secure connection (HTTPS or localhost) and that your browser allows the microphone.",
+      "unknown": "Couldn't start recording. Please try again.",
+      "recorderFailed": "Recording stopped unexpectedly. Please try again."
+    }
   },
   "sampleList": {
     "loading": "Loading samples…",
@@ -1124,7 +1142,8 @@
         "title": "Switch to CPU backend",
         "description": "Disable GPU acceleration. You can re-download the GPU backend later.",
         "button": "Switch"
-      },      "remove": {
+      },
+      "remove": {
         "title": "Remove CUDA backend",
         "description": "Delete the downloaded CUDA binary to free disk space.",
         "button": "Remove"

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -167,6 +167,7 @@
         "title": "Microphone access is turned off",
         "bodyMac": "Voicebox can't record until you allow it in <path>System Settings → Privacy & Security → Microphone</path>. Turn Voicebox on there, then come back and try again.",
         "bodyWindows": "Voicebox can't record until you allow it in <path>Settings → Privacy & security → Microphone</path>. Turn Voicebox on there, then come back and try again.",
+        "bodyLinux": "Voicebox can't record until your desktop allows microphone access for it. Check your system's sound or privacy settings, then come back and try again.",
         "bodyWeb": "Your browser is blocking microphone access for Voicebox. Allow the microphone from the icon in the address bar, then try again.",
         "openSettings": "Open Settings",
         "retry": "Try again",

--- a/app/src/lib/hooks/useAudioRecording.ts
+++ b/app/src/lib/hooks/useAudioRecording.ts
@@ -1,6 +1,55 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { usePlatform } from '@/platform/PlatformContext';
+import { useTranslation } from 'react-i18next';
 import { convertToWav } from '@/lib/utils/audio';
+import { usePlatform } from '@/platform/PlatformContext';
+
+/**
+ * Why a recording attempt failed, so callers can pick a recovery affordance
+ * instead of dumping the browser's own prose at the user. `permission-denied`
+ * is the one that needs a way out — macOS never re-prompts once TCC has a
+ * denial on record, so the UI has to deep-link the user into System Settings.
+ */
+export type RecordingErrorKind =
+  | 'permission-denied'
+  | 'no-device'
+  | 'device-busy'
+  | 'unavailable'
+  | 'unknown';
+
+/**
+ * Map a `getUserMedia` rejection onto {@link RecordingErrorKind}. The spec-defined
+ * `DOMException.name` is the only stable signal here — `message` is wildly
+ * engine-specific (WebKit's denial reads "The request is not allowed by the user
+ * agent or the platform in the current context…") and must never reach the UI.
+ */
+function classifyMediaError(err: unknown): RecordingErrorKind {
+  const name = err instanceof Error ? err.name : '';
+  switch (name) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+      return 'permission-denied';
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+      return 'no-device';
+    case 'NotReadableError':
+    case 'AbortError':
+      return 'device-busy';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * `navigator.mediaDevices` itself is missing — a stale WKWebView, a non-secure
+ * origin on the web build. Distinct from a denial: there is no permission for
+ * the user to flip, so the recovery advice differs.
+ */
+class MediaUnavailableError extends Error {
+  constructor() {
+    super('mediaDevices unavailable');
+    this.name = 'MediaUnavailableError';
+  }
+}
 
 interface UseAudioRecordingOptions {
   maxDurationSeconds?: number;
@@ -12,9 +61,11 @@ export function useAudioRecording({
   onRecordingComplete,
 }: UseAudioRecordingOptions = {}) {
   const platform = usePlatform();
+  const { t } = useTranslation();
   const [isRecording, setIsRecording] = useState(false);
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<RecordingErrorKind | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
@@ -22,9 +73,30 @@ export function useAudioRecording({
   const startTimeRef = useRef<number | null>(null);
   const cancelledRef = useRef<boolean>(false);
 
+  const describeError = useCallback(
+    (kind: RecordingErrorKind): string => {
+      switch (kind) {
+        case 'permission-denied':
+          return t('audioSample.errors.permissionDenied');
+        case 'no-device':
+          return t('audioSample.errors.noDevice');
+        case 'device-busy':
+          return t('audioSample.errors.deviceBusy');
+        case 'unavailable':
+          return platform.metadata.isTauri
+            ? t('audioSample.errors.unavailableTauri')
+            : t('audioSample.errors.unavailableWeb');
+        default:
+          return t('audioSample.errors.unknown');
+      }
+    },
+    [t, platform.metadata.isTauri],
+  );
+
   const startRecording = useCallback(async () => {
     try {
       setError(null);
+      setErrorKind(null);
       chunksRef.current = [];
       cancelledRef.current = false;
       setDuration(0);
@@ -32,10 +104,7 @@ export function useAudioRecording({
       // Check if getUserMedia is available
       // In Tauri, navigator.mediaDevices might not be available immediately
       if (typeof navigator === 'undefined') {
-        const errorMsg =
-          'Navigator API is not available. This might be a Tauri configuration issue.';
-        setError(errorMsg);
-        throw new Error(errorMsg);
+        throw new MediaUnavailableError();
       }
 
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
@@ -50,11 +119,7 @@ export function useAudioRecording({
             isTauri: platform.metadata.isTauri,
           });
 
-          const errorMsg = platform.metadata.isTauri
-            ? 'Microphone access is not available. Please ensure:\n1. The app has microphone permissions in System Settings (macOS: System Settings > Privacy & Security > Microphone)\n2. You restart the app after granting permissions\n3. You are using Tauri v2 with a webview that supports getUserMedia'
-            : 'Microphone access is not available. Please ensure you are using a secure context (HTTPS or localhost) and that your browser has microphone permissions enabled.';
-          setError(errorMsg);
-          throw new Error(errorMsg);
+          throw new MediaUnavailableError();
         }
       }
 
@@ -120,7 +185,8 @@ export function useAudioRecording({
       };
 
       mediaRecorder.onerror = (event) => {
-        setError('Recording error occurred');
+        setError(t('audioSample.errors.recorderFailed'));
+        setErrorKind('unknown');
         console.error('MediaRecorder error:', event);
       };
 
@@ -155,14 +221,15 @@ export function useAudioRecording({
         }
       }, 100);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error
-          ? err.message
-          : 'Failed to access microphone. Please check permissions.';
-      setError(errorMessage);
+      const kind = err instanceof MediaUnavailableError ? 'unavailable' : classifyMediaError(err);
+      // Keep the raw rejection in the console for bug reports — only the
+      // translated summary reaches the UI.
+      console.error('Failed to start recording:', err);
+      setErrorKind(kind);
+      setError(describeError(kind));
       setIsRecording(false);
     }
-  }, [maxDurationSeconds, onRecordingComplete]);
+  }, [maxDurationSeconds, onRecordingComplete, platform.metadata.isTauri, t, describeError]);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {
@@ -213,6 +280,7 @@ export function useAudioRecording({
     isRecording,
     duration,
     error,
+    errorKind,
     startRecording,
     stopRecording,
     cancelRecording,

--- a/app/src/lib/hooks/useAudioRecording.ts
+++ b/app/src/lib/hooks/useAudioRecording.ts
@@ -56,6 +56,18 @@ interface UseAudioRecordingOptions {
   onRecordingComplete?: (blob: Blob, duration?: number) => void;
 }
 
+/**
+ * Record a single audio clip from the user's microphone.
+ *
+ * Wraps `getUserMedia` plus `MediaRecorder` and hands the caller a WAV blob
+ * through `onRecordingComplete`, falling back to the raw WebM when conversion
+ * fails. Pass `maxDurationSeconds` to auto-stop (voice-clone samples use 29s);
+ * omit it for open-ended dictation that runs until `stopRecording`.
+ *
+ * Failures surface as a translated `error` string plus an `errorKind` the UI
+ * can branch on, so a denied microphone can offer a way to grant it rather
+ * than printing the browser's own wording.
+ */
 export function useAudioRecording({
   maxDurationSeconds,
   onRecordingComplete,
@@ -73,6 +85,11 @@ export function useAudioRecording({
   const startTimeRef = useRef<number | null>(null);
   const cancelledRef = useRef<boolean>(false);
 
+  /**
+   * Translate a {@link RecordingErrorKind} into the sentence shown to the
+   * user. `unavailable` splits by platform: on desktop the microphone is a
+   * system grant, in the browser it is usually a non-secure origin.
+   */
   const describeError = useCallback(
     (kind: RecordingErrorKind): string => {
       switch (kind) {

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1182,6 +1182,34 @@ fn open_input_monitoring_settings(app: tauri::AppHandle) -> Result<(), String> {
     }
 }
 
+/// Open the Privacy & Security → Microphone pane in System Settings. macOS
+/// never re-prompts once the user has denied the mic on record, so the
+/// recording UI deep-links here instead of leaving them to hunt for the
+/// toggle. Windows has an equivalent `ms-settings:` pane.
+#[command]
+fn open_microphone_settings(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let url = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+        app.shell()
+            .open(url, None)
+            .map_err(|e| format!("Failed to open Microphone settings: {e}"))?;
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        app.shell()
+            .open("ms-settings:privacy-microphone", None)
+            .map_err(|e| format!("Failed to open Microphone settings: {e}"))?;
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = app;
+        Err("Microphone settings pane is only implemented on macOS and Windows".into())
+    }
+}
+
 /// Deliver `text` into the UI that had focus when the chord fired.
 ///
 /// Pipeline: activate the captured PID → settle → save the user's
@@ -1527,6 +1555,7 @@ pub fn run() {
             check_input_monitoring_permission,
             open_accessibility_settings,
             open_input_monitoring_settings,
+            open_microphone_settings,
             paste_final_text,
             enable_hotkey,
             disable_hotkey,


### PR DESCRIPTION
Denying the microphone prompt once left the voice-creation flow with no way back, on both macOS and Windows. The recording hook now classifies the getUserMedia rejection by its error name instead of passing the raw message through, and a denied mic renders an inline notice in place of the record button, mirroring the existing Accessibility and Input Monitoring gates. It also stops the waveform visualizer's own mic request from silently swallowing the first denial, so the notice appears as soon as the Record tab opens rather than after a failed click.

Fixes #334. Fixes #709. Fixes #879.

## Before

Start Recording surfaced the raw browser DOMException in a destructive toast, and the OS does not re-prompt once a denial is on record, so there was nothing in the app to act on.

![Recording error toast showing the raw browser permission message](https://raw.githubusercontent.com/chrisvalmonte/voicebox/pr-assets/mic-permission/1-before-recording-error-toast.png)

## After

The notice replaces the record button with a plain-language explanation, a deep-link to the microphone pane in system settings, and a retry. Linux gets generic wording and no button, since there is no pane to open.

![Inline notice reading "Microphone access is turned off" with Open Settings and Try again buttons](https://raw.githubusercontent.com/chrisvalmonte/voicebox/pr-assets/mic-permission/2-after-inline-permission-notice.png)

If a retry comes back denied, it surfaces the macOS caveat that the grant usually needs an app restart.

![The same notice with an added hint that macOS usually requires quitting and reopening Voicebox](https://raw.githubusercontent.com/chrisvalmonte/voicebox/pr-assets/mic-permission/3-after-retry-still-blocked-hint.png)
